### PR TITLE
feat(config): per-task data-source fields on BaseTaskConfig (refactor PR1)

### DIFF
--- a/REFACTOR_composition_datamodule_PLAN.md
+++ b/REFACTOR_composition_datamodule_PLAN.md
@@ -35,15 +35,19 @@ data_files: str | Sequence[str] = ()      # per-task source file(s); concatenate
 composition_column: str | None = None      # override DataModule's global default
 split_column: str = "split"                 # optional split column name inside the file(s)
 task_masking_ratio: float | None = None      # replaces DataModule.task_masking_ratios
-predict_idx: Sequence[str] | str | None = None  # composition subset / "train|val|test|all" / file path
+predict_idx: Sequence[str] | str | None = None  # composition subset, or "train|val|test|all" literal
 ```
 
 - `data_column` / `t_column` keep their meaning, but now reference columns **inside the
   task's own file(s)**.
 - `AutoEncoderTaskConfig` needs no `data_files` (its target is the input `x`); it "rides
   along" whatever compositions are present in the batch.
-- Validation: a non-AE supervised task with empty `data_files` is an error; ratios must be
-  in `[0, 1]`; `predict_idx` string literals restricted to `{train,val,test,all}`.
+- Validation split: dataclass-level `__post_init__` (PR1) enforces ratio bounds in `[0, 1]`
+  and `predict_idx` string literals restricted to `{train,val,test,all}` (an explicit
+  composition subset is passed as a sequence of keys; file-path mode is not in scope).
+  The "non-AE supervised task must declare `data_files`" check lives in the **data layer
+  (PR2/PR3)**, not the dataclass, because the old `attributes_source` path must keep working
+  through PR1/PR2.
 
 ### 3.2 DataModule signature (`data/datamodule.py`)
 
@@ -136,7 +140,9 @@ are written. Add composition keys to the written output for downstream joins.
 ### PR1 — Config surface (additive, green)
 - Add the new `BaseTaskConfig` fields + `__post_init__` validation.
 - **Tests**: `model_config_test.py` (new/extended) — field defaults, ratio bounds,
-  predict_idx literal validation, AE-without-files allowed, supervised-without-files errors.
+  predict_idx literal validation, AE-without-files allowed, and backward-compatible
+  construction. PR1 does **not** enforce "supervised task must have `data_files`" — that
+  check is deferred to PR2/PR3 so the old `attributes_source` path stays green.
 - No behavior change anywhere else; tree stays green.
 
 ### PR2 — Composition data layer (new module, green, pure unit tests)

--- a/REFACTOR_composition_datamodule_PLAN.md
+++ b/REFACTOR_composition_datamodule_PLAN.md
@@ -1,0 +1,187 @@
+# Refactor Plan — Composition-keyed, per-task data sources
+
+Status: **PROPOSED** · Owner: TBD · Created: 2026-05-21
+
+## 1. Motivation
+
+Today `CompoundDataModule` takes a single `attributes_source` file that must contain
+**every** task's target column (plus an optional `split` column), aligned positionally
+to a single precomputed `formula_desc_source`. Adding one new property task means
+rebuilding the whole monolithic attributes file.
+
+Goal: let each property task own its **own data file(s)** (`csv` / `pd.xz` / `parquet`),
+joined to the others by a **composition** column. Descriptors are no longer pre-baked
+into a file — the DataModule computes them on demand from the union of compositions via
+a user-supplied function. Adding a task becomes "drop in one more file + one more task
+config", with no global rebuild.
+
+## 2. Confirmed design decisions
+
+| # | Decision | Choice |
+|---|----------|--------|
+| 1 | Old `formula_desc_source` / `attributes_source` API | **Hard remove**, migrate all callers in sync (no deprecated coexistence in the final state) |
+| 2 | train/val/test split source (after `attributes_source` removal) | Each task file **may carry a `split` column**; compositions with no label fall back to **random split** |
+| 3 | `predict_idx` (moved onto `BaseTaskConfig`) | Each task names **its own composition subset** to predict; predict set = union of per-task subsets, each task aligned/masked to its own subset |
+| 4 | descriptor function contract | `Callable[[list[str]], pd.DataFrame]` indexed by composition; DataModule **caches** per unique composition |
+
+## 3. Target architecture
+
+### 3.1 Config surface (`models/model_config.py`)
+
+`BaseTaskConfig` gains (all keyword-only, validated in `__post_init__`):
+
+```python
+data_files: str | Sequence[str] = ()      # per-task source file(s); concatenated by rows
+composition_column: str | None = None      # override DataModule's global default
+split_column: str = "split"                 # optional split column name inside the file(s)
+task_masking_ratio: float | None = None      # replaces DataModule.task_masking_ratios
+predict_idx: Sequence[str] | str | None = None  # composition subset / "train|val|test|all" / file path
+```
+
+- `data_column` / `t_column` keep their meaning, but now reference columns **inside the
+  task's own file(s)**.
+- `AutoEncoderTaskConfig` needs no `data_files` (its target is the input `x`); it "rides
+  along" whatever compositions are present in the batch.
+- Validation: a non-AE supervised task with empty `data_files` is an error; ratios must be
+  in `[0, 1]`; `predict_idx` string literals restricted to `{train,val,test,all}`.
+
+### 3.2 DataModule signature (`data/datamodule.py`)
+
+```python
+CompoundDataModule(
+    task_configs,
+    descriptor_fn: Callable[[list[str]], pd.DataFrame],   # NEW, required
+    *,
+    composition_column: str = "composition",               # global default, per-task overridable
+    val_split: float = 0.1,
+    test_split: float = 0.1,
+    test_all: bool = False,
+    swap_train_val_split: float = 0.0,
+    random_seed: int | None = 42,
+    batch_size: int = 32,
+    num_workers: int = 0,
+)
+```
+
+**Removed**: `formula_desc_source`, `attributes_source`, `task_masking_ratios`, `predict_idx`.
+
+### 3.3 Data assembly pipeline (inside DataModule `setup`)
+
+1. **Load** each enabled non-AE task's `data_files` (csv/pd.xz/parquet), set the composition
+   column as index. Multiple files for one task → concatenated by rows; duplicate
+   compositions deduped (keep-first + warn).
+2. **Composition universe** = union of all task-file compositions ∪ all task `predict_idx`
+   compositions (so predict-only compositions still get descriptors).
+3. **Descriptors**: call `descriptor_fn(unique_uncached_compositions)` → DataFrame indexed by
+   composition; merge into an instance cache. Compositions with no valid descriptor are
+   dropped (+warn); the surviving set is the **master composition index**.
+4. **Per-task alignment**: reindex each task's target / `t` / `split` to the master index;
+   absent compositions → NaN (→ masked out). This reproduces the old "attributes_df" role
+   but assembled from many files, keyed by composition.
+5. **Split resolution** (composition-level, single global split shared by all tasks):
+   overlay every task file's `split` column with precedence `test > val > train` (warn on
+   conflict); unlabeled compositions get the random fallback (`val_split`/`test_split`/seed).
+   `test_all=True` short-circuits to all-test. `swap_train_val_split` preserved.
+6. **Predict** (`setup("predict")`): predict composition universe = union of per-task
+   `predict_idx`; build a predict dataset where each task is masked to its own subset.
+
+Reproducibility: keep the existing deterministic `_seed_for(purpose)` offset scheme.
+
+### 3.4 CompoundDataset rewrite (`data/dataset.py`)
+
+New constructor consumes already-loaded, composition-keyed inputs (produced by §3.3):
+
+```python
+CompoundDataset(
+    compositions: list[str],                 # sample order + dataset length for this split
+    descriptors: pd.DataFrame,                # indexed by composition
+    task_frames: dict[str, pd.DataFrame],     # per-task data, indexed by composition
+    task_configs,
+    task_masking_ratios: dict[str, float] | None = None,
+    task_masking_seed: int | None = None,
+    is_predict_set: bool = False,
+    dataset_name: str = "dataset",
+)
+```
+
+- **Alignment by composition happens at construction**: each task frame is reindexed to
+  `compositions`; `x_formula` is `descriptors.loc[compositions]`. `__getitem__(idx)` then
+  fetches positionally from these aligned structures.
+- **Output tuple is unchanged**: `(x, y_dict, task_masks_dict, t_sequences_dict)` — so
+  `CollateFnWithTaskInfo`, `forward`, `training/validation/test/predict_step` need **no
+  change**. This deliberately contains the blast radius.
+- Reuse `_parse_structured_element` for list-valued / kernel-regression cells.
+- Per-task masking (`task_masking_ratio`) applied here exactly as today, but sourced from
+  the task config instead of a DataModule dict.
+
+### 3.5 Splitter (`data/splitter.py`)
+
+`MultiTaskSplitter` is currently positional/DataFrame-based. Adapt it to operate on a
+composition-indexed task-availability matrix and serve as the **random fallback** in §3.3
+step 5 (so each task keeps representation across train/val/test). Optional polish — a plain
+random split is acceptable for the first cut.
+
+### 3.6 Prediction writer (`scripts/callbacks/prediction_writer.py`)
+
+`predict_step` emits every head for every sample in the batch. With per-task `predict_idx`,
+the writer must filter each task's rows by that task's mask so only requested compositions
+are written. Add composition keys to the written output for downstream joins.
+
+## 4. PR breakdown (each independently testable & green)
+
+> The hard-remove + sync-migrate decision makes the Dataset+DataModule switch naturally
+> atomic (the old DataModule calls the old Dataset constructor). PR3 is therefore the large
+> "core switch". PR1/PR2 de-risk it by landing and fully testing the new pieces first.
+
+### PR1 — Config surface (additive, green)
+- Add the new `BaseTaskConfig` fields + `__post_init__` validation.
+- **Tests**: `model_config_test.py` (new/extended) — field defaults, ratio bounds,
+  predict_idx literal validation, AE-without-files allowed, supervised-without-files errors.
+- No behavior change anywhere else; tree stays green.
+
+### PR2 — Composition data layer (new module, green, pure unit tests)
+- New `data/composition_sources.py` (name TBD) with pure helpers:
+  multi-file loading, composition-universe build, **cached** `descriptor_fn` application,
+  per-task reindex/alignment, composition-level split resolution (overlay + random fallback).
+- **Tests**: `composition_sources_test.py` with a fake `descriptor_fn`, tiny in-memory
+  frames, and temp files for each format. Cover dedupe, missing descriptors, split conflict
+  precedence, predict-only compositions, NaN→mask.
+- Not yet wired into DataModule → tree green.
+
+### PR3 — Core switch (atomic, green)
+- Rewrite `CompoundDataset` (§3.4) and `CompoundDataModule` (§3.2/§3.3) on top of PR2.
+- Migrate **both** consumers: `scripts/dynamic_task_suite.py`,
+  `scripts/multi_task_progressive_clf.py` (provide a `descriptor_fn`; move file paths /
+  masking ratio / predict subset into task configs; suite wraps its precomputed descriptor
+  table as a lookup `descriptor_fn`).
+- Update `prediction_writer.py` (§3.6) and sample TOMLs under `samples/`.
+- Rewrite `dataset_test.py` + `datamodule_test.py` for the new API; update
+  `dynamic_task_suite_test.py` / prediction-writer tests.
+- **Optional sub-split** if the diff is too large: (3a) Dataset with a temporary dual-mode
+  constructor → (3b) DataModule + scripts switch and remove the temporary mode. Final state
+  is still hard-removed.
+
+### PR4 — Splitter + docs (green)
+- Adapt `MultiTaskSplitter` (§3.5) and wire as the random fallback.
+- Refresh `AGENTS.md` "Data" section, `ARCHITECTURE.md`, `README.md`; add a short
+  end-to-end example (descriptor_fn + 2 task files joined by composition).
+
+## 5. Open edge cases to handle (tracked in PR2/PR3)
+
+- Composition in multiple task files with conflicting `split` labels → precedence + warn.
+- Composition with no valid descriptor → drop + warn.
+- `predict_idx` referencing compositions absent from all task files → still added to the
+  descriptor universe.
+- Pure-AE / unsupervised config (no supervised task files) → needs an explicit composition
+  source; document as unsupported-for-now or add a minimal composition-only channel.
+- In-memory task data for tests/suite (avoid forcing temp files): allow the
+  Dataset/DataModule layer to accept in-memory frames in addition to `data_files` paths.
+- DDP: descriptor computation/cache placement (`setup` runs per-rank) — compute-once vs
+  per-rank; keep simple (per-rank cache) and note for later.
+- KernelRegression `t_column` now lives in the same per-task file as its `data_column`.
+
+## 6. Validation per PR
+
+Run `ruff format`, `ruff check`, `mypy src`, and the affected `*_test.py` for every PR;
+run full `pytest` before PR3 and PR4 merge. Each PR ships its co-located tests per
+`AGENTS.md` testing policy.

--- a/src/foundation_model/models/model_config.py
+++ b/src/foundation_model/models/model_config.py
@@ -186,13 +186,18 @@ class OptimizerConfig:
     frequency: int = 1  # Frequency of monitoring
 
 
+# Allowed string selectors for ``BaseTaskConfig.predict_idx``. Any other string is rejected;
+# an explicit composition subset must be passed as a sequence of composition keys.
+PREDICT_IDX_LITERALS = frozenset({"train", "val", "test", "all"})
+
+
 @dataclass
 class BaseTaskConfig:
     """Base configuration for all task types."""
 
     name: str  # Name of the task
     type: TaskType  # Type of the task (will be overridden by subclasses with a default)
-    data_column: str = ""  # Column name in attributes_df for primary task data
+    data_column: str = ""  # Column name (inside this task's data file) for primary task data
 
     # Default fields below are now keyword-only
     enabled: bool = field(default=True, kw_only=True)  # Whether the task is enabled
@@ -201,6 +206,57 @@ class BaseTaskConfig:
 
     # Optimizer configuration
     optimizer: Optional[OptimizerConfig] = field(default=None, kw_only=True)  # Optimizer configuration for this task
+
+    # --- Per-task data-source configuration (composition-keyed refactor) ---
+    # Path(s) to this task's own data file(s) (csv / pd.xz / parquet). A single path may be
+    # given as a string; multiple files are concatenated by rows. Normalized to a tuple.
+    data_files: str | Sequence[str] = field(default=(), kw_only=True)
+    # Name of the composition key column inside this task's file(s); overrides the
+    # CompoundDataModule global default when set.
+    composition_column: Optional[str] = field(default=None, kw_only=True)
+    # Name of the optional split column inside this task's file(s) ("train"/"val"/"test").
+    split_column: str = field(default="split", kw_only=True)
+    # Random keep-ratio applied to this task's valid samples during training (None disables).
+    task_masking_ratio: Optional[float] = field(default=None, kw_only=True)
+    # Composition subset to predict for this task: a literal in PREDICT_IDX_LITERALS, an
+    # explicit sequence of composition keys, or None (defaults handled by the DataModule).
+    predict_idx: Sequence[str] | str | None = field(default=None, kw_only=True)
+
+    def __post_init__(self) -> None:
+        # Normalize data_files to a tuple of path strings.
+        if isinstance(self.data_files, str):
+            self.data_files = (self.data_files,)
+        else:
+            self.data_files = tuple(str(path) for path in self.data_files)
+
+        # Validate the random keep-ratio bounds.
+        if self.task_masking_ratio is not None and not 0.0 <= self.task_masking_ratio <= 1.0:
+            raise ValueError(
+                f"Task '{self.name}': task_masking_ratio must be in [0.0, 1.0], got {self.task_masking_ratio}."
+            )
+
+        # Normalize / validate predict_idx.
+        self.predict_idx = self._normalize_predict_idx(self.predict_idx)
+
+    def _normalize_predict_idx(self, value: Sequence[str] | str | None) -> str | tuple[str, ...] | None:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            if value not in PREDICT_IDX_LITERALS:
+                raise ValueError(
+                    f"Task '{self.name}': predict_idx string must be one of "
+                    f"{sorted(PREDICT_IDX_LITERALS)}, got '{value}'. "
+                    "Pass an explicit composition subset as a sequence of strings."
+                )
+            return value
+        try:
+            items = list(value)
+        except TypeError as exc:
+            raise TypeError(
+                f"Task '{self.name}': predict_idx must be None, one of {sorted(PREDICT_IDX_LITERALS)}, "
+                "or a sequence of composition keys."
+            ) from exc
+        return tuple(str(item) for item in items)
 
 
 @dataclass

--- a/src/foundation_model/models/model_config.py
+++ b/src/foundation_model/models/model_config.py
@@ -197,7 +197,7 @@ class BaseTaskConfig:
 
     name: str  # Name of the task
     type: TaskType  # Type of the task (will be overridden by subclasses with a default)
-    data_column: str = ""  # Column name (inside this task's data file) for primary task data
+    data_column: str = ""  # Column name for primary task data (currently in attributes_df; per-task file after PR3)
 
     # Default fields below are now keyword-only
     enabled: bool = field(default=True, kw_only=True)  # Whether the task is enabled

--- a/src/foundation_model/models/model_config_test.py
+++ b/src/foundation_model/models/model_config_test.py
@@ -1,0 +1,102 @@
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the per-task data-source fields added to BaseTaskConfig (composition refactor PR1)."""
+
+import pytest
+
+from foundation_model.models.model_config import (
+    PREDICT_IDX_LITERALS,
+    AutoEncoderTaskConfig,
+    ClassificationTaskConfig,
+    KernelRegressionTaskConfig,
+    RegressionTaskConfig,
+    TaskType,
+)
+
+# Subclasses whose extra positional fields all have defaults, so they can be built with
+# just ``name`` and exercise the inherited BaseTaskConfig.__post_init__.
+ALL_TASK_CONFIG_CLASSES = [
+    RegressionTaskConfig,
+    ClassificationTaskConfig,
+    KernelRegressionTaskConfig,
+    AutoEncoderTaskConfig,
+]
+
+
+@pytest.mark.parametrize("config_cls", ALL_TASK_CONFIG_CLASSES)
+def test_new_fields_have_expected_defaults(config_cls):
+    """New per-task data-source fields default to inert values across all task types."""
+    cfg = config_cls(name="t")
+    assert cfg.data_files == ()
+    assert cfg.composition_column is None
+    assert cfg.split_column == "split"
+    assert cfg.task_masking_ratio is None
+    assert cfg.predict_idx is None
+
+
+def test_data_files_single_string_is_wrapped_in_tuple():
+    cfg = RegressionTaskConfig(name="t", data_files="a.parquet")
+    assert cfg.data_files == ("a.parquet",)
+
+
+def test_data_files_sequence_is_normalized_to_tuple_of_str():
+    cfg = RegressionTaskConfig(name="t", data_files=["a.csv", "b.pd.xz"])
+    assert cfg.data_files == ("a.csv", "b.pd.xz")
+    assert isinstance(cfg.data_files, tuple)
+
+
+def test_autoencoder_task_allowed_without_data_files():
+    """AE targets are the input x; it must build fine without any data file."""
+    cfg = AutoEncoderTaskConfig(name="ae")
+    assert cfg.data_files == ()
+
+
+@pytest.mark.parametrize("ratio", [0.0, 0.5, 1.0])
+def test_task_masking_ratio_accepts_unit_interval(ratio):
+    cfg = RegressionTaskConfig(name="t", task_masking_ratio=ratio)
+    assert cfg.task_masking_ratio == ratio
+
+
+@pytest.mark.parametrize("ratio", [-0.1, 1.0001, 2.0])
+def test_task_masking_ratio_rejects_out_of_range(ratio):
+    with pytest.raises(ValueError, match="task_masking_ratio must be in"):
+        RegressionTaskConfig(name="t", task_masking_ratio=ratio)
+
+
+@pytest.mark.parametrize("literal", sorted(PREDICT_IDX_LITERALS))
+def test_predict_idx_accepts_known_literals(literal):
+    cfg = RegressionTaskConfig(name="t", predict_idx=literal)
+    assert cfg.predict_idx == literal
+
+
+def test_predict_idx_rejects_unknown_string():
+    with pytest.raises(ValueError, match="predict_idx string must be one of"):
+        RegressionTaskConfig(name="t", predict_idx="holdout")
+
+
+def test_predict_idx_sequence_is_normalized_to_tuple_of_str():
+    cfg = RegressionTaskConfig(name="t", predict_idx=["comp_a", "comp_b"])
+    assert cfg.predict_idx == ("comp_a", "comp_b")
+    assert isinstance(cfg.predict_idx, tuple)
+
+
+def test_predict_idx_none_stays_none():
+    cfg = RegressionTaskConfig(name="t", predict_idx=None)
+    assert cfg.predict_idx is None
+
+
+def test_predict_idx_non_iterable_raises_type_error():
+    with pytest.raises(TypeError, match="predict_idx must be None"):
+        RegressionTaskConfig(name="t", predict_idx=5)  # type: ignore[arg-type]
+
+
+def test_existing_construction_pattern_still_works():
+    """Pre-refactor positional/keyword usage must remain valid (backward compatibility)."""
+    cfg = RegressionTaskConfig(name="bandgap", data_column="bandgap", enabled=True)
+    assert cfg.name == "bandgap"
+    assert cfg.data_column == "bandgap"
+    assert cfg.type == TaskType.REGRESSION
+    # New fields are inert for old-style configs.
+    assert cfg.data_files == ()
+    assert cfg.predict_idx is None


### PR DESCRIPTION
## Scope

**PR1** of the composition-keyed data refactor (see `REFACTOR_composition_datamodule_PLAN.md`, also added here). Purely additive config surface — no behavior change to the existing `formula_desc_source`/`attributes_source` data path.

## What changed

Adds five optional, keyword-only fields to `BaseTaskConfig` (inherited by `RegressionTaskConfig`, `ClassificationTaskConfig`, `KernelRegressionTaskConfig`, `AutoEncoderTaskConfig`):

| Field | Type | Default | Purpose |
|---|---|---|---|
| `data_files` | `str \| Sequence[str]` | `()` | This task's own source file(s); single str wrapped, normalized to a tuple |
| `composition_column` | `str \| None` | `None` | Override the DataModule's global composition column |
| `split_column` | `str` | `"split"` | Optional in-file split column name |
| `task_masking_ratio` | `float \| None` | `None` | Per-task keep ratio (replaces `DataModule.task_masking_ratios`) |
| `predict_idx` | `Sequence[str] \| str \| None` | `None` | Literal `{train,val,test,all}` or an explicit composition subset |

Validation in an inherited `__post_init__`: `task_masking_ratio` bounds `[0,1]`, `predict_idx` literal membership / iterability, `data_files` normalization. Exports the `PREDICT_IDX_LITERALS` constant.

## Why inert defaults

All fields default to inert values and have no consumer yet, so the current data stack is untouched. They are wired up in PR2 (composition data layer) and PR3 (Dataset + DataModule switch).

## Tests / validation

- New co-located `model_config_test.py`: defaults across all four task types (parametrized), `data_files` normalization, AE-without-files allowed, ratio bounds + out-of-range errors, `predict_idx` literal/sequence/None/non-iterable, and a backward-compatibility case.
- `pytest src/foundation_model/models src/foundation_model/data` → **80 passed**.
- `ruff format --check`, `ruff check`, `mypy src/foundation_model/models/model_config.py` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)