### PR TITLE
feat(data): composition-keyed data-source helpers (refactor PR2)

### DIFF
--- a/src/foundation_model/data/composition_sources.py
+++ b/src/foundation_model/data/composition_sources.py
@@ -1,0 +1,340 @@
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Composition-keyed data-source helpers (refactor PR2).
+
+Pure building blocks used by the composition-keyed ``CompoundDataModule`` (wired in PR3):
+
+* :func:`read_data_file` / :func:`load_task_frame` — load a task's own file(s) and index
+  them by a composition column.
+* :func:`build_composition_universe` — the union of compositions across tasks (plus any
+  predict-only compositions).
+* :class:`DescriptorCache` — apply a user descriptor function once per unique composition.
+* :func:`resolve_splits` — derive a single composition-level train/val/test split by
+  overlaying per-task ``split`` columns and randomly assigning the rest.
+
+These functions are intentionally side-effect free (apart from logging) so they can be unit
+tested in isolation with in-memory frames and a fake descriptor function.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Mapping, Sequence
+
+import joblib  # type: ignore[import-untyped]
+import numpy as np
+import pandas as pd
+from loguru import logger
+
+DescriptorFn = Callable[[list[str]], pd.DataFrame]
+
+# Split labels, ordered by precedence (later wins on conflict).
+_SPLIT_PRECEDENCE: dict[str, int] = {"train": 1, "val": 2, "test": 3}
+VALID_SPLIT_LABELS = frozenset(_SPLIT_PRECEDENCE)
+
+
+def read_data_file(path: str) -> pd.DataFrame:
+    """Load a single data file into a DataFrame based on its extension.
+
+    Supported: ``.csv``, ``.parquet`` / ``.pd.parquet``, pickled frames
+    (``.pd`` / ``.pd.z`` / ``.pd.xz``), and ``.pkl`` (joblib).
+
+    Parameters
+    ----------
+    path : str
+        Path to the data file.
+
+    Returns
+    -------
+    pd.DataFrame
+        The loaded frame (index untouched; caller sets the composition index).
+
+    Raises
+    ------
+    ValueError
+        If the file extension is not recognized or the loaded object is not a DataFrame.
+    """
+    lower = path.lower()
+    if lower.endswith(".csv"):
+        df = pd.read_csv(path)
+    elif lower.endswith(".parquet"):
+        df = pd.read_parquet(path)
+    elif lower.endswith((".pd", ".pd.z", ".pd.xz")):
+        df = pd.read_pickle(path)
+    elif lower.endswith(".pkl"):
+        df = joblib.load(path)
+    else:
+        raise ValueError(
+            f"Unsupported file type: {path}. Must be .csv, .parquet/.pd.parquet, .pd/.pd.z/.pd.xz, or .pkl."
+        )
+    if not isinstance(df, pd.DataFrame):
+        raise ValueError(f"File {path} did not load into a pandas DataFrame (got {type(df).__name__}).")
+    return df
+
+
+def load_task_frame(
+    data_files: Sequence[str],
+    composition_column: str,
+    *,
+    task_name: str = "",
+) -> pd.DataFrame:
+    """Load and concatenate a task's data file(s), indexed by composition.
+
+    Multiple files are concatenated by rows. Duplicate compositions are dropped keeping the
+    first occurrence (with a warning). The composition column becomes a string index and is
+    removed from the columns.
+
+    Parameters
+    ----------
+    data_files : Sequence[str]
+        One or more paths to the task's data file(s).
+    composition_column : str
+        Name of the column holding composition keys.
+    task_name : str, optional
+        Task name used only for log messages.
+
+    Returns
+    -------
+    pd.DataFrame
+        Frame indexed by composition (string), columns are the remaining data columns.
+
+    Raises
+    ------
+    ValueError
+        If ``data_files`` is empty or the composition column is missing from a file.
+    """
+    label = task_name or "<task>"
+    if not data_files:
+        raise ValueError(f"Task '{label}': data_files is empty; cannot load a task frame.")
+
+    frames: list[pd.DataFrame] = []
+    for path in data_files:
+        df = read_data_file(path)
+        if composition_column not in df.columns:
+            raise ValueError(
+                f"Task '{label}': composition column '{composition_column}' not found in '{path}' "
+                f"(available columns: {list(df.columns)})."
+            )
+        df = df.set_index(composition_column)
+        frames.append(df)
+
+    combined = pd.concat(frames, axis=0) if len(frames) > 1 else frames[0]
+    combined.index = combined.index.astype(str)
+    combined.index.name = composition_column
+
+    duplicated = combined.index.duplicated(keep="first")
+    if duplicated.any():
+        logger.warning(
+            f"Task '{label}': {int(duplicated.sum())} duplicate composition(s) across data_files; "
+            "keeping the first occurrence of each."
+        )
+        combined = combined[~duplicated]
+
+    return combined
+
+
+def build_composition_universe(
+    task_frames: Mapping[str, pd.DataFrame],
+    extra_compositions: Sequence[str] | None = None,
+) -> list[str]:
+    """Return the order-preserving union of all task compositions plus any extras.
+
+    Parameters
+    ----------
+    task_frames : Mapping[str, pd.DataFrame]
+        Per-task frames indexed by composition (as produced by :func:`load_task_frame`).
+    extra_compositions : Sequence[str] | None, optional
+        Additional compositions to include (e.g. predict-only compositions) so descriptors
+        are computed for them even when they carry no task target.
+
+    Returns
+    -------
+    list[str]
+        Unique compositions, preserving first-seen order across tasks then extras.
+    """
+    universe: dict[str, None] = {}
+    for frame in task_frames.values():
+        for comp in frame.index.astype(str):
+            universe.setdefault(comp, None)
+    if extra_compositions:
+        for comp in extra_compositions:
+            universe.setdefault(str(comp), None)
+    return list(universe)
+
+
+class DescriptorCache:
+    """Apply a user descriptor function once per unique composition.
+
+    The descriptor function maps a list of composition strings to a DataFrame indexed by
+    composition. Results are cached; subsequent calls only compute compositions not seen
+    before. Compositions the function fails to produce (or returns as all-NaN rows) are
+    reported as "dropped" by :meth:`resolve`.
+
+    Parameters
+    ----------
+    descriptor_fn : Callable[[list[str]], pd.DataFrame]
+        Function returning a composition-indexed descriptor frame.
+    """
+
+    def __init__(self, descriptor_fn: DescriptorFn):
+        self._descriptor_fn = descriptor_fn
+        self._cache: pd.DataFrame | None = None
+        self._attempted: set[str] = set()
+
+    def compute(self, compositions: Sequence[str]) -> pd.DataFrame:
+        """Return cached descriptors for ``compositions``, computing any not yet attempted.
+
+        The returned frame contains only the requested compositions the function has
+        produced, in the requested order.
+        """
+        requested = [str(c) for c in compositions]
+        uncached = [c for c in dict.fromkeys(requested) if c not in self._attempted]
+        if uncached:
+            produced = self._descriptor_fn(uncached)
+            if not isinstance(produced, pd.DataFrame):
+                raise TypeError(f"descriptor_fn must return a pandas DataFrame, got {type(produced).__name__}.")
+            produced = produced.copy()
+            produced.index = produced.index.astype(str)
+            self._attempted.update(uncached)
+            if not produced.empty:
+                self._cache = produced if self._cache is None else pd.concat([self._cache, produced], axis=0)
+                # Keep the first descriptor row for any composition seen more than once.
+                self._cache = self._cache[~self._cache.index.duplicated(keep="first")]
+
+        if self._cache is None:
+            return pd.DataFrame()
+        present = [c for c in requested if c in self._cache.index]
+        return self._cache.loc[present]
+
+    def resolve(self, compositions: Sequence[str]) -> tuple[pd.DataFrame, list[str]]:
+        """Compute descriptors and split the request into valid frame + dropped list.
+
+        A composition is "dropped" when the descriptor function did not produce it or
+        produced an all-NaN row.
+
+        Returns
+        -------
+        tuple[pd.DataFrame, list[str]]
+            ``(valid_descriptors, dropped_compositions)`` where ``valid_descriptors`` is
+            indexed by composition in the requested order.
+        """
+        requested = [str(c) for c in compositions]
+        computed = self.compute(requested)
+        if computed.empty:
+            return computed, list(dict.fromkeys(requested))
+
+        all_nan = computed.isna().all(axis=1)
+        valid_index = computed.index[~all_nan]
+        valid_set = set(valid_index)
+        valid = [c for c in requested if c in valid_set]
+        dropped = [c for c in dict.fromkeys(requested) if c not in valid_set]
+        return computed.loc[valid], dropped
+
+
+def _random_split(
+    compositions: Sequence[str],
+    *,
+    val_split: float,
+    test_split: float,
+    rng: np.random.Generator,
+) -> dict[str, str]:
+    """Assign train/val/test labels to ``compositions`` by proportional random split."""
+    comps = list(compositions)
+    n = len(comps)
+    if n == 0:
+        return {}
+    order = rng.permutation(n)
+    shuffled = [comps[i] for i in order]
+    n_test = int(round(n * test_split))
+    n_val = int(round(n * val_split))
+    n_test = min(n_test, n)
+    n_val = min(n_val, n - n_test)
+    labels: dict[str, str] = {}
+    for comp in shuffled[:n_test]:
+        labels[comp] = "test"
+    for comp in shuffled[n_test : n_test + n_val]:
+        labels[comp] = "val"
+    for comp in shuffled[n_test + n_val :]:
+        labels[comp] = "train"
+    return labels
+
+
+def resolve_splits(
+    task_frames: Mapping[str, pd.DataFrame],
+    master_index: Sequence[str],
+    split_columns: Mapping[str, str],
+    *,
+    val_split: float = 0.1,
+    test_split: float = 0.1,
+    random_seed: int | None = 42,
+    test_all: bool = False,
+) -> pd.Series:
+    """Derive a single composition-level train/val/test split.
+
+    Per-task ``split`` columns are overlaid (precedence ``test > val > train``; conflicts are
+    warned). Compositions with no label from any task fall back to a proportional random
+    split. With ``test_all=True`` every composition is assigned to ``test``.
+
+    Parameters
+    ----------
+    task_frames : Mapping[str, pd.DataFrame]
+        Per-task frames indexed by composition.
+    master_index : Sequence[str]
+        The compositions to label (typically those with valid descriptors).
+    split_columns : Mapping[str, str]
+        Per-task name of the split column to read (tasks absent from the map, or whose
+        column is missing from their frame, contribute no labels).
+    val_split, test_split : float
+        Random-fallback proportions for unlabeled compositions.
+    random_seed : int | None
+        Seed for the random fallback.
+    test_all : bool
+        If True, assign every composition to ``test``.
+
+    Returns
+    -------
+    pd.Series
+        Index = ``master_index``, values in ``{"train", "val", "test"}``.
+
+    Raises
+    ------
+    ValueError
+        If a split column contains a value outside ``{"train", "val", "test"}``.
+    """
+    master = [str(c) for c in master_index]
+    if test_all:
+        return pd.Series(["test"] * len(master), index=pd.Index(master, name="composition"), dtype=object)
+
+    labels: dict[str, str] = {}
+    for task_name, frame in task_frames.items():
+        col = split_columns.get(task_name)
+        if not col or col not in frame.columns:
+            continue
+        series = frame[col].dropna()
+        for comp, raw in series.items():
+            comp = str(comp)
+            value = str(raw)
+            if value not in VALID_SPLIT_LABELS:
+                raise ValueError(
+                    f"Task '{task_name}': invalid value '{value}' in split column '{col}'. "
+                    f"Must be one of {sorted(VALID_SPLIT_LABELS)}."
+                )
+            existing = labels.get(comp)
+            if existing is None:
+                labels[comp] = value
+            elif existing != value:
+                logger.warning(
+                    f"Composition '{comp}' has conflicting split labels ('{existing}' vs '{value}'); "
+                    f"keeping higher precedence."
+                )
+                if _SPLIT_PRECEDENCE[value] > _SPLIT_PRECEDENCE[existing]:
+                    labels[comp] = value
+
+    unlabeled = [comp for comp in master if comp not in labels]
+    if unlabeled:
+        rng = np.random.default_rng(random_seed)
+        labels.update(_random_split(unlabeled, val_split=val_split, test_split=test_split, rng=rng))
+
+    resolved = [labels[comp] for comp in master]
+    return pd.Series(resolved, index=pd.Index(master, name="composition"), dtype=object)

--- a/src/foundation_model/data/composition_sources.py
+++ b/src/foundation_model/data/composition_sources.py
@@ -40,6 +40,12 @@ def read_data_file(path: str) -> pd.DataFrame:
     Supported: ``.csv``, ``.parquet`` / ``.pd.parquet``, pickled frames
     (``.pd`` / ``.pd.z`` / ``.pd.xz``), and ``.pkl`` (joblib).
 
+    .. warning::
+        The pickle-based formats (``.pd`` / ``.pd.z`` / ``.pd.xz`` via ``pd.read_pickle``
+        and ``.pkl`` via ``joblib.load``) deserialize arbitrary Python objects and can
+        execute arbitrary code. Only load these from sources you trust; prefer ``.csv`` or
+        ``.parquet`` for untrusted inputs.
+
     Parameters
     ----------
     path : str
@@ -157,7 +163,7 @@ def build_composition_universe(
     for frame in task_frames.values():
         for comp in frame.index.astype(str):
             universe.setdefault(comp, None)
-    if extra_compositions:
+    if extra_compositions is not None:
         for comp in extra_compositions:
             universe.setdefault(str(comp), None)
     return list(universe)

--- a/src/foundation_model/data/composition_sources_test.py
+++ b/src/foundation_model/data/composition_sources_test.py
@@ -3,6 +3,7 @@
 
 """Tests for composition-keyed data-source helpers (refactor PR2)."""
 
+import joblib
 import numpy as np
 import pandas as pd
 import pytest
@@ -36,14 +37,16 @@ def sample_frame():
     return pd.DataFrame({"composition": ["H2O", "CO2", "NaCl"], "y": [1.0, 2.0, 3.0]})
 
 
-@pytest.mark.parametrize("suffix", [".csv", ".parquet", ".pd.xz"])
+@pytest.mark.parametrize("suffix", [".csv", ".parquet", ".pd", ".pd.z", ".pd.xz", ".pkl"])
 def test_read_data_file_roundtrip(tmp_path, sample_frame, suffix):
     path = tmp_path / f"data{suffix}"
     if suffix == ".csv":
         sample_frame.to_csv(path, index=False)
     elif suffix == ".parquet":
         sample_frame.to_parquet(path)
-    else:
+    elif suffix == ".pkl":
+        joblib.dump(sample_frame, path)
+    else:  # .pd / .pd.z / .pd.xz pickled frames
         sample_frame.to_pickle(path)
     loaded = read_data_file(str(path))
     assert list(loaded["composition"]) == ["H2O", "CO2", "NaCl"]
@@ -119,6 +122,13 @@ def test_build_composition_universe_unions_and_preserves_order():
 def test_build_composition_universe_includes_extras():
     frames = {"t1": pd.DataFrame({"y": [1]}, index=pd.Index(["A"], name="composition"))}
     assert build_composition_universe(frames, extra_compositions=["A", "Z"]) == ["A", "Z"]
+
+
+@pytest.mark.parametrize("extras", [pd.Index(["A", "Z"]), np.array(["A", "Z"])])
+def test_build_composition_universe_accepts_array_like_extras(extras):
+    """pd.Index / np.ndarray extras must not trip ambiguous-truthiness errors."""
+    frames = {"t1": pd.DataFrame({"y": [1]}, index=pd.Index(["A"], name="composition"))}
+    assert build_composition_universe(frames, extra_compositions=extras) == ["A", "Z"]
 
 
 # --- DescriptorCache --------------------------------------------------------

--- a/src/foundation_model/data/composition_sources_test.py
+++ b/src/foundation_model/data/composition_sources_test.py
@@ -1,0 +1,253 @@
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for composition-keyed data-source helpers (refactor PR2)."""
+
+import numpy as np
+import pandas as pd
+import pytest
+from loguru import logger
+
+from foundation_model.data.composition_sources import (
+    DescriptorCache,
+    build_composition_universe,
+    load_task_frame,
+    read_data_file,
+    resolve_splits,
+)
+
+
+@pytest.fixture
+def loguru_warnings():
+    """Capture loguru WARNING-level messages (caplog only sees stdlib logging)."""
+    messages: list[str] = []
+    sink_id = logger.add(messages.append, level="WARNING", format="{message}")
+    try:
+        yield messages
+    finally:
+        logger.remove(sink_id)
+
+
+# --- read_data_file ---------------------------------------------------------
+
+
+@pytest.fixture
+def sample_frame():
+    return pd.DataFrame({"composition": ["H2O", "CO2", "NaCl"], "y": [1.0, 2.0, 3.0]})
+
+
+@pytest.mark.parametrize("suffix", [".csv", ".parquet", ".pd.xz"])
+def test_read_data_file_roundtrip(tmp_path, sample_frame, suffix):
+    path = tmp_path / f"data{suffix}"
+    if suffix == ".csv":
+        sample_frame.to_csv(path, index=False)
+    elif suffix == ".parquet":
+        sample_frame.to_parquet(path)
+    else:
+        sample_frame.to_pickle(path)
+    loaded = read_data_file(str(path))
+    assert list(loaded["composition"]) == ["H2O", "CO2", "NaCl"]
+    assert list(loaded["y"]) == [1.0, 2.0, 3.0]
+
+
+def test_read_data_file_rejects_unknown_extension(tmp_path):
+    path = tmp_path / "data.txt"
+    path.write_text("nope")
+    with pytest.raises(ValueError, match="Unsupported file type"):
+        read_data_file(str(path))
+
+
+# --- load_task_frame --------------------------------------------------------
+
+
+def test_load_task_frame_indexes_by_composition(tmp_path, sample_frame):
+    path = tmp_path / "t.csv"
+    sample_frame.to_csv(path, index=False)
+    frame = load_task_frame([str(path)], "composition", task_name="t")
+    assert frame.index.name == "composition"
+    assert list(frame.index) == ["H2O", "CO2", "NaCl"]
+    assert "composition" not in frame.columns
+    assert list(frame["y"]) == [1.0, 2.0, 3.0]
+
+
+def test_load_task_frame_concatenates_multiple_files(tmp_path):
+    a = pd.DataFrame({"composition": ["A", "B"], "y": [1.0, 2.0]})
+    b = pd.DataFrame({"composition": ["C"], "y": [3.0]})
+    pa, pb = tmp_path / "a.csv", tmp_path / "b.csv"
+    a.to_csv(pa, index=False)
+    b.to_csv(pb, index=False)
+    frame = load_task_frame([str(pa), str(pb)], "composition")
+    assert list(frame.index) == ["A", "B", "C"]
+
+
+def test_load_task_frame_dedupes_keep_first_with_warning(tmp_path, loguru_warnings):
+    a = pd.DataFrame({"composition": ["A", "B"], "y": [1.0, 2.0]})
+    b = pd.DataFrame({"composition": ["B", "C"], "y": [99.0, 3.0]})
+    pa, pb = tmp_path / "a.csv", tmp_path / "b.csv"
+    a.to_csv(pa, index=False)
+    b.to_csv(pb, index=False)
+    frame = load_task_frame([str(pa), str(pb)], "composition", task_name="dup")
+    assert list(frame.index) == ["A", "B", "C"]
+    assert frame.loc["B", "y"] == 2.0  # first occurrence kept
+    assert any("duplicate composition" in m for m in loguru_warnings)
+
+
+def test_load_task_frame_missing_composition_column_raises(tmp_path):
+    df = pd.DataFrame({"name": ["A"], "y": [1.0]})
+    path = tmp_path / "t.csv"
+    df.to_csv(path, index=False)
+    with pytest.raises(ValueError, match="composition column 'composition' not found"):
+        load_task_frame([str(path)], "composition", task_name="t")
+
+
+def test_load_task_frame_empty_files_raises():
+    with pytest.raises(ValueError, match="data_files is empty"):
+        load_task_frame([], "composition", task_name="t")
+
+
+# --- build_composition_universe ---------------------------------------------
+
+
+def test_build_composition_universe_unions_and_preserves_order():
+    frames = {
+        "t1": pd.DataFrame({"y": [1, 2]}, index=pd.Index(["A", "B"], name="composition")),
+        "t2": pd.DataFrame({"y": [1, 2]}, index=pd.Index(["B", "C"], name="composition")),
+    }
+    assert build_composition_universe(frames) == ["A", "B", "C"]
+
+
+def test_build_composition_universe_includes_extras():
+    frames = {"t1": pd.DataFrame({"y": [1]}, index=pd.Index(["A"], name="composition"))}
+    assert build_composition_universe(frames, extra_compositions=["A", "Z"]) == ["A", "Z"]
+
+
+# --- DescriptorCache --------------------------------------------------------
+
+
+def _make_counting_fn(calls):
+    def fn(comps):
+        calls.append(list(comps))
+        return pd.DataFrame({"d0": [float(len(c)) for c in comps]}, index=list(comps))
+
+    return fn
+
+
+def test_descriptor_cache_computes_each_composition_once():
+    calls = []
+    cache = DescriptorCache(_make_counting_fn(calls))
+    first = cache.compute(["a", "bb"])
+    second = cache.compute(["bb", "ccc"])
+    assert calls == [["a", "bb"], ["ccc"]]  # "bb" not recomputed
+    assert list(first.index) == ["a", "bb"]
+    assert list(second.index) == ["bb", "ccc"]
+    assert second.loc["ccc", "d0"] == 3.0
+
+
+def test_descriptor_cache_preserves_requested_order():
+    cache = DescriptorCache(_make_counting_fn([]))
+    out = cache.compute(["ccc", "a", "bb"])
+    assert list(out.index) == ["ccc", "a", "bb"]
+
+
+def test_descriptor_cache_resolve_drops_missing_compositions():
+    def fn(comps):
+        keep = [c for c in comps if c != "bad"]
+        return pd.DataFrame({"d0": [1.0] * len(keep)}, index=keep)
+
+    cache = DescriptorCache(fn)
+    valid, dropped = cache.resolve(["a", "bad", "b"])
+    assert list(valid.index) == ["a", "b"]
+    assert dropped == ["bad"]
+
+
+def test_descriptor_cache_resolve_drops_all_nan_rows():
+    def fn(comps):
+        return pd.DataFrame({"d0": [np.nan if c == "x" else 1.0 for c in comps]}, index=list(comps))
+
+    cache = DescriptorCache(fn)
+    valid, dropped = cache.resolve(["x", "y"])
+    assert list(valid.index) == ["y"]
+    assert dropped == ["x"]
+
+
+def test_descriptor_cache_does_not_retry_known_missing():
+    calls = []
+
+    def fn(comps):
+        calls.append(list(comps))
+        keep = [c for c in comps if c != "bad"]
+        return pd.DataFrame({"d0": [1.0] * len(keep)}, index=keep)
+
+    cache = DescriptorCache(fn)
+    cache.resolve(["a", "bad"])
+    cache.resolve(["bad", "a"])  # "bad" already attempted; "a" cached
+    assert calls == [["a", "bad"]]
+
+
+def test_descriptor_cache_rejects_non_dataframe():
+    cache = DescriptorCache(lambda comps: [1, 2, 3])  # type: ignore[arg-type,return-value]
+    with pytest.raises(TypeError, match="must return a pandas DataFrame"):
+        cache.compute(["a"])
+
+
+# --- resolve_splits ---------------------------------------------------------
+
+
+def _frame_with_split(index, labels):
+    return pd.DataFrame({"split": labels}, index=pd.Index(index, name="composition"))
+
+
+def test_resolve_splits_reads_split_column():
+    frames = {"t1": _frame_with_split(["a", "b", "c"], ["train", "val", "test"])}
+    out = resolve_splits(frames, ["a", "b", "c"], {"t1": "split"}, val_split=0.0, test_split=0.0)
+    assert out.to_dict() == {"a": "train", "b": "val", "c": "test"}
+
+
+def test_resolve_splits_conflict_uses_precedence(loguru_warnings):
+    frames = {
+        "t1": _frame_with_split(["a"], ["train"]),
+        "t2": _frame_with_split(["a"], ["test"]),
+    }
+    out = resolve_splits(frames, ["a"], {"t1": "split", "t2": "split"})
+    assert out["a"] == "test"  # test > train
+    assert any("conflicting split labels" in m for m in loguru_warnings)
+
+
+def test_resolve_splits_invalid_label_raises():
+    frames = {"t1": _frame_with_split(["a"], ["holdout"])}
+    with pytest.raises(ValueError, match="invalid value 'holdout'"):
+        resolve_splits(frames, ["a"], {"t1": "split"})
+
+
+def test_resolve_splits_random_fallback_is_deterministic():
+    comps = [f"c{i}" for i in range(10)]
+    frames = {"t1": pd.DataFrame({"y": range(10)}, index=pd.Index(comps, name="composition"))}
+    kwargs = dict(val_split=0.2, test_split=0.2, random_seed=42)
+    out1 = resolve_splits(frames, comps, {"t1": "split"}, **kwargs)
+    out2 = resolve_splits(frames, comps, {"t1": "split"}, **kwargs)
+    assert out1.equals(out2)
+    counts = out1.value_counts().to_dict()
+    assert counts["test"] == 2
+    assert counts["val"] == 2
+    assert counts["train"] == 6
+
+
+def test_resolve_splits_mixes_labeled_and_random():
+    frames = {"t1": _frame_with_split(["a", "b", "c"], ["train", None, "test"])}
+    out = resolve_splits(frames, ["a", "b", "c"], {"t1": "split"}, val_split=0.0, test_split=0.0, random_seed=0)
+    assert out["a"] == "train"
+    assert out["c"] == "test"
+    assert out["b"] in {"train", "val", "test"}  # unlabeled -> random fallback
+
+
+def test_resolve_splits_test_all_overrides_everything():
+    frames = {"t1": _frame_with_split(["a", "b"], ["train", "val"])}
+    out = resolve_splits(frames, ["a", "b"], {"t1": "split"}, test_all=True)
+    assert out.to_dict() == {"a": "test", "b": "test"}
+
+
+def test_resolve_splits_ignores_tasks_without_split_column():
+    frames = {"t1": pd.DataFrame({"y": [1, 2]}, index=pd.Index(["a", "b"], name="composition"))}
+    out = resolve_splits(frames, ["a", "b"], {"t1": "split"}, val_split=0.5, test_split=0.0, random_seed=1)
+    assert set(out.unique()) <= {"train", "val", "test"}
+    assert len(out) == 2


### PR DESCRIPTION
## Scope

**PR2** of the composition-keyed data refactor (see `REFACTOR_composition_datamodule_PLAN.md` §3.3 / §3.5, landed in #8). Adds a new pure helper module — **no wiring into `CompoundDataModule`/`CompoundDataset` yet**, so the existing data path is untouched and the tree stays green.

Branches from `master` and is independent of #8 (it only consumes PR1's config fields once everything is wired together in PR3).

## What's added

`src/foundation_model/data/composition_sources.py`:

| Helper | Responsibility |
|---|---|
| `read_data_file(path)` | Load one file by extension: `.csv`, `.parquet`/`.pd.parquet`, `.pd`/`.pd.z`/`.pd.xz`, `.pkl` |
| `load_task_frame(data_files, composition_column, ...)` | Load + row-concat a task's file(s), index by composition (str), dedup keep-first + warn |
| `build_composition_universe(task_frames, extra_compositions)` | Order-preserving union of task compositions ∪ predict-only extras |
| `DescriptorCache(descriptor_fn)` | Apply `descriptor_fn` once per unique composition; `.resolve()` returns `(valid_frame, dropped)` for missing / all-NaN descriptors |
| `resolve_splits(...)` | Single composition-level train/val/test split: overlay per-task `split` columns (precedence `test > val > train`, warn on conflict) + deterministic random fallback; `test_all` short-circuit |

All functions are side-effect free apart from `loguru` logging, so they unit-test in isolation.

## Tests

`composition_sources_test.py` (24 tests): file roundtrip per format + unknown-extension error; multi-file concat, dedup-with-warning, missing-composition-column / empty-files errors; universe union + extras; descriptor cache compute-once / order preservation / drop-missing / drop-all-NaN / no-retry-known-missing / non-DataFrame guard; split column read, conflict precedence, invalid-label error, deterministic random fallback, labeled+random mix, `test_all`, tasks without a split column.

A `loguru_warnings` fixture captures loguru WARNING output (pytest's `caplog` only sees stdlib logging).

## Validation

- `pytest src/foundation_model/data src/foundation_model/models` → **104 passed**
- `ruff format --check`, `ruff check`, `mypy` on the new module all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)