### PR TITLE
feat(data): composition-keyed per-task DataModule core switch (refactor PR3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,10 +73,15 @@ x_formula ──▶ FoundationEncoder ──▶ latent ──tanh──▶ h_tas
 
 ## Data
 
-- `CompoundDataModule` / `CompoundDataset` (`data/`) load formula descriptors plus an `attributes_source` (CSV/DataFrame) holding targets.
-- Each task config names its target via `data_column`; kernel-regression tasks add a `t_column` naming the sequence x-axis values (energy/temperature/time). **Column names must match the source exactly.**
-- List-valued cells in CSV (sequences, multi-dim targets) must be strings parseable by `ast.literal_eval`, e.g. `"[1.0, 2.5, 3.0]"`.
-- Missing targets / NaNs are **masked out** per task rather than dropped; placeholders fill `y_dict`. Modality dropout and missing-value masking are built in.
+- `CompoundDataModule` / `CompoundDataset` (`data/`) are **composition-keyed**: each task owns its own data file(s), joined to the others by a **composition** column. There is no monolithic `attributes_source` — adding a property task means adding one file + one task config.
+- `CompoundDataModule(task_configs, descriptor_fn, *, task_frames=None, default_data_files=None, composition_column="composition", val_split, test_split, test_all, swap_train_val_split, random_seed, batch_size, num_workers)`:
+  - `descriptor_fn: Callable[[list[str]], pd.DataFrame]` computes descriptors from the union of compositions (results cached per unique composition). `PrecomputedDescriptorSource(path)` in `data/composition_sources.py` is a YAML/CLI-friendly callable for already-computed, composition-indexed descriptor files.
+  - Per-task data comes from `cfg.data_files` (paths; helpers in `data/composition_sources.py`), or an in-memory `task_frames` mapping, or a shared `default_data_files` fallback. `composition_column` may be a column name or the file's index name (per-task override via `cfg.composition_column`).
+- Per-task config fields (`model_config.py` `BaseTaskConfig`): `data_files`, `data_column` (+ `t_column` for kernel regression), `split_column`, `task_masking_ratio`, `predict_idx`. **Column names must match the source exactly.**
+- Splits: a single composition-level train/val/test split overlays each task file's `split` column (precedence `test > val > train`) with a random fallback (`val_split`/`test_split`/`random_seed`).
+- Prediction: each task's `predict_idx` (literal `train`/`val`/`test`/`all` or an explicit composition sequence) selects a subset; the predict set is their union, exposed as `datamodule.predict_compositions` (the prediction writer attaches these as the output index).
+- List-valued cells (sequences, multi-dim targets) must be strings parseable by `ast.literal_eval`, e.g. `"[1.0, 2.5, 3.0]"`.
+- Missing targets / NaNs (incl. compositions absent from a task's frame) are **masked out** per task rather than dropped; placeholders fill `y_dict`.
 
 ## Coding Style & Naming Conventions
 - Follow Ruff formatting (`ruff format`) and lint checks (`ruff check`): 4-space indentation, 120-character lines, double quotes.

--- a/samples/configs/test_t_depends_on_mac_pro/fit_config.yaml
+++ b/samples/configs/test_t_depends_on_mac_pro/fit_config.yaml
@@ -176,10 +176,14 @@ model:
 data:
   class_path: foundation_model.data.CompoundDataModule
   init_args:
-    # formula_desc_source: qc_ac_te_mp_dos_composition_desc_trans_20250615.pd.parquet
-    # attributes_source: data/qc_ac_te_mp_dos_reformat_20250615.pd.parquet
-    formula_desc_source: /Users/liuchang/projects/foundation_model/data/qc_ac_te_mp_dos_composition_desc_trans_20250615.pd.parquet
-    attributes_source: /Users/liuchang/projects/foundation_model/data/qc_ac_te_mp_dos_reformat_20250615.pd.parquet
+    # Descriptors are looked up by composition from the descriptor parquet (indexed by 'id').
+    descriptor_fn:
+      class_path: foundation_model.data.composition_sources.PrecomputedDescriptorSource
+      init_args:
+        path: /Users/liuchang/projects/foundation_model/data/qc_ac_te_mp_dos_composition_desc_trans_20250615.pd.parquet
+    # All tasks share one targets file here; per-task data_files would override this.
+    default_data_files: /Users/liuchang/projects/foundation_model/data/qc_ac_te_mp_dos_reformat_20250615.pd.parquet
+    composition_column: id  # join key is the 'id' index, not the 'composition' formula column
     task_configs: ${model.init_args.task_configs}
     batch_size: 64
     num_workers: 0

--- a/samples/configs/test_t_depends_on_mac_pro/predict_config.yaml
+++ b/samples/configs/test_t_depends_on_mac_pro/predict_config.yaml
@@ -176,10 +176,14 @@ model:
 data:
   class_path: foundation_model.data.CompoundDataModule
   init_args:
-    # formula_desc_source: qc_ac_te_mp_dos_composition_desc_trans_20250615.pd.parquet
-    # attributes_source: data/qc_ac_te_mp_dos_reformat_20250615.pd.parquet
-    formula_desc_source: /Users/liuchang/projects/foundation_model/data/qc_ac_te_mp_dos_composition_desc_trans_20250615.pd.parquet
-    attributes_source: /Users/liuchang/projects/foundation_model/data/qc_ac_te_mp_dos_reformat_20250615.pd.parquet
+    # Descriptors are looked up by composition from the descriptor parquet (indexed by 'id').
+    descriptor_fn:
+      class_path: foundation_model.data.composition_sources.PrecomputedDescriptorSource
+      init_args:
+        path: /Users/liuchang/projects/foundation_model/data/qc_ac_te_mp_dos_composition_desc_trans_20250615.pd.parquet
+    # All tasks share one targets file here; per-task data_files would override this.
+    default_data_files: /Users/liuchang/projects/foundation_model/data/qc_ac_te_mp_dos_reformat_20250615.pd.parquet
+    composition_column: id  # join key is the 'id' index, not the 'composition' formula column
     task_configs: ${model.init_args.task_configs}
     batch_size: 256
     num_workers: 0

--- a/samples/configs/test_t_depends_on_mac_pro/test_config.yaml
+++ b/samples/configs/test_t_depends_on_mac_pro/test_config.yaml
@@ -176,10 +176,14 @@ model:
 data:
   class_path: foundation_model.data.CompoundDataModule
   init_args:
-    # formula_desc_source: qc_ac_te_mp_dos_composition_desc_trans_20250615.pd.parquet
-    # attributes_source: data/qc_ac_te_mp_dos_reformat_20250615.pd.parquet
-    formula_desc_source: /Users/liuchang/projects/foundation_model/data/qc_ac_te_mp_dos_composition_desc_trans_20250615.pd.parquet
-    attributes_source: /Users/liuchang/projects/foundation_model/data/qc_ac_te_mp_dos_reformat_20250615.pd.parquet
+    # Descriptors are looked up by composition from the descriptor parquet (indexed by 'id').
+    descriptor_fn:
+      class_path: foundation_model.data.composition_sources.PrecomputedDescriptorSource
+      init_args:
+        path: /Users/liuchang/projects/foundation_model/data/qc_ac_te_mp_dos_composition_desc_trans_20250615.pd.parquet
+    # All tasks share one targets file here; per-task data_files would override this.
+    default_data_files: /Users/liuchang/projects/foundation_model/data/qc_ac_te_mp_dos_reformat_20250615.pd.parquet
+    composition_column: id  # join key is the 'id' index, not the 'composition' formula column
     task_configs: ${model.init_args.task_configs}
     batch_size: 256
     num_workers: 0

--- a/samples/example_config.yaml
+++ b/samples/example_config.yaml
@@ -29,36 +29,40 @@ model:
       # You can merge task configurations from other YAML files:
       - ${file(src/foundation_model/configs/legacy_ac_qc_starry_tasks.yaml):tasks}
       - ${file(src/foundation_model/configs/legacy_mp_tasks.yaml):tasks}
-      # Or define tasks directly here:
+      # Or define tasks directly here. Each task owns its data file(s), joined to others by the
+      # composition column configured on the datamodule (data.init_args.composition_column):
       # - name: "custom_regression_task"
       #   type: REGRESSION
-      #   data_column: "name_of_column_for_regression_targets_in_attributes_file" # NEW
+      #   data_files: "path/to/custom_regression_task.parquet" # this task's own file(s)
+      #   data_column: "target_column_inside_that_file"
+      #   # split_column: "split"          # optional in-file train/val/test labels
+      #   # task_masking_ratio: 0.9        # optional: keep 90% of valid training samples
+      #   # predict_idx: "test"            # optional: subset to predict (literal or composition list)
       #   enabled: True
       #   loss_weight: 1.0 # Static scaling for this task's loss
-      #   dims: [256, 128, 1] # Example: [model_latent_dim, head_hidden_dim, output_dim]
-      #                      # The first element should match the model's encoder_config.latent_dim
+      #   dims: [256, 128, 1] # [model_latent_dim, head_hidden_dim, output_dim]
       #   norm: True
       #   residual: False
       #   optimizer: # Optional: task-specific optimizer settings
       #     lr: 0.001
       # - name: "custom_classification_task"
       #   type: CLASSIFICATION
-      #   data_column: "name_of_column_for_classification_targets_in_attributes_file" # NEW
+      #   data_files: "path/to/custom_classification_task.parquet"
+      #   data_column: "label_column_inside_that_file"
       #   enabled: True
       #   loss_weight: 1.0
-      #   dims: [256, 128] # Example: [model_latent_dim, head_hidden_dim]
+      #   dims: [256, 128] # [model_latent_dim, head_hidden_dim]
       #   num_classes: 3
       #   norm: True
-      # - name: "custom_sequence_task"
-      #   type: SEQUENCE
-      #   data_column: "name_of_column_for_sequence_data_in_attributes_file" # NEW
-      #   steps_column: "name_of_column_for_sequence_steps_in_attributes_file" # NEW (optional, for sequence steps/x-axis)
+      # - name: "custom_kernel_regression_task"
+      #   type: KernelRegression
+      #   data_files: "path/to/custom_kernel_task.parquet"
+      #   data_column: "sequence_target_column"
+      #   t_column: "sequence_x_axis_column" # energy / temperature / time values
       #   enabled: True
       #   loss_weight: 1.0
-      #   subtype: "rnn" # Or "tcn", "fixed_vec"
-      #   d_in: 256 # Should match model_latent_dim
-      #   hidden: 128
-      #   # seq_len: 100 # Required for fixed_vec if not inferable
+      #   x_dim: [256, 128, 64] # x_dim[0] should match model_latent_dim
+      #   t_dim: [256, 128, 64]
 
     # --- Optimizer for Shared Blocks (Encoder/Deposit) ---
     shared_block_optimizer:
@@ -73,22 +77,28 @@ model:
 data:
   class_path: foundation_model.data.datamodule.CompoundDataModule
   init_args:
-    # --- Paths to your precomputed data files ---
-    formula_desc_source: "path/to/your/precomputed_formula_descriptors.pkl" # Or .csv
-    attributes_source: "path/to/your/precomputed_attributes.pkl" # Or .csv
+    # --- Descriptors are computed on demand from the union of task compositions ---
+    # PrecomputedDescriptorSource reads a composition-indexed descriptor file and looks up rows.
+    # Replace with your own callable (class_path) to compute descriptors from compositions instead.
+    descriptor_fn:
+      class_path: foundation_model.data.composition_sources.PrecomputedDescriptorSource
+      init_args:
+        path: "path/to/your/precomputed_descriptors.parquet" # .csv / .parquet / .pd.xz / .pkl
+        composition_column: null # set if composition is a column; null uses the file's index
 
-    # --- Task configurations will be linked from model.init_args.task_configs by default ---
-    # task_configs: "${model.init_args.task_configs}" # This linking is usually automatic
+    # Name of the composition key shared across all task files (a column name or index name).
+    composition_column: "composition"
+
+    # --- Task configurations are linked from model.init_args.task_configs (automatic) ---
+    # Each task names its OWN data via the per-task fields on its config:
+    #   data_files, data_column (+ t_column for kernel regression), split_column,
+    #   task_masking_ratio, predict_idx.  There is no monolithic attributes file anymore.
 
     # --- Data Handling and Splitting ---
-    # task_masking_ratios: # Optional: mask training samples (dict per task or single float for all tasks)
-    #   "Band gap": 0.9 # Example: use 90% of available "Band gap" data for training samples
-    # task_masking_ratios: 0.9 # Example: use same keep ratio for every enabled task
-    val_split: 0.1 # Proportion of non-test data for validation
-    test_split: 0.1 # Proportion of total data for testing
+    val_split: 0.1 # Random-fallback validation proportion for compositions lacking a split label
+    test_split: 0.1 # Random-fallback test proportion
     random_seed: 42
-    # test_all: False # If True, all data is used for the test set
-    # predict_idx: null # Path to a file or list of indices for prediction
+    # test_all: False # If True, all compositions are assigned to the test set
 
     # --- Dataloader Settings ---
     batch_size: 64

--- a/src/foundation_model/data/composition_sources.py
+++ b/src/foundation_model/data/composition_sources.py
@@ -117,12 +117,16 @@ def load_task_frame(
     frames: list[pd.DataFrame] = []
     for path in data_files:
         df = read_data_file(path)
-        if composition_column not in df.columns:
+        if composition_column in df.columns:
+            df = df.set_index(composition_column)
+        elif df.index.name == composition_column:
+            pass  # already indexed by the composition column
+        else:
             raise ValueError(
                 f"Task '{label}': composition column '{composition_column}' not found in '{path}' "
-                f"(available columns: {list(df.columns)})."
+                f"as a column or index name (available columns: {list(df.columns)}, "
+                f"index name: {df.index.name!r})."
             )
-        df = df.set_index(composition_column)
         frames.append(df)
 
     combined = pd.concat(frames, axis=0) if len(frames) > 1 else frames[0]
@@ -167,6 +171,44 @@ def build_composition_universe(
         for comp in extra_compositions:
             universe.setdefault(str(comp), None)
     return list(universe)
+
+
+class PrecomputedDescriptorSource:
+    """A ``descriptor_fn`` backed by a precomputed, composition-indexed descriptor file.
+
+    This is a YAML/CLI-friendly callable (it can be instantiated via ``class_path`` /
+    ``init_args``) for the common case where descriptors are already computed and stored. The
+    file is loaded once on first call and rows are looked up by composition; compositions absent
+    from the file are simply omitted from the result (and reported as dropped by the DataModule).
+
+    Parameters
+    ----------
+    path : str
+        Path to a composition-indexed descriptor file (see :func:`read_data_file` for formats).
+    composition_column : str | None, optional
+        If given and present as a column, it is set as the index; otherwise the file's existing
+        index is treated as the composition key.
+    """
+
+    def __init__(self, path: str, composition_column: str | None = None):
+        self.path = path
+        self.composition_column = composition_column
+        self._frame: pd.DataFrame | None = None
+
+    def _load(self) -> pd.DataFrame:
+        if self._frame is None:
+            frame = read_data_file(self.path)
+            if self.composition_column is not None and self.composition_column in frame.columns:
+                frame = frame.set_index(self.composition_column)
+            frame = frame.copy()
+            frame.index = frame.index.astype(str)
+            self._frame = frame
+        return self._frame
+
+    def __call__(self, compositions: Sequence[str]) -> pd.DataFrame:
+        frame = self._load()
+        present = [str(c) for c in compositions if str(c) in frame.index]
+        return frame.loc[present]
 
 
 class DescriptorCache:

--- a/src/foundation_model/data/composition_sources_test.py
+++ b/src/foundation_model/data/composition_sources_test.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 from foundation_model.data.composition_sources import (
     DescriptorCache,
+    PrecomputedDescriptorSource,
     build_composition_universe,
     load_task_frame,
     read_data_file,
@@ -101,6 +102,16 @@ def test_load_task_frame_missing_composition_column_raises(tmp_path):
     df.to_csv(path, index=False)
     with pytest.raises(ValueError, match="composition column 'composition' not found"):
         load_task_frame([str(path)], "composition", task_name="t")
+
+
+def test_load_task_frame_uses_index_when_named_like_composition(tmp_path):
+    """A file already indexed by the composition column (e.g. parquet) is accepted."""
+    df = pd.DataFrame({"y": [1.0, 2.0]}, index=pd.Index(["A", "B"], name="id"))
+    path = tmp_path / "t.parquet"
+    df.to_parquet(path)
+    frame = load_task_frame([str(path)], "id", task_name="t")
+    assert list(frame.index) == ["A", "B"]
+    assert list(frame["y"]) == [1.0, 2.0]
 
 
 def test_load_task_frame_empty_files_raises():
@@ -198,6 +209,32 @@ def test_descriptor_cache_rejects_non_dataframe():
     cache = DescriptorCache(lambda comps: [1, 2, 3])  # type: ignore[arg-type,return-value]
     with pytest.raises(TypeError, match="must return a pandas DataFrame"):
         cache.compute(["a"])
+
+
+# --- PrecomputedDescriptorSource --------------------------------------------
+
+
+@pytest.mark.parametrize("comp_col", [None, "id"])
+def test_precomputed_descriptor_source_indexed_file(tmp_path, comp_col):
+    """Looks up descriptors from a composition-indexed file; missing comps omitted."""
+    df = pd.DataFrame({"d0": [1.0, 2.0, 3.0]}, index=pd.Index(["A", "B", "C"], name="id"))
+    path = tmp_path / "desc.parquet"
+    df.to_parquet(path)
+    source = PrecomputedDescriptorSource(str(path), composition_column=comp_col)
+    out = source(["C", "A", "missing"])
+    assert list(out.index) == ["C", "A"]
+    assert out.loc["C", "d0"] == 3.0
+
+
+def test_precomputed_descriptor_source_column_file(tmp_path):
+    """Looks up descriptors from a file where composition is a column."""
+    df = pd.DataFrame({"id": ["A", "B"], "d0": [1.0, 2.0]})
+    path = tmp_path / "desc.csv"
+    df.to_csv(path, index=False)
+    source = PrecomputedDescriptorSource(str(path), composition_column="id")
+    out = source(["A"])
+    assert list(out.index) == ["A"]
+    assert out.loc["A", "d0"] == 1.0
 
 
 # --- resolve_splits ---------------------------------------------------------

--- a/src/foundation_model/data/datamodule.py
+++ b/src/foundation_model/data/datamodule.py
@@ -200,6 +200,13 @@ class CompoundDataModule(L.LightningDataModule):
             raise ValueError("descriptor_fn must be provided.")
         if not 0.0 <= swap_train_val_split <= 1.0:
             raise ValueError("swap_train_val_split must be between 0.0 and 1.0 inclusive.")
+        for split_name, split_value in (("val_split", val_split), ("test_split", test_split)):
+            if not 0.0 <= split_value <= 1.0:
+                raise ValueError(f"{split_name} must be between 0.0 and 1.0 inclusive, got {split_value}.")
+        if val_split + test_split > 1.0:
+            raise ValueError(
+                f"val_split + test_split must not exceed 1.0 (got {val_split} + {test_split} = {val_split + test_split})."
+            )
 
         self.task_configs = list(task_configs)
         self.descriptor_fn = descriptor_fn
@@ -265,12 +272,19 @@ class CompoundDataModule(L.LightningDataModule):
     def _composition_column_for(self, cfg: TaskConfig) -> str:
         return cfg.composition_column or self.composition_column
 
-    def _normalize_frame(self, frame: pd.DataFrame, composition_column: str) -> pd.DataFrame:
-        """Return a copy indexed by string composition keys."""
+    def _normalize_frame(self, frame: pd.DataFrame, composition_column: str, *, task_name: str = "") -> pd.DataFrame:
+        """Return a copy indexed by string composition keys, deduped keep-first."""
         frame = frame.copy()
         if composition_column in frame.columns:
             frame = frame.set_index(composition_column)
         frame.index = frame.index.astype(str)
+        duplicated = frame.index.duplicated(keep="first")
+        if duplicated.any():
+            logger.warning(
+                f"Task '{task_name or '<task>'}': in-memory frame has {int(duplicated.sum())} duplicate "
+                "composition(s); keeping the first occurrence of each."
+            )
+            frame = frame[~duplicated]
         return frame
 
     def _resolved_task_masking_ratios(self) -> Dict[str, float]:
@@ -296,7 +310,7 @@ class CompoundDataModule(L.LightningDataModule):
         for cfg in self._supervised_tasks():
             comp_col = self._composition_column_for(cfg)
             if cfg.name in self._input_task_frames:
-                frame = self._normalize_frame(self._input_task_frames[cfg.name], comp_col)
+                frame = self._normalize_frame(self._input_task_frames[cfg.name], comp_col, task_name=cfg.name)
                 logger.info(f"Task '{cfg.name}': using provided in-memory frame ({len(frame)} rows).")
             elif cfg.data_files:
                 frame = load_task_frame(cfg.data_files, comp_col, task_name=cfg.name)

--- a/src/foundation_model/data/datamodule.py
+++ b/src/foundation_model/data/datamodule.py
@@ -151,6 +151,10 @@ class CompoundDataModule(L.LightningDataModule):
         In-memory per-task frames (indexed by composition or carrying the composition column),
         used instead of ``cfg.data_files`` for the named tasks. Convenient for programmatic /
         test usage.
+    default_data_files : str | Sequence[str] | None, optional
+        Shared fallback data file(s) used for any enabled task that has neither an in-memory
+        frame nor its own ``cfg.data_files``. Supports the legacy "one file holds all targets"
+        case from a YAML/CLI config without repeating the path on every task.
     composition_column : str, optional
         Global default composition column name; overridable per task via
         ``cfg.composition_column``. Defaults to ``"composition"``.
@@ -177,6 +181,7 @@ class CompoundDataModule(L.LightningDataModule):
         descriptor_fn: DescriptorFn,
         *,
         task_frames: Mapping[str, pd.DataFrame] | None = None,
+        default_data_files: str | Sequence[str] | None = None,
         composition_column: str = "composition",
         random_seed: int | None = 42,
         val_split: float = 0.1,
@@ -199,6 +204,12 @@ class CompoundDataModule(L.LightningDataModule):
         self.task_configs = list(task_configs)
         self.descriptor_fn = descriptor_fn
         self._input_task_frames = dict(task_frames) if task_frames is not None else {}
+        if default_data_files is None:
+            self.default_data_files: tuple[str, ...] = ()
+        elif isinstance(default_data_files, str):
+            self.default_data_files = (default_data_files,)
+        else:
+            self.default_data_files = tuple(str(p) for p in default_data_files)
         self.composition_column = composition_column
         self.random_seed = random_seed
         self.val_split = val_split
@@ -290,10 +301,16 @@ class CompoundDataModule(L.LightningDataModule):
             elif cfg.data_files:
                 frame = load_task_frame(cfg.data_files, comp_col, task_name=cfg.name)
                 logger.info(f"Task '{cfg.name}': loaded {len(frame)} rows from {len(cfg.data_files)} file(s).")
+            elif self.default_data_files:
+                frame = load_task_frame(self.default_data_files, comp_col, task_name=cfg.name)
+                logger.info(
+                    f"Task '{cfg.name}': loaded {len(frame)} rows from shared default_data_files "
+                    f"({len(self.default_data_files)} file(s))."
+                )
             else:
                 logger.warning(
-                    f"Task '{cfg.name}': no in-memory frame and no data_files; it will only contribute "
-                    "placeholder (masked) targets. Provide data_files or task_frames for supervised training."
+                    f"Task '{cfg.name}': no in-memory frame, data_files, or default_data_files; it will only "
+                    "contribute placeholder (masked) targets. Provide a data source for supervised training."
                 )
                 continue
             self._task_frames[cfg.name] = frame

--- a/src/foundation_model/data/datamodule.py
+++ b/src/foundation_model/data/datamodule.py
@@ -1,16 +1,13 @@
 # Copyright 2025 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, List, Sequence
+from typing import Dict, List, Mapping, Sequence
 
-import joblib
 import lightning as L
 import numpy as np
 import pandas as pd
 import torch
-from jsonargparse.typing import Path_fr
 from loguru import logger
-from sklearn.model_selection import train_test_split  # For data splitting
 from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 
@@ -22,7 +19,16 @@ from foundation_model.models.model_config import (
     TaskType,
 )
 
+from .composition_sources import (
+    DescriptorCache,
+    DescriptorFn,
+    build_composition_universe,
+    load_task_frame,
+    resolve_splits,
+)
 from .dataset import CompoundDataset
+
+TaskConfig = RegressionTaskConfig | ClassificationTaskConfig | KernelRegressionTaskConfig | AutoEncoderTaskConfig
 
 
 class CollateFnWithTaskInfo:
@@ -105,216 +111,102 @@ def create_collate_fn_with_task_info(task_configs):
 
 class CompoundDataModule(L.LightningDataModule):
     """
-    A PyTorch Lightning DataModule for managing compound data with multiple task configurations.
+    PyTorch Lightning DataModule for composition-keyed, per-task data sources.
 
-    This DataModule handles the loading, alignment, and splitting of chemical compound data
-    (formula descriptors and attributes) for training machine learning models with multiple
-    tasks. It supports regression, classification, and kernel regression tasks, with features
-    including data masking, train/validation swapping, and flexible prediction dataset selection.
+    Each task owns its own data file(s) (or an in-memory frame), joined to the others by a
+    **composition** column. Descriptors are computed on demand from the union of compositions
+    via a user-supplied ``descriptor_fn`` (results cached per unique composition). Adding a
+    new property task means adding one more file + one more task config — no monolithic
+    attributes file to rebuild.
 
-    Key Features
-    ------------
-    - Multi-task learning support (regression, classification, kernel regression)
-    - Flexible data loading from multiple formats (DataFrame, pickle, CSV, parquet)
-    - Automatic data alignment between formula descriptors and attributes
-    - Configurable train/validation/test splitting with multiple strategies
-    - Optional random masking for data augmentation
-    - Train/validation bootstrap-style sample swapping
-    - Distributed training support with DistributedSampler
-    - Extended predict dataset selection (by name, combination, or custom indices)
+    Data assembly (performed once, lazily, in :meth:`setup`)
+    -------------------------------------------------------
+    1. Load each enabled non-AUTOENCODER task's data (in-memory ``task_frames`` override, else
+       ``cfg.data_files``), indexed by composition.
+    2. Build the composition universe = union of all task compositions plus any compositions
+       named by explicit per-task ``predict_idx`` sequences (so predict-only compositions get
+       descriptors too).
+    3. Compute descriptors via ``descriptor_fn`` (cached); drop compositions with no valid
+       descriptor. The survivors form the master composition index.
+    4. Resolve a single composition-level train/val/test split by overlaying each task's
+       ``split`` column (precedence ``test > val > train``) with a random fallback.
+    5. Build per-stage :class:`CompoundDataset` instances; each reindexes the per-task frames
+       to its split's compositions.
 
-    Data Alignment
-    --------------
-    The `formula_desc_source` index serves as the master reference for all data alignment.
-    If `attributes_source` is provided, it will be reindexed to match the formula descriptors.
-    Samples with all NaN values after alignment are automatically removed.
+    Prediction
+    ----------
+    Each task's ``predict_idx`` selects a composition subset (literal ``train``/``val``/``test``/
+    ``all``, an explicit sequence, or ``None`` → the test split, falling back to all). The
+    predict set is the union of these subsets, exposed in order as
+    :attr:`predict_compositions` so a prediction writer can attach composition keys.
 
-    Splitting Strategies
-    --------------------
-    The module supports three splitting strategies (in priority order):
-    1. **test_all=True**: All data assigned to test set (train/val empty)
-    2. **'split' column**: Uses pre-defined splits from attributes_source
-    3. **Random splitting**: Uses val_split and test_split ratios
-
-    Reproducibility
-    ---------------
-    All random operations (splitting, masking, swapping) are controlled by deterministic
-    seeds derived from the base `random_seed` parameter, ensuring full reproducibility.
-
-    Distributed Training
-    --------------------
-    Automatically detects distributed training environments and uses DistributedSampler
-    to ensure proper data partitioning across multiple GPUs.
-
-    Examples
-    --------
-    Basic usage with random splitting:
-
-    >>> from foundation_model.data.datamodule import CompoundDataModule
-    >>> from foundation_model.data.task_config import RegressionTaskConfig
-    >>>
-    >>> task_configs = [
-    ...     RegressionTaskConfig(name="bandgap", data_column="bandgap", enabled=True)
-    ... ]
-    >>>
-    >>> dm = CompoundDataModule(
-    ...     formula_desc_source="descriptors.pkl",
-    ...     attributes_source="attributes.csv",
-    ...     task_configs=task_configs,
-    ...     val_split=0.1,
-    ...     test_split=0.2,
-    ...     batch_size=32
-    ... )
-    >>>
-    >>> dm.setup(stage="fit")
-    >>> train_loader = dm.train_dataloader()
-
-    Using pre-defined splits:
-
-    >>> # attributes.csv should contain a 'split' column with values: 'train', 'val', 'test'
-    >>> dm = CompoundDataModule(
-    ...     formula_desc_source="descriptors.pkl",
-    ...     attributes_source="attributes.csv",  # Must have 'split' column
-    ...     task_configs=task_configs,
-    ...     batch_size=32
-    ... )
-
-    Prediction with specific datasets:
-
-    >>> # Predict on test set
-    >>> dm = CompoundDataModule(
-    ...     formula_desc_source="descriptors.pkl",
-    ...     task_configs=task_configs,
-    ...     predict_idx="test"
-    ... )
-    >>>
-    >>> # Predict on combined train and validation sets
-    >>> dm = CompoundDataModule(
-    ...     formula_desc_source="descriptors.pkl",
-    ...     task_configs=task_configs,
-    ...     predict_idx=["train", "val"]
-    ... )
-    >>>
-    >>> # Predict on custom indices
-    >>> custom_indices = pd.Index(["compound_1", "compound_2", "compound_3"])
-    >>> dm = CompoundDataModule(
-    ...     formula_desc_source="descriptors.pkl",
-    ...     task_configs=task_configs,
-    ...     predict_idx=custom_indices
-    ... )
-
-    With data masking and swapping:
-
-    >>> dm = CompoundDataModule(
-    ...     formula_desc_source="descriptors.pkl",
-    ...     attributes_source="attributes.csv",
-    ...     task_configs=task_configs,
-    ...     task_masking_ratios=0.8,  # Keep 80% of data per task
-    ...     swap_train_val_split=0.1,  # Swap 10% of samples between train/val
-    ...     random_seed=42
-    ... )
-
-    Notes
-    -----
-    - When `attributes_source` is None, only prediction mode is fully supported for
-        non-sequence tasks, as supervised training requires target attributes.
-    - Kernel regression tasks requiring a t_column will raise an error if
-        `attributes_source` is None.
-    - Empty datasets will result in None dataloaders to prevent training errors.
+    Parameters
+    ----------
+    task_configs : Sequence[TaskConfig]
+        Task configurations. Per-task ``data_files`` / ``composition_column`` / ``split_column``
+        / ``task_masking_ratio`` / ``predict_idx`` drive data loading.
+    descriptor_fn : Callable[[list[str]], pd.DataFrame]
+        Maps composition keys to a composition-indexed descriptor frame.
+    task_frames : Mapping[str, pd.DataFrame] | None, optional
+        In-memory per-task frames (indexed by composition or carrying the composition column),
+        used instead of ``cfg.data_files`` for the named tasks. Convenient for programmatic /
+        test usage.
+    composition_column : str, optional
+        Global default composition column name; overridable per task via
+        ``cfg.composition_column``. Defaults to ``"composition"``.
+    random_seed : int | None, optional
+        Base seed for all stochastic operations (split, masking, swap). Defaults to 42.
+    val_split, test_split : float, optional
+        Random-fallback proportions for compositions lacking a ``split`` label. Defaults 0.1.
+    test_all : bool, optional
+        If True, every composition is assigned to the test set. Defaults to False.
+    swap_train_val_split : float, optional
+        Fraction of samples to exchange between train and validation after splitting. Defaults 0.
+    batch_size, num_workers : int, optional
+        DataLoader settings.
 
     See Also
     --------
-    foundation_model.data.dataset.CompoundDataset : The underlying dataset class
-    foundation_model.data.task_config : Task configuration classes
+    foundation_model.data.dataset.CompoundDataset
+    foundation_model.data.composition_sources
     """
 
     def __init__(
         self,
-        formula_desc_source: pd.DataFrame | Path_fr,  # type: ignore
-        task_configs: Sequence[
-            RegressionTaskConfig | ClassificationTaskConfig | KernelRegressionTaskConfig | AutoEncoderTaskConfig
-        ],
-        attributes_source: pd.DataFrame | Path_fr | None = None,  # type: ignore
-        task_masking_ratios: float | Dict[str, float] | None = None,
+        task_configs: Sequence[TaskConfig],
+        descriptor_fn: DescriptorFn,
+        *,
+        task_frames: Mapping[str, pd.DataFrame] | None = None,
+        composition_column: str = "composition",
         random_seed: int | None = 42,
         val_split: float = 0.1,
         test_split: float = 0.1,
         test_all: bool = False,
         swap_train_val_split: float = 0.0,
-        predict_idx: pd.Index | np.ndarray | List | str | List[str] | None = None,  # Extended functionality
         batch_size: int = 32,
         num_workers: int = 0,
     ):
-        """
-        Initialize the data module.
-        The `formula_desc_source` and its index are treated as the primary reference for data alignment.
-
-        Parameters
-        ----------
-        formula_desc_source : pd.DataFrame | np.ndarray | str
-            Formula descriptors (DataFrame, NumPy array, or path to pickle/CSV/parquet). Its index is the master reference.
-        task_configs : List
-            List of task configurations.
-        attributes_source : pd.DataFrame | str | None, optional
-            Source for task target attributes, sequence data, temperature data, and 'split' column.
-            Can be a DataFrame, NumPy array, or a path to a pickle/CSV/parquet file.
-            Defaults to None. If None, the DataModule can only be used for prediction with non-sequence tasks,
-            as sequence tasks typically require input columns (e.g., for series or temperatures) from this source.
-            If provided, it will be aligned with `formula_desc_source`.
-        task_masking_ratios : float | Dict[str, float] | None, optional
-            Random masking ratios for training data.
-            Accepts either a mapping of task name to keep-ratio, or a single float applied to every enabled task.
-            Defaults to None (no additional masking).
-        random_seed : int | None, optional
-            Base seed controlling all stochastic operations (test split, validation split, task masking, train/val swap).
-            Derived seeds are generated deterministically per operation to preserve reproducibility. Defaults to 42.
-        val_split : float, optional
-            Proportion of non-test data (derived from `attributes_source` if available, or `formula_desc_source` otherwise)
-            to use for validation. Defaults to 0.1. Only applicable if `attributes_source` is provided and no 'split' column is used.
-        test_split : float, optional
-            Proportion of data (derived from `attributes_source` if available, or `formula_desc_source` otherwise)
-            to use for testing. Defaults to 0.1. Only applicable if `attributes_source` is provided and no 'split' column is used.
-        test_all : bool, optional
-            If True, all data (after alignment) is used for the test set. `train_idx` and `val_idx` will be empty.
-            This overrides `test_split` and 'split' column logic if `attributes_source` is provided. Defaults to False.
-        swap_train_val_split : float, optional
-            Fraction of samples to exchange between the train and validation splits after they are formed.
-            Supports values in [0, 1]. Set to >0 to enable bootstrap-style resampling of train/val while keeping
-            overall split sizes unchanged. Defaults to 0.0.
-        predict_idx : pd.Index | np.ndarray | List | str | List[str] | None, optional
-            Specific indices to use for the prediction set. Can be:
-            - pd.Index, np.ndarray, List: Specific indices that must be present in `formula_desc_source`
-            - str: One of "test", "val", "train", "all" to use the corresponding dataset
-            - List[str]: Combination of datasets, e.g., ["train", "val"] to combine train and validation sets
-            If provided, `setup(stage='predict')` will use these indices directly.
-            If None (default), `predict_idx` will be derived during `setup(stage='predict')` from `test_idx` (if available and not empty)
-            or otherwise from the full set of available indices from `formula_desc_source`.
-            Note: If a specified dataset (e.g., "test") doesn't exist or is empty, an error will be raised.
-        batch_size : int, optional
-            Batch size for dataloaders. Defaults to 32.
-        num_workers : int, optional
-            Number of workers for dataloaders. Defaults to 0.
-        """
         super().__init__()
         logger.info("Initializing CompoundDataModule...")
 
-        # Explicitly assign parameters to self for clarity and linter compatibility
-        self.task_configs = task_configs
-        self.task_masking_ratios = task_masking_ratios
+        if not task_configs:
+            raise ValueError("task_configs cannot be empty.")
+        if descriptor_fn is None:
+            raise ValueError("descriptor_fn must be provided.")
+        if not 0.0 <= swap_train_val_split <= 1.0:
+            raise ValueError("swap_train_val_split must be between 0.0 and 1.0 inclusive.")
+
+        self.task_configs = list(task_configs)
+        self.descriptor_fn = descriptor_fn
+        self._input_task_frames = dict(task_frames) if task_frames is not None else {}
+        self.composition_column = composition_column
         self.random_seed = random_seed
         self.val_split = val_split
         self.test_split = test_split
         self.test_all = test_all
-        if not 0.0 <= swap_train_val_split <= 1.0:
-            raise ValueError("swap_train_val_split must be between 0.0 and 1.0 inclusive.")
         self.swap_train_val_split = swap_train_val_split
-        # Store user-provided predict_idx without converting to pd.Index yet
-        # We'll handle string/list conversion in setup() method
-        self.init_predict_idx = predict_idx
         self.batch_size = batch_size
         self.num_workers = num_workers
-        self.structure_df: pd.DataFrame | None = None
-        self.actual_with_structure = False
 
         self._seed_offsets: Dict[str, int] = {
             "train_split": 0,
@@ -323,714 +215,301 @@ class CompoundDataModule(L.LightningDataModule):
             "swap": 30_000,
         }
 
+        # Populated by _prepare_sources()
+        self._sources_ready = False
+        self._descriptor_cache = DescriptorCache(descriptor_fn)
+        self.descriptors: pd.DataFrame | None = None
+        self._task_frames: Dict[str, pd.DataFrame] = {}
+        self.master_index: List[str] = []
+        self.split_series: pd.Series | None = None
+        self.train_idx: List[str] = []
+        self.val_idx: List[str] = []
+        self.test_idx: List[str] = []
+        self.predict_compositions: List[str] = []
+        self.train_dataset: CompoundDataset | None = None
+        self.val_dataset: CompoundDataset | None = None
+        self.test_dataset: CompoundDataset | None = None
+        self.predict_dataset: CompoundDataset | None = None
+        self._train_sampler: DistributedSampler | None = None
+
         self.save_hyperparameters(
-            ignore=[
-                "formula_desc_source",
-                "attributes_source",
-                "predict_idx",
-                "task_configs",
-            ]  # ADDED "task_configs"
+            ignore=["task_configs", "descriptor_fn", "task_frames"],
         )
-
-        # --- Load Data ---
-        logger.info("--- Loading Data ---")
-        source_to_load = str(formula_desc_source) if isinstance(formula_desc_source, Path_fr) else formula_desc_source  # type: ignore
-        self.formula_df = self._load_data(source_to_load, "formula_desc")
-        if self.formula_df is None or self.formula_df.empty:
-            raise ValueError("formula_desc_source must be successfully loaded and cannot be empty.")
-        logger.info(f"Initial loaded formula_df length: {len(self.formula_df)}")
-
-        # Formula_df is the primary reference. Clean it first.
-        self.formula_df.dropna(how="all", inplace=True)
-        if self.formula_df.empty:  # Check again after dropna
-            raise ValueError("formula_df became empty after removing rows with all NaNs.")
-        master_index = self.formula_df.index
-        logger.info(
-            f"Formula_df length after initial dropna: {len(self.formula_df)}. This index is now the master reference."
-        )
-
-        # Handle optional attributes_source
-        self.attributes_df = None
-        if attributes_source is not None:
-            source_to_load_attrs = (
-                str(attributes_source) if isinstance(attributes_source, Path_fr) else attributes_source  # type: ignore
-            )
-            self.attributes_df = self._load_data(source_to_load_attrs, "attributes")
-            if self.attributes_df is None or self.attributes_df.empty:
-                # If source was provided but failed to load or was empty, it's an error.
-                raise ValueError("attributes_source was provided but could not be loaded or is empty.")
-            logger.info(f"Initial loaded attributes_df length: {len(self.attributes_df)}")
-
-            # --- Align DataFrames ---
-            logger.info(f"--- Aligning DataFrames by formula_df index (master_index length: {len(master_index)}) ---")
-
-            # Align attributes_df to master_index (from formula_df)
-            original_attributes_len = len(self.attributes_df)
-            self.attributes_df = self.attributes_df.reindex(master_index)
-            if len(self.attributes_df) != original_attributes_len:
-                logger.warning(
-                    f"Attributes_df reindexed. Original length: {original_attributes_len}, new length: {len(self.attributes_df)}."
-                )
-            if self.attributes_df.isnull().values.any():
-                logger.warning(
-                    "attributes_df contains NaN values after reindexing. This is expected if some properties are missing for certain samples."
-                )
-            self.attributes_df.dropna(how="all", inplace=True)
-            if self.attributes_df.empty:
-                raise ValueError(
-                    "attributes_df became empty after reindexing and removing rows with all NaNs. Check index compatibility with formula_df."
-                )
-
-            # Update master_index based on intersection after attributes_df processing
-            common_index_after_attrs = master_index.intersection(self.attributes_df.index)
-            if common_index_after_attrs.empty:
-                raise ValueError(
-                    "No common_index found between formula_df and attributes_df after processing. Data is not alignable."
-                )
-            if len(common_index_after_attrs) < len(master_index):
-                logger.warning(
-                    f"Master index (from formula_df) reduced from {len(master_index)} to {len(common_index_after_attrs)} after aligning with attributes_df. "
-                    "Some formula_df entries might not have corresponding attributes_df entries or vice-versa after NaN removal."
-                )
-            master_index = common_index_after_attrs
-
-            self.formula_df = self.formula_df.loc[master_index]
-            self.attributes_df = self.attributes_df.loc[master_index]  # attributes_df is now aligned
-            logger.info(f"Length after aligning formula_df and attributes_df: {len(master_index)}")
-        else:  # attributes_source is None
-            logger.info(
-                "attributes_source is None. Proceeding without attributes_df. This is only supported if no sequence tasks require it."
-            )
-            # Validate that no task requires attributes_df if it's None,
-            # especially if a KernelRegression task specifies a t_column.
-            for cfg in self.task_configs:
-                if cfg.enabled and cfg.type == TaskType.KERNEL_REGRESSION:
-                    # Type check and cast to access KernelRegression-specific attributes
-                    if isinstance(cfg, KernelRegressionTaskConfig) and hasattr(cfg, "t_column") and cfg.t_column:
-                        logger.error(
-                            f"Task '{cfg.name}' is a KernelRegression task that specifies a 't_column' ('{cfg.t_column}'), "
-                            f"but attributes_source is None. attributes_source is required to load this t-parameter data."
-                        )
-                        raise ValueError(
-                            f"attributes_source cannot be None when KernelRegression task '{cfg.name}' requires a t_column ('{cfg.t_column}')."
-                        )
-            # If we reach here, attributes_source is None, and no enabled KernelRegressionTaskConfig requires a t_column.
-            # Other tasks (or KernelRegression tasks without a t_column) will have their data_column handled by CompoundDataset
-            # (likely resulting in placeholders if data_column was specified).
-            # self.attributes_df remains None. self.formula_df uses the original master_index.
-            logger.info(f"formula_df (master) length: {len(master_index)}")
-
-        # Initialize sampler reference for distributed training
-        self._train_sampler = None
 
         logger.info(f"DataModule initialized with {len(self.task_configs)} task configurations.")
 
-    def on_train_epoch_start(self):
-        """
-        Called at the beginning of each training epoch.
-        Updates the DistributedSampler's epoch to ensure different shuffling patterns.
-        """
-        if hasattr(self, "_train_sampler") and self._train_sampler is not None:
-            if hasattr(self._train_sampler, "set_epoch"):
-                # Access the trainer's current epoch
-                # Lightning automatically injects self.trainer when this DataModule is used
-                if hasattr(self, "trainer") and self.trainer is not None:
-                    epoch = self.trainer.current_epoch
-                    self._train_sampler.set_epoch(epoch)
-                    logger.debug(f"Set DistributedSampler epoch to {epoch}")
+    # ------------------------------------------------------------------ helpers
 
     def _seed_for(self, purpose: str) -> int | None:
         """Return a deterministic seed for the given purpose derived from the base random_seed."""
         if self.random_seed is None:
             return None
         offset = self._seed_offsets.get(purpose, 0)
-        # Modulo 2**32 to keep value within 32-bit integer range expected by numpy/sklearn
         return (self.random_seed + offset) % (2**32)
 
-    def _resolved_task_masking_ratios(self) -> Dict[str, float] | None:
-        """
-        Normalize task_masking_ratios input to a dictionary keyed by task name.
+    def _supervised_tasks(self) -> List[TaskConfig]:
+        """Enabled tasks that load external data (everything except AUTOENCODER)."""
+        return [cfg for cfg in self.task_configs if cfg.enabled and cfg.type != TaskType.AUTOENCODER]
 
-        Returns
-        -------
-        Dict[str, float] | None
-            Mapping of task names to keep ratios, or None when masking is disabled.
-        """
-        ratios = self.task_masking_ratios
-        if ratios is None:
-            return None
-        if isinstance(ratios, dict):
-            return ratios
+    def _composition_column_for(self, cfg: TaskConfig) -> str:
+        return cfg.composition_column or self.composition_column
 
-        try:
-            ratio_value = float(ratios)
-        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive, should not happen with type hints
-            raise TypeError("task_masking_ratios must be a dict, float, or None.") from exc
+    def _normalize_frame(self, frame: pd.DataFrame, composition_column: str) -> pd.DataFrame:
+        """Return a copy indexed by string composition keys."""
+        frame = frame.copy()
+        if composition_column in frame.columns:
+            frame = frame.set_index(composition_column)
+        frame.index = frame.index.astype(str)
+        return frame
 
-        return {cfg.name: ratio_value for cfg in self.task_configs if getattr(cfg, "enabled", True)}
+    def _resolved_task_masking_ratios(self) -> Dict[str, float]:
+        """Per-task keep ratios sourced from each config's task_masking_ratio."""
+        ratios: Dict[str, float] = {}
+        for cfg in self.task_configs:
+            ratio = getattr(cfg, "task_masking_ratio", None)
+            if getattr(cfg, "enabled", True) and ratio is not None:
+                ratios[cfg.name] = float(ratio)
+        return ratios
 
-    def _resolve_predict_idx(self, full_idx: pd.Index) -> pd.Index:
-        """
-        Resolve predict_idx based on its type and validate dataset existence.
+    # ------------------------------------------------------------------ sources
 
-        # Added 2025/7/2: Extended predict_idx functionality to support string literals
-        # and list of strings for easier dataset selection (e.g., "test", ["train", "val"])
+    def _prepare_sources(self) -> None:
+        """Load task frames, compute descriptors, and resolve the global split (idempotent)."""
+        if self._sources_ready:
+            return
 
-        Parameters
-        ----------
-        full_idx : pd.Index
-            The full index of available data
+        logger.info("--- Preparing composition-keyed data sources ---")
 
-        Returns
-        -------
-        pd.Index
-            Resolved predict indices
-
-        Raises
-        ------
-        ValueError
-            If specified dataset doesn't exist or is empty
-        """
-        if self.init_predict_idx is None:
-            # Default behavior: use test_idx if available, otherwise full_idx
-            return self.test_idx if not self.test_idx.empty else full_idx
-
-        # Handle string literals
-        if isinstance(self.init_predict_idx, str):
-            dataset_name = self.init_predict_idx
-            if dataset_name == "all":
-                logger.info("predict_idx='all': Using all available data for prediction")
-                return full_idx
-            elif dataset_name == "test":
-                if self.test_idx.empty:
-                    logger.error(f"predict_idx='{dataset_name}' specified but test dataset is empty")
-                    raise ValueError(f"Test dataset is empty. Cannot use predict_idx='{dataset_name}'")
-                logger.info(
-                    f"predict_idx='{dataset_name}': Using test dataset for prediction ({len(self.test_idx)} samples)"
-                )
-                return self.test_idx
-            elif dataset_name == "val":
-                if self.val_idx.empty:
-                    logger.error(f"predict_idx='{dataset_name}' specified but validation dataset is empty")
-                    raise ValueError(f"Validation dataset is empty. Cannot use predict_idx='{dataset_name}'")
-                logger.info(
-                    f"predict_idx='{dataset_name}': Using validation dataset for prediction ({len(self.val_idx)} samples)"
-                )
-                return self.val_idx
-            elif dataset_name == "train":
-                if self.train_idx.empty:
-                    logger.error(f"predict_idx='{dataset_name}' specified but train dataset is empty")
-                    raise ValueError(f"Train dataset is empty. Cannot use predict_idx='{dataset_name}'")
-                logger.info(
-                    f"predict_idx='{dataset_name}': Using train dataset for prediction ({len(self.train_idx)} samples)"
-                )
-                return self.train_idx
+        # 1. Load each supervised task's frame (in-memory override or data_files).
+        self._task_frames = {}
+        for cfg in self._supervised_tasks():
+            comp_col = self._composition_column_for(cfg)
+            if cfg.name in self._input_task_frames:
+                frame = self._normalize_frame(self._input_task_frames[cfg.name], comp_col)
+                logger.info(f"Task '{cfg.name}': using provided in-memory frame ({len(frame)} rows).")
+            elif cfg.data_files:
+                frame = load_task_frame(cfg.data_files, comp_col, task_name=cfg.name)
+                logger.info(f"Task '{cfg.name}': loaded {len(frame)} rows from {len(cfg.data_files)} file(s).")
             else:
-                logger.error(
-                    f"Invalid predict_idx string: '{dataset_name}'. Must be one of 'test', 'val', 'train', 'all'"
-                )
-                raise ValueError(
-                    f"Invalid predict_idx string: '{dataset_name}'. Must be one of 'test', 'val', 'train', 'all'"
-                )
-
-        # Handle list of strings
-        elif isinstance(self.init_predict_idx, list) and all(isinstance(item, str) for item in self.init_predict_idx):
-            dataset_names = self.init_predict_idx
-            combined_idx = pd.Index([])
-
-            for dataset_name in dataset_names:
-                if dataset_name == "test":
-                    if self.test_idx.empty:
-                        logger.error(f"predict_idx contains '{dataset_name}' but test dataset is empty")
-                        raise ValueError(f"Test dataset is empty. Cannot use '{dataset_name}' in predict_idx")
-                    combined_idx = combined_idx.union(self.test_idx)
-                elif dataset_name == "val":
-                    if self.val_idx.empty:
-                        logger.error(f"predict_idx contains '{dataset_name}' but validation dataset is empty")
-                        raise ValueError(f"Validation dataset is empty. Cannot use '{dataset_name}' in predict_idx")
-                    combined_idx = combined_idx.union(self.val_idx)
-                elif dataset_name == "train":
-                    if self.train_idx.empty:
-                        logger.error(f"predict_idx contains '{dataset_name}' but train dataset is empty")
-                        raise ValueError(f"Train dataset is empty. Cannot use '{dataset_name}' in predict_idx")
-                    combined_idx = combined_idx.union(self.train_idx)
-                else:
-                    logger.error(
-                        f"Invalid dataset name in predict_idx list: '{dataset_name}'. Must be one of 'test', 'val', 'train'"
-                    )
-                    raise ValueError(
-                        f"Invalid dataset name in predict_idx list: '{dataset_name}'. Must be one of 'test', 'val', 'train'"
-                    )
-
-            logger.info(f"predict_idx={dataset_names}: Combined datasets for prediction ({len(combined_idx)} samples)")
-            return combined_idx
-
-        # Handle traditional types (pd.Index, np.ndarray, List of indices)
-        else:
-            # Convert to pd.Index for validation
-            if isinstance(self.init_predict_idx, np.ndarray):
-                predict_indices = pd.Index(self.init_predict_idx)
-            elif isinstance(self.init_predict_idx, list):
-                predict_indices = pd.Index(self.init_predict_idx)
-            elif isinstance(self.init_predict_idx, pd.Index):
-                predict_indices = self.init_predict_idx
-            else:
-                logger.error(f"Unsupported predict_idx type: {type(self.init_predict_idx)}")
-                raise ValueError(f"Unsupported predict_idx type: {type(self.init_predict_idx)}")
-
-            # Validate indices against formula_df
-            valid_predict_indices = predict_indices.intersection(self.formula_df.index)
-            if len(valid_predict_indices) != len(predict_indices):
                 logger.warning(
-                    f"User-provided predict_idx contains indices not found in the loaded formula_df. "
-                    f"Original: {len(predict_indices)}, Valid: {len(valid_predict_indices)}. Using valid subset."
+                    f"Task '{cfg.name}': no in-memory frame and no data_files; it will only contribute "
+                    "placeholder (masked) targets. Provide data_files or task_frames for supervised training."
                 )
-            if valid_predict_indices.empty:
-                logger.warning(
-                    "User-provided predict_idx resulted in an empty set after validation. Returning empty index."
-                )
-                return pd.Index([])
+                continue
+            self._task_frames[cfg.name] = frame
 
-            logger.info(
-                f"predict_idx: Using user-provided indices for prediction ({len(valid_predict_indices)} samples)"
+        # 2. Composition universe = task compositions plus explicit predict_idx compositions.
+        extra: List[str] = []
+        for cfg in self._supervised_tasks():
+            pid = cfg.predict_idx
+            if isinstance(pid, (list, tuple)):
+                extra.extend(str(c) for c in pid)
+        universe = build_composition_universe(self._task_frames, extra_compositions=extra)
+        if not universe:
+            raise ValueError(
+                "No compositions found across task data sources. Provide data_files / task_frames "
+                "or explicit predict_idx composition sequences."
             )
-            return valid_predict_indices
+        logger.info(f"Composition universe size: {len(universe)}")
 
-    def _load_data(self, source: pd.DataFrame | str, name: str) -> pd.DataFrame | None:
-        """Helper to load data from various sources."""
-        logger.debug(f"Attempting to load '{name}' from source type: {type(source)}")
-        if source is None:
-            logger.warning(f"Source for '{name}' is None.")
-            return None
-        try:
-            df = None
-            if isinstance(source, str):
-                logger.info(f"Loading '{name}' data from path: {source}")
-                if source.endswith(".pkl"):
-                    df = joblib.load(source)
-                elif source.endswith((".pd", ".pd.z", ".pd.xz")):
-                    df = pd.read_pickle(source)
-                elif source.endswith(".pd.parquet"):
-                    df = pd.read_parquet(source)
-                elif source.endswith(".csv"):
-                    df = pd.read_csv(source, index_col=0)  # Assuming first column as index
-                else:
-                    logger.error(
-                        f"Unsupported file type for '{name}': {source}. Must be .pkl, .pd, .pd.z, .pd.xz, .pd.parquet, or .csv."
-                    )
-                    raise ValueError(f"Unsupported file type for {name}: {source}.")
-            elif isinstance(source, pd.DataFrame):
-                logger.info(f"Using provided pd.DataFrame for '{name}' data.")
-                df = source.copy()  # Use a copy
-            else:
-                logger.error(f"Unsupported data type for '{name}': {type(source)}.")
-                raise TypeError(f"Unsupported data type for {name}: {type(source)}.")
-
-            if df is not None:
-                logger.info(f"Successfully loaded '{name}'. Shape: {df.shape}")
-            return df
-
-        except FileNotFoundError:
-            logger.error(f"File not found for '{name}': {source}")
-            return None
-        except (ValueError, TypeError) as e:  # Catch specific errors to re-raise
-            # These are intentionally raised for unsupported types/files, so let them propagate
-            raise e
-        except Exception as e:  # Catch other, unexpected exceptions
-            logger.error(f"Unexpected error loading '{name}' data from {source}: {e}", exc_info=True)
-            return None
-
-    def _get_attributes_for_indices(self, indices: pd.Index) -> pd.DataFrame:
-        """Return attribute rows matching the provided indices."""
-        if self.attributes_df is not None:
-            return self.attributes_df.loc[indices]
-        if self.formula_df is not None:
-            return pd.DataFrame(index=self.formula_df.loc[indices].index)
-        return pd.DataFrame()
-
-    def _build_fit_datasets(self, log_prefix: str = "--- Creating 'fit' stage datasets (train/val) ---") -> None:
-        """Construct train and validation datasets based on current indices."""
-        logger.info(log_prefix)
-        if not self.train_idx.empty:
-            logger.info(f"Creating train_dataset with {len(self.train_idx)} samples.")
-            train_masking_ratios = self._resolved_task_masking_ratios()
-            self.train_dataset = CompoundDataset(
-                formula_desc=self.formula_df.loc[self.train_idx],
-                attributes=self._get_attributes_for_indices(self.train_idx),
-                task_configs=self.task_configs,
-                task_masking_ratios=train_masking_ratios,
-                task_masking_seed=self._seed_for("task_masking"),
-                is_predict_set=False,
-                dataset_name="train_dataset",
+        # 3. Descriptors (cached); drop compositions without a valid descriptor.
+        self.descriptors, dropped = self._descriptor_cache.resolve(universe)
+        if dropped:
+            logger.warning(
+                f"{len(dropped)} composition(s) dropped: descriptor_fn produced no valid descriptor "
+                f"(e.g. {', '.join(dropped[:5])})."
             )
-        else:
-            logger.warning("Train index is empty. train_dataset will be None.")
-            self.train_dataset = None
+        if self.descriptors.empty:
+            raise ValueError("descriptor_fn produced no valid descriptors for any composition.")
+        self.master_index = [str(c) for c in self.descriptors.index]
+        logger.info(f"Master composition index size (with valid descriptors): {len(self.master_index)}")
 
-        if not self.val_idx.empty:
-            logger.info(f"Creating val_dataset with {len(self.val_idx)} samples.")
-            self.val_dataset = CompoundDataset(
-                formula_desc=self.formula_df.loc[self.val_idx],
-                attributes=self._get_attributes_for_indices(self.val_idx),
-                task_configs=self.task_configs,
-                task_masking_ratios=None,
-                task_masking_seed=self._seed_for("task_masking"),
-                is_predict_set=False,
-                dataset_name="val_dataset",
-            )
-        else:
-            logger.warning("Validation index is empty. val_dataset will be None.")
-            self.val_dataset = None
+        # 4. Resolve a single composition-level split.
+        split_columns = {
+            cfg.name: cfg.split_column for cfg in self._supervised_tasks() if cfg.name in self._task_frames
+        }
+        self.split_series = resolve_splits(
+            self._task_frames,
+            self.master_index,
+            split_columns,
+            val_split=self.val_split,
+            test_split=self.test_split,
+            random_seed=self._seed_for("test_split"),
+            test_all=self.test_all,
+        )
+        labels = self.split_series
+        self.train_idx = [c for c in self.master_index if labels[c] == "train"]
+        self.val_idx = [c for c in self.master_index if labels[c] == "val"]
+        self.test_idx = [c for c in self.master_index if labels[c] == "test"]
+
+        self._apply_train_val_swap(self.swap_train_val_split, self._seed_for("swap"))
+
+        logger.info(f"Split sizes: Train={len(self.train_idx)}, Val={len(self.val_idx)}, Test={len(self.test_idx)}")
+        self._sources_ready = True
 
     def _apply_train_val_swap(self, swap_ratio: float, random_seed: int | None) -> None:
         """Randomly exchange a fraction of samples between train and validation splits."""
         if swap_ratio <= 0.0:
             return
-
-        if not hasattr(self, "train_idx") or not hasattr(self, "val_idx"):
-            raise RuntimeError("Data splits are not initialized. Call setup(stage='fit') before applying swap.")
-
         train_count = len(self.train_idx)
         val_count = len(self.val_idx)
-
         if train_count == 0 or val_count == 0:
             logger.warning(
-                "swap_train_val_split skipped because one of the splits is empty "
-                f"(train={train_count}, val={val_count})."
+                f"swap_train_val_split skipped because one split is empty (train={train_count}, val={val_count})."
             )
             return
-
         n_swap = int(min(train_count, val_count) * swap_ratio)
         if n_swap == 0:
-            logger.info(
-                "swap_train_val_split computed zero samples to swap "
-                f"(swap_ratio={swap_ratio}, min_size={min(train_count, val_count)})."
-            )
+            logger.info(f"swap_train_val_split computed zero samples to swap (swap_ratio={swap_ratio}).")
             return
 
         rng = np.random.default_rng(random_seed)
-        train_choices = rng.choice(self.train_idx.to_numpy(), size=n_swap, replace=False)
-        val_choices = rng.choice(self.val_idx.to_numpy(), size=n_swap, replace=False)
+        train_choice = rng.choice(np.array(self.train_idx), size=n_swap, replace=False).tolist()
+        val_choice = rng.choice(np.array(self.val_idx), size=n_swap, replace=False).tolist()
+        train_swap_set = set(train_choice)
+        val_swap_set = set(val_choice)
+        train_remaining = [c for c in self.train_idx if c not in train_swap_set]
+        val_remaining = [c for c in self.val_idx if c not in val_swap_set]
+        self.train_idx = train_remaining + val_choice
+        self.val_idx = val_remaining + train_choice
+        logger.info(f"Swapped {n_swap} samples between train and validation (swap_ratio={swap_ratio}).")
 
-        train_swap = pd.Index(train_choices)
-        val_swap = pd.Index(val_choices)
-
-        train_remaining = self.train_idx[~self.train_idx.isin(train_swap)]
-        val_remaining = self.val_idx[~self.val_idx.isin(val_swap)]
-
-        self.train_idx = pd.Index(list(train_remaining) + list(val_swap))
-        self.val_idx = pd.Index(list(val_remaining) + list(train_swap))
-
-        if self.attributes_df is not None and "split" in self.attributes_df.columns:
-            self.attributes_df.loc[train_swap, "split"] = "val"
-            self.attributes_df.loc[val_swap, "split"] = "train"
-
-        logger.info(
-            f"Swapped {n_swap} samples between train and validation splits "
-            f"(swap_ratio={swap_ratio}, random_seed={random_seed})."
+    def _build_dataset(
+        self,
+        compositions: Sequence[str],
+        *,
+        is_predict: bool,
+        dataset_name: str,
+        apply_masking: bool,
+    ) -> CompoundDataset | None:
+        if len(compositions) == 0:
+            logger.warning(f"{dataset_name}: no compositions; dataset will be None.")
+            return None
+        assert self.descriptors is not None
+        masking = self._resolved_task_masking_ratios() if apply_masking else None
+        return CompoundDataset(
+            compositions=list(compositions),
+            descriptors=self.descriptors,
+            task_frames=self._task_frames,
+            task_configs=self.task_configs,
+            task_masking_ratios=masking,
+            task_masking_seed=self._seed_for("task_masking"),
+            is_predict_set=is_predict,
+            dataset_name=dataset_name,
         )
+
+    def _resolve_predict_compositions(self) -> List[str]:
+        """Union of each task's predict_idx subset, preserving master-index order."""
+        master_set = set(self.master_index)
+        default_pool = list(self.test_idx) if len(self.test_idx) > 0 else list(self.master_index)
+        selected: set[str] = set()
+
+        for cfg in self._supervised_tasks():
+            pid = cfg.predict_idx
+            if pid is None:
+                subset = default_pool
+            elif isinstance(pid, str):
+                if pid == "all":
+                    subset = list(self.master_index)
+                elif pid == "train":
+                    subset = list(self.train_idx)
+                elif pid == "val":
+                    subset = list(self.val_idx)
+                else:  # "test"
+                    subset = list(self.test_idx)
+            else:  # explicit sequence of composition keys
+                requested = [str(c) for c in pid]
+                subset = [c for c in requested if c in master_set]
+                missing = [c for c in requested if c not in master_set]
+                if missing:
+                    logger.warning(
+                        f"Task '{cfg.name}': {len(missing)} predict_idx composition(s) have no descriptor "
+                        f"and are skipped (e.g. {', '.join(missing[:5])})."
+                    )
+            selected.update(subset)
+
+        return [c for c in self.master_index if c in selected]
+
+    # ------------------------------------------------------------------ lightning
+
+    def on_train_epoch_start(self):
+        """Update the DistributedSampler epoch so shuffling differs across epochs."""
+        if getattr(self, "_train_sampler", None) is not None and hasattr(self._train_sampler, "set_epoch"):
+            if getattr(self, "trainer", None) is not None:
+                self._train_sampler.set_epoch(self.trainer.current_epoch)
 
     def setup(self, stage: str | None = None):
-        """Prepare datasets for different stages (fit, test, predict)."""
+        """Prepare datasets for the requested stage (fit, test, predict)."""
         logger.info(f"--- Setting up DataModule for stage: {stage} ---")
-        if self.formula_df is None:  # attributes_df can now be None
-            logger.error("formula_df is None. Cannot proceed with setup.")
-            raise ValueError("formula_df not loaded properly.")
-
-        # Determine full_idx based on whether attributes_df exists
-        if self.attributes_df is not None:
-            full_idx = self.attributes_df.index  # Should be same as formula_df.index at this point
-        else:  # attributes_df is None, use formula_df.index as the source of all samples
-            full_idx = self.formula_df.index
-        logger.info(
-            f"Total samples available before splitting (from {'attributes_df' if self.attributes_df is not None else 'formula_df'} index): {len(full_idx)}"
-        )
-
-        if self.test_all:
-            self.train_idx = pd.Index([])
-            self.val_idx = pd.Index([])
-            self.test_idx = full_idx
-            logger.info("Data split strategy: Using all data for testing (test_all=True).")
-        # Splitting logic relies on attributes_df for 'split' column or for random splits if attributes_df exists
-        elif self.attributes_df is not None and "split" in self.attributes_df.columns:
-            logger.info("Data split strategy: Using 'split' column from attributes_df.")
-            split_counts = self.attributes_df["split"].value_counts()
-            logger.info(f"Value counts in 'split' column: {split_counts.to_dict()}")
-            if not all(s_type in ["train", "val", "test"] for s_type in split_counts.index):
-                logger.error(f"Invalid values in 'split' column: {split_counts.index.tolist()}")
-                raise ValueError("Invalid values in 'split' column. Must be 'train', 'val', or 'test'.")
-
-            self.train_idx = self.attributes_df[self.attributes_df["split"] == "train"].index
-            self.val_idx = self.attributes_df[self.attributes_df["split"] == "val"].index
-            self.test_idx = self.attributes_df[self.attributes_df["split"] == "test"].index
-
-            if self.val_idx.empty and not self.train_idx.empty:  # and self.attributes_df is not None implicitly
-                logger.warning("No 'val' samples in 'split' column. Splitting 10% of 'train' for validation.")
-                self.train_idx, self.val_idx = train_test_split(
-                    self.train_idx,
-                    test_size=0.1,
-                    random_state=self._seed_for("train_split"),
-                    shuffle=True,
-                )
-        elif (
-            self.attributes_df is not None
-        ):  # Random split only if attributes_df exists to provide a basis for splitting
-            logger.info(
-                "Data split strategy: Performing random train/val/test splits based on full_idx (derived from attributes_df)."
-            )
-            logger.info(f"Test split ratio: {self.test_split}, Validation split ratio (of non-test): {self.val_split}")
-            if self.test_split >= 1.0:
-                logger.info(f"test_split is {self.test_split}, assigning all data to test set.")
-                self.test_idx = full_idx
-                train_val_idx = pd.Index([])
-            elif self.test_split > 0:
-                train_val_idx, self.test_idx = train_test_split(
-                    full_idx,  # full_idx here is from attributes_df.index
-                    test_size=self.test_split,
-                    random_state=self._seed_for("test_split"),
-                    shuffle=True,
-                )
-                logger.info(
-                    f"Split full data ({len(full_idx)}) into train_val ({len(train_val_idx)}) and test ({len(self.test_idx)}) "
-                    f"using derived seed {self._seed_for('test_split')} (base random_seed={self.random_seed})."
-                )
-            else:  # test_split is 0
-                train_val_idx = full_idx
-                self.test_idx = pd.Index([])
-                logger.info("test_split is 0. All data used for train_val.")
-
-            if self.val_split > 0 and len(train_val_idx) > 0:
-                effective_val_split = self.val_split
-                if (1.0 - self.test_split) > 1e-6:  # Avoid division by zero
-                    effective_val_split = self.val_split / (1.0 - self.test_split)
-
-                if effective_val_split >= 1.0:
-                    logger.info(
-                        f"Calculated effective_val_split ({effective_val_split:.3f}) >= 1.0. Assigning all train_val to validation."
-                    )
-                    self.val_idx = train_val_idx
-                    self.train_idx = pd.Index([])
-                else:
-                    self.train_idx, self.val_idx = train_test_split(
-                        train_val_idx,
-                        test_size=effective_val_split,
-                        random_state=self._seed_for("train_split"),
-                        shuffle=True,
-                    )
-                    logger.info(
-                        f"Split train_val ({len(train_val_idx)}) into train ({len(self.train_idx)}) and val ({len(self.val_idx)}) "
-                        f"using derived seed {self._seed_for('train_split')} (base random_seed={self.random_seed}), "
-                        f"effective_val_split {effective_val_split:.3f}."
-                    )
-            elif len(train_val_idx) > 0:  # val_split is 0
-                self.train_idx = train_val_idx
-                self.val_idx = pd.Index([])
-                logger.info("val_split is 0. All remaining train_val data used for train. Validation set is empty.")
-            else:  # train_val_idx is empty
-                self.train_idx = pd.Index([])
-                self.val_idx = pd.Index([])
-                logger.info("train_val_idx is empty. Train and Validation sets are empty.")
-        else:  # attributes_df is None, so no basis for 'split' column or random splitting.
-            # All data is effectively for prediction or a single use case if not test_all.
-            logger.info("attributes_df is None. No 'split' column or random splitting applied. All data in full_idx.")
-            if not self.test_all:  # If test_all is true, it's already handled.
-                # If not test_all, and no other split info, assume all for train, no val/test.
-                # This might need adjustment based on how predict_idx is handled later.
-                self.train_idx = full_idx
-                self.val_idx = pd.Index([])
-                self.test_idx = pd.Index([])
-                logger.info("Using all data for train_idx as attributes_df is None and not test_all.")
-            # If self.test_all is True, self.test_idx is already full_idx, train/val are empty.
-
-        # Optional bootstrap-style train/val swapping
-        self._apply_train_val_swap(self.swap_train_val_split, self._seed_for("swap"))
-
-        logger.info(
-            f"Final dataset sizes after splitting: Train={len(self.train_idx)}, Validation={len(self.val_idx)}, Test={len(self.test_idx)}"
-        )
+        self._prepare_sources()
 
         if stage == "fit" or stage is None:
-            self._build_fit_datasets()
+            logger.info("--- Creating 'fit' stage datasets (train/val) ---")
+            self.train_dataset = self._build_dataset(
+                self.train_idx, is_predict=False, dataset_name="train_dataset", apply_masking=True
+            )
+            self.val_dataset = self._build_dataset(
+                self.val_idx, is_predict=False, dataset_name="val_dataset", apply_masking=False
+            )
 
         if stage == "test" or stage is None:
             logger.info("--- Creating 'test' stage dataset ---")
-            if not self.test_idx.empty and self.attributes_df is not None:
-                logger.info(f"Creating test_dataset with {len(self.test_idx)} samples.")
-                self.test_dataset = CompoundDataset(
-                    formula_desc=self.formula_df.loc[self.test_idx],
-                    attributes=self._get_attributes_for_indices(self.test_idx),
-                    task_configs=self.task_configs,
-                    task_masking_ratios=None,  # No masking for test
-                    task_masking_seed=self._seed_for("task_masking"),
-                    is_predict_set=False,  # Typically False for test, model might output targets for metrics
-                    dataset_name="test_dataset",
-                )
-            elif self.attributes_df is None and not self.test_idx.empty:
-                logger.warning(
-                    "attributes_df is None; skipping test_dataset creation because supervised targets are unavailable."
-                )
-                self.test_dataset = None
-            else:
-                logger.info("Test index is empty. test_dataset will be None.")
-                self.test_dataset = None
+            self.test_dataset = self._build_dataset(
+                self.test_idx, is_predict=False, dataset_name="test_dataset", apply_masking=False
+            )
 
         if stage == "predict":
             logger.info("--- Creating 'predict' stage dataset ---")
-            # Use the new resolver method to handle all predict_idx types
-            self.predict_idx = self._resolve_predict_idx(full_idx)
-
-            if not self.predict_idx.empty:
-                self.predict_dataset = CompoundDataset(
-                    formula_desc=self.formula_df.loc[self.predict_idx],
-                    attributes=self._get_attributes_for_indices(self.predict_idx),
-                    task_configs=self.task_configs,
-                    task_masking_ratios=None,  # No masking for predict
-                    task_masking_seed=self._seed_for("task_masking"),
-                    is_predict_set=True,
-                    dataset_name="predict_dataset",
-                )
-            else:
-                logger.warning("Predict index is empty after processing. predict_dataset will be None.")
-                self.predict_dataset = None
+            self.predict_compositions = self._resolve_predict_compositions()
+            self.predict_dataset = self._build_dataset(
+                self.predict_compositions, is_predict=True, dataset_name="predict_dataset", apply_masking=False
+            )
         logger.info(f"--- DataModule setup for stage '{stage}' complete ---")
 
-    def train_dataloader(self):
-        if not hasattr(self, "train_dataset") or self.train_dataset is None:
-            logger.warning("train_dataloader: Train dataset is None or not initialized. Returning None.")
-            return None
-        if len(self.train_dataset) == 0:
-            logger.warning("train_dataloader: Train dataset is empty (length 0). Returning None.")
-            return None
+    # ------------------------------------------------------------------ dataloaders
 
-        # Create custom collate function for KernelRegression tasks
+    def _make_loader(self, dataset, *, shuffle: bool, track_sampler: bool):
         collate_fn = create_collate_fn_with_task_info(self.task_configs)
-
-        # Detect distributed training environment
         use_ddp = torch.distributed.is_available() and torch.distributed.is_initialized()
-
+        sampler: DistributedSampler | None
         if use_ddp:
-            # Use DistributedSampler for multi-GPU training
-            sampler = DistributedSampler(
-                self.train_dataset,
-                shuffle=True,
-                drop_last=False,  # Keep all samples
-            )
-            shuffle = False  # shuffle and sampler are mutually exclusive
-            # Store reference for on_train_epoch_start hook
-            self._train_sampler = sampler
+            sampler = DistributedSampler(dataset, shuffle=shuffle, drop_last=False)
+            loader_shuffle = False
         else:
             sampler = None
-            shuffle = True
-            self._train_sampler = None
-
+            loader_shuffle = shuffle
+        if track_sampler:
+            self._train_sampler = sampler
         return DataLoader(
-            self.train_dataset,
+            dataset,
             batch_size=self.batch_size,
-            shuffle=shuffle,
+            shuffle=loader_shuffle,
             sampler=sampler,
             num_workers=self.num_workers,
             pin_memory=True,
             collate_fn=collate_fn,
         )
+
+    def train_dataloader(self):
+        if self.train_dataset is None or len(self.train_dataset) == 0:
+            logger.warning("train_dataloader: Train dataset is None or empty. Returning None.")
+            return None
+        return self._make_loader(self.train_dataset, shuffle=True, track_sampler=True)
 
     def val_dataloader(self):
-        if not hasattr(self, "val_dataset") or self.val_dataset is None:
-            logger.info("val_dataloader: Validation dataset is None or not initialized. Returning None.")
+        if self.val_dataset is None or len(self.val_dataset) == 0:
+            logger.info("val_dataloader: Validation dataset is None or empty. Returning None.")
             return None
-        if len(self.val_dataset) == 0:
-            logger.info("val_dataloader: Validation dataset is empty (length 0). Returning None.")
-            return None
-
-        # Create custom collate function for KernelRegression tasks
-        collate_fn = create_collate_fn_with_task_info(self.task_configs)
-
-        # Detect distributed training environment
-        use_ddp = torch.distributed.is_available() and torch.distributed.is_initialized()
-
-        if use_ddp:
-            # Use DistributedSampler for multi-GPU validation
-            sampler = DistributedSampler(
-                self.val_dataset,
-                shuffle=False,  # Don't shuffle validation data
-                drop_last=False,  # Keep all samples
-            )
-        else:
-            sampler = None
-
-        return DataLoader(
-            self.val_dataset,
-            batch_size=self.batch_size,
-            shuffle=False,
-            sampler=sampler,
-            num_workers=self.num_workers,
-            pin_memory=True,
-            collate_fn=collate_fn,
-        )
+        return self._make_loader(self.val_dataset, shuffle=False, track_sampler=False)
 
     def test_dataloader(self):
-        if not hasattr(self, "test_dataset") or self.test_dataset is None:
-            logger.info("test_dataloader: Test dataset is None or not initialized. Returning None.")
+        if self.test_dataset is None or len(self.test_dataset) == 0:
+            logger.info("test_dataloader: Test dataset is None or empty. Returning None.")
             return None
-        if len(self.test_dataset) == 0:
-            logger.info("test_dataloader: Test dataset is empty (length 0). Returning None.")
-            return None
-
-        # Create custom collate function for KernelRegression tasks
-        collate_fn = create_collate_fn_with_task_info(self.task_configs)
-
-        # Detect distributed training environment
-        use_ddp = torch.distributed.is_available() and torch.distributed.is_initialized()
-
-        if use_ddp:
-            # Use DistributedSampler for multi-GPU testing
-            sampler = DistributedSampler(
-                self.test_dataset,
-                shuffle=False,  # Don't shuffle test data
-                drop_last=False,  # Keep all samples
-            )
-        else:
-            sampler = None
-
-        return DataLoader(
-            self.test_dataset,
-            batch_size=self.batch_size,
-            shuffle=False,
-            sampler=sampler,
-            num_workers=self.num_workers,
-            pin_memory=True,
-            collate_fn=collate_fn,
-        )
+        return self._make_loader(self.test_dataset, shuffle=False, track_sampler=False)
 
     def predict_dataloader(self):
-        if not hasattr(self, "predict_dataset") or self.predict_dataset is None:
-            logger.info("predict_dataloader: Predict dataset is None or not initialized. Returning None.")
+        if self.predict_dataset is None or len(self.predict_dataset) == 0:
+            logger.info("predict_dataloader: Predict dataset is None or empty. Returning None.")
             return None
-        if len(self.predict_dataset) == 0:
-            logger.info("predict_dataloader: Predict dataset is empty (length 0). Returning None.")
-            return None
-
-        # Create custom collate function for KernelRegression tasks
-        collate_fn = create_collate_fn_with_task_info(self.task_configs)
-
-        # Detect distributed training environment
-        use_ddp = torch.distributed.is_available() and torch.distributed.is_initialized()
-
-        if use_ddp:
-            # Use DistributedSampler for multi-GPU prediction
-            sampler = DistributedSampler(
-                self.predict_dataset,
-                shuffle=False,  # Don't shuffle prediction data
-                drop_last=False,  # Keep all samples
-            )
-        else:
-            sampler = None
-
-        return DataLoader(
-            self.predict_dataset,
-            batch_size=self.batch_size,
-            shuffle=False,
-            sampler=sampler,
-            num_workers=self.num_workers,
-            pin_memory=True,
-            collate_fn=collate_fn,
-        )
+        return self._make_loader(self.predict_dataset, shuffle=False, track_sampler=False)

--- a/src/foundation_model/data/datamodule_test.py
+++ b/src/foundation_model/data/datamodule_test.py
@@ -142,6 +142,26 @@ def test_data_files_loading(tmp_path, descriptors_df):
     assert len(dm._task_frames["task1"]) == 20
 
 
+def test_default_data_files_shared_across_tasks(tmp_path, descriptors_df):
+    """A single shared file fills in tasks that declare no data_files of their own."""
+    shared = pd.DataFrame({"composition": list(COMPOSITIONS), "task1": np.arange(20.0), "task2": np.arange(20.0)})
+    path = tmp_path / "shared.parquet"
+    shared.to_parquet(path)
+    configs = [
+        RegressionTaskConfig(name="task1", data_column="task1", dims=[2, 16, 1]),
+        RegressionTaskConfig(name="task2", data_column="task2", dims=[2, 16, 1]),
+    ]
+    dm = CompoundDataModule(
+        task_configs=configs,
+        descriptor_fn=make_descriptor_fn(descriptors_df),
+        default_data_files=str(path),
+        test_all=True,
+    )
+    dm.setup(stage="test")
+    assert set(dm._task_frames) == {"task1", "task2"}
+    assert len(dm._task_frames["task1"]) == 20
+
+
 # --- splitting --------------------------------------------------------------
 
 

--- a/src/foundation_model/data/datamodule_test.py
+++ b/src/foundation_model/data/datamodule_test.py
@@ -1,170 +1,153 @@
-import logging
-import os
-import tempfile
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the composition-keyed CompoundDataModule (refactor PR3)."""
+
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
 import pytest
-import torch
-from loguru import logger as loguru_logger  # ADDED for loguru bridge
+from loguru import logger
+from torch.utils.data.distributed import DistributedSampler
 
 from foundation_model.data.datamodule import CompoundDataModule
 from foundation_model.models.model_config import (
     AutoEncoderTaskConfig,
     ClassificationTaskConfig,
     RegressionTaskConfig,
-    TaskType,
 )
 
-
-def _expected_swapped_indices(train_idx, val_idx, swap_ratio, seed):
-    """Replicate the swapping logic used by CompoundDataModule."""
-    if swap_ratio <= 0.0:
-        return pd.Index(train_idx), pd.Index(val_idx)
-
-    train_idx = pd.Index(train_idx)
-    val_idx = pd.Index(val_idx)
-
-    n_swap = int(min(len(train_idx), len(val_idx)) * swap_ratio)
-    if n_swap == 0:
-        return train_idx, val_idx
-
-    rng = np.random.default_rng(seed)
-    train_swap = pd.Index(rng.choice(train_idx.to_numpy(), size=n_swap, replace=False))
-    val_swap = pd.Index(rng.choice(val_idx.to_numpy(), size=n_swap, replace=False))
-
-    train_swap_set = set(train_swap)
-    val_swap_set = set(val_swap)
-
-    train_remaining = [idx for idx in train_idx if idx not in train_swap_set]
-    val_remaining = [idx for idx in val_idx if idx not in val_swap_set]
-
-    new_train = pd.Index(train_remaining + list(val_swap))
-    new_val = pd.Index(val_remaining + list(train_swap))
-    return new_train, new_val
-
-
-# --- Fixtures ---
-@pytest.fixture
-def base_formula_df():  # 20 samples s0-s19
-    return pd.DataFrame({"f1": np.random.rand(20), "f2": np.random.rand(20)}, index=[f"s{i}" for i in range(20)])
+COMPOSITIONS = [f"s{i}" for i in range(20)]
 
 
 @pytest.fixture
-def formula_df_subset():  # 15 samples, s0-s14
-    return pd.DataFrame({"f1": np.random.rand(15), "f2": np.random.rand(15)}, index=[f"s{i}" for i in range(15)])
+def loguru_messages():
+    """Capture loguru INFO+ messages (caplog only sees stdlib logging)."""
+    messages: list[str] = []
+    sink_id = logger.add(messages.append, level="INFO", format="{message}")
+    try:
+        yield messages
+    finally:
+        logger.remove(sink_id)
+
+
+def make_descriptor_fn(descriptor_df, call_log=None):
+    """Build a descriptor_fn that looks up rows from a precomputed descriptor frame."""
+
+    def fn(compositions):
+        if call_log is not None:
+            call_log.append(list(compositions))
+        present = [c for c in compositions if c in descriptor_df.index]
+        return descriptor_df.loc[present]
+
+    return fn
 
 
 @pytest.fixture
-def attributes_df_full_match():  # 20 samples s0-s19, with split col
-    data = {
-        "task1_regression_value": np.random.rand(20),
-        "task_cls_classification_value": np.random.randint(0, 3, size=20),
-        "split": ["train"] * 10 + ["val"] * 5 + ["test"] * 5,
-    }
-    return pd.DataFrame(data, index=[f"s{i}" for i in range(20)])
+def descriptors_df():
+    rng = np.random.default_rng(0)
+    return pd.DataFrame({"f1": rng.random(20), "f2": rng.random(20)}, index=list(COMPOSITIONS))
 
 
 @pytest.fixture
-def attributes_df_partial_match():  # 18 samples, s2-s19, with split col
-    data = {
-        "task1_regression_value": np.random.rand(18),
-        "task_cls_classification_value": np.random.randint(0, 3, size=18),
-        "split": ["train"] * 9 + ["val"] * 5 + ["test"] * 4,
-    }
-    return pd.DataFrame(data, index=[f"s{i}" for i in range(2, 20)])
-
-
-@pytest.fixture
-def attributes_df_no_split_full_match():  # 20 samples, s0-s19, no split col
-    data = {
-        "task1_regression_value": np.random.rand(20),
-        "task_cls_classification_value": np.random.randint(0, 3, size=20),
-    }
-    return pd.DataFrame(data, index=[f"s{i}" for i in range(20)])
-
-
-@pytest.fixture
-def sample_task_configs_dm():
+def reg_cls_configs():
     return [
-        RegressionTaskConfig(
-            name="task1", type=TaskType.REGRESSION, data_column="task1_regression_value", dims=[256, 128, 1]
-        ),
-        ClassificationTaskConfig(
-            name="task_cls", type=TaskType.CLASSIFICATION, data_column="task_cls_classification_value", num_classes=3
-        ),
+        RegressionTaskConfig(name="task1", data_column="task1", dims=[2, 16, 1]),
+        ClassificationTaskConfig(name="task_cls", data_column="task_cls", num_classes=3, dims=[2, 16, 3]),
     ]
 
 
-@pytest.fixture
-def sample_task_configs_no_seq_dm():
-    return [
-        RegressionTaskConfig(
-            name="task1", type=TaskType.REGRESSION, data_column="task1_regression_value", dims=[256, 128, 1]
-        ),
-        ClassificationTaskConfig(
-            name="task_cls", type=TaskType.CLASSIFICATION, data_column="task_cls_classification_value", num_classes=3
-        ),
-    ]
+def _reg_cls_frames(split=None):
+    rng = np.random.default_rng(1)
+    data1 = {"task1": rng.random(20)}
+    data_cls = {"task_cls": rng.integers(0, 3, size=20)}
+    if split is not None:
+        data1["split"] = split
+        data_cls["split"] = split
+    return {
+        "task1": pd.DataFrame(data1, index=list(COMPOSITIONS)),
+        "task_cls": pd.DataFrame(data_cls, index=list(COMPOSITIONS)),
+    }
 
 
-@pytest.fixture
-def temp_files_dir():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        yield tmpdir
-
-
-# --- Test Cases ---
-
-
-def test_datamodule_init_with_dfs(base_formula_df, attributes_df_full_match, sample_task_configs_dm):
-    dm = CompoundDataModule(
-        formula_desc_source=base_formula_df,
-        attributes_source=attributes_df_full_match,
-        task_configs=sample_task_configs_dm,
+def build_dm(descriptors_df, task_frames=None, configs=None, call_log=None, **kwargs):
+    return CompoundDataModule(
+        task_configs=configs,
+        descriptor_fn=make_descriptor_fn(descriptors_df, call_log),
+        task_frames=task_frames,
+        **kwargs,
     )
-    assert dm.formula_df is not None
-    assert dm.attributes_df is not None
-    assert len(dm.formula_df) == 20
-    assert len(dm.attributes_df) == 20
-    assert dm.formula_df.index.equals(attributes_df_full_match.index)
 
 
-def test_datamodule_alignment_formula_master(base_formula_df, attributes_df_partial_match, sample_task_configs_dm):
-    """Test alignment when formula_df is master and attributes_df is partial."""
-    # base_formula_df (s0-s19)
-    # attributes_df_partial_match (s2-s19)
-    # Expected final common index: s2-s19
-    dm = CompoundDataModule(
-        formula_desc_source=base_formula_df.copy(),
-        attributes_source=attributes_df_partial_match.copy(),
-        task_configs=sample_task_configs_dm,
-    )
-    expected_final_index = base_formula_df.index.intersection(attributes_df_partial_match.index)  # s2-s19
-    assert dm.formula_df.index.equals(expected_final_index)
-    assert dm.attributes_df.index.equals(expected_final_index)
-    assert len(dm.formula_df) == 18
-    assert len(dm.attributes_df) == 18
+# --- init validation --------------------------------------------------------
 
 
-def test_datamodule_init_attributes_none_non_sequence(base_formula_df, sample_task_configs_no_seq_dm):
-    """Test init with attributes_source=None and only non-sequence tasks."""
-    dm = CompoundDataModule(
-        formula_desc_source=base_formula_df,
-        attributes_source=None,
-        task_configs=sample_task_configs_no_seq_dm,
-    )
-    assert dm.formula_df is not None
-    assert dm.attributes_df is None
-    assert len(dm.formula_df) == 20
+def test_init_requires_descriptor_fn(reg_cls_configs):
+    with pytest.raises(ValueError, match="descriptor_fn must be provided"):
+        CompoundDataModule(task_configs=reg_cls_configs, descriptor_fn=None)  # type: ignore[arg-type]
 
 
-def test_datamodule_setup_split_column(base_formula_df, attributes_df_full_match, sample_task_configs_dm):
-    dm = CompoundDataModule(
-        formula_desc_source=base_formula_df,
-        attributes_source=attributes_df_full_match,
-        task_configs=sample_task_configs_dm,
-    )
+def test_init_requires_task_configs(descriptors_df):
+    with pytest.raises(ValueError, match="task_configs cannot be empty"):
+        CompoundDataModule(task_configs=[], descriptor_fn=make_descriptor_fn(descriptors_df))
+
+
+def test_init_rejects_bad_swap_ratio(descriptors_df, reg_cls_configs):
+    with pytest.raises(ValueError, match="swap_train_val_split"):
+        build_dm(descriptors_df, configs=reg_cls_configs, swap_train_val_split=1.5)
+
+
+# --- sources & descriptors --------------------------------------------------
+
+
+def test_in_memory_task_frames_drive_setup(descriptors_df, reg_cls_configs):
+    dm = build_dm(descriptors_df, task_frames=_reg_cls_frames(), configs=reg_cls_configs, test_all=True)
+    dm.setup(stage="test")
+    assert dm.descriptors is not None
+    assert len(dm.descriptors) == 20
+    assert len(dm.test_idx) == 20
+    assert dm.test_dataset is not None and len(dm.test_dataset) == 20
+
+
+def test_descriptor_fn_caches_across_stages(descriptors_df, reg_cls_configs):
+    call_log: list[list[str]] = []
+    dm = build_dm(descriptors_df, task_frames=_reg_cls_frames(), configs=reg_cls_configs, call_log=call_log)
+    dm.setup(stage="fit")
+    dm.setup(stage="test")
+    dm.setup(stage="predict")
+    # Sources are prepared once; descriptor_fn invoked a single time over the universe.
+    assert len(call_log) == 1
+    assert sorted(call_log[0]) == sorted(COMPOSITIONS)
+
+
+def test_dropped_composition_without_descriptor(descriptors_df, reg_cls_configs, loguru_messages):
+    # Descriptor frame missing s19 -> it should be dropped from the master index.
+    partial = descriptors_df.drop(index=["s19"])
+    dm = build_dm(partial, task_frames=_reg_cls_frames(), configs=reg_cls_configs, test_all=True)
+    dm.setup(stage="test")
+    assert "s19" not in dm.master_index
+    assert len(dm.master_index) == 19
+    assert any("dropped" in m for m in loguru_messages)
+
+
+def test_data_files_loading(tmp_path, descriptors_df):
+    frame = pd.DataFrame({"composition": list(COMPOSITIONS), "task1": np.arange(20.0)})
+    path = tmp_path / "task1.parquet"
+    frame.to_parquet(path)
+    configs = [RegressionTaskConfig(name="task1", data_column="task1", dims=[2, 16, 1], data_files=str(path))]
+    dm = build_dm(descriptors_df, configs=configs, test_all=True)
+    dm.setup(stage="test")
+    assert "task1" in dm._task_frames
+    assert len(dm._task_frames["task1"]) == 20
+
+
+# --- splitting --------------------------------------------------------------
+
+
+def test_split_column_resolution(descriptors_df, reg_cls_configs):
+    split = ["train"] * 10 + ["val"] * 5 + ["test"] * 5
+    dm = build_dm(descriptors_df, task_frames=_reg_cls_frames(split=split), configs=reg_cls_configs)
     dm.setup(stage="fit")
     assert len(dm.train_idx) == 10
     assert len(dm.val_idx) == 5
@@ -172,837 +155,210 @@ def test_datamodule_setup_split_column(base_formula_df, attributes_df_full_match
     assert len(dm.test_idx) == 5
 
 
-def test_datamodule_setup_random_split(base_formula_df, attributes_df_no_split_full_match, sample_task_configs_dm):
-    dm = CompoundDataModule(
-        formula_desc_source=base_formula_df,
-        attributes_source=attributes_df_no_split_full_match,
-        task_configs=sample_task_configs_dm,
+def test_random_split_counts(descriptors_df, reg_cls_configs):
+    dm = build_dm(
+        descriptors_df,
+        task_frames=_reg_cls_frames(),  # no split column -> random fallback
+        configs=reg_cls_configs,
         val_split=0.2,
         test_split=0.1,
+        random_seed=42,
     )
-    dm.setup(stage="fit")  # test_split=0.1 -> 2 test, 18 train_val. val_split=0.2 -> 0.2/0.9 * 18 = 4 val. 14 train.
-    assert len(dm.test_idx) == 2
-    assert len(dm.val_idx) == 4
+    dm.setup(stage="fit")
+    assert len(dm.test_idx) == 2  # round(20 * 0.1)
+    assert len(dm.val_idx) == 4  # round(20 * 0.2)
     assert len(dm.train_idx) == 14
 
 
-def test_datamodule_setup_attributes_none_splitting(base_formula_df, sample_task_configs_no_seq_dm):
-    """Test splitting when attributes_source is None (all data should go to train if not test_all)."""
-    dm = CompoundDataModule(
-        formula_desc_source=base_formula_df,
-        attributes_source=None,
-        task_configs=sample_task_configs_no_seq_dm,
-        val_split=0.1,  # These should be ignored as no basis for random split from attributes
-        test_split=0.1,
-    )
-    dm.setup("fit")
-    assert len(dm.train_idx) == 20  # All data from formula_df
-    assert dm.val_idx.empty
-    assert dm.test_idx.empty
-
-    dm_test_all = CompoundDataModule(
-        formula_desc_source=base_formula_df,
-        attributes_source=None,
-        task_configs=sample_task_configs_no_seq_dm,
-        test_all=True,
-    )
-    dm_test_all.setup("test")
-    assert len(dm_test_all.test_idx) == 20
-    assert dm_test_all.train_idx.empty
-    assert dm_test_all.val_idx.empty
-
-
-def test_swap_train_val_split_applied(base_formula_df, attributes_df_full_match, sample_task_configs_dm):
-    swap_ratio = 0.4
-
-    dm = CompoundDataModule(
-        formula_desc_source=base_formula_df,
-        attributes_source=attributes_df_full_match,
-        task_configs=sample_task_configs_dm,
-        swap_train_val_split=swap_ratio,
+def test_swap_train_val_applied(descriptors_df, reg_cls_configs):
+    split = ["train"] * 10 + ["val"] * 5 + ["test"] * 5
+    dm = build_dm(
+        descriptors_df,
+        task_frames=_reg_cls_frames(split=split),
+        configs=reg_cls_configs,
+        swap_train_val_split=0.4,
         random_seed=123,
     )
-
-    original_train = attributes_df_full_match[attributes_df_full_match["split"] == "train"].index
-    original_val = attributes_df_full_match[attributes_df_full_match["split"] == "val"].index
-    expected_train, expected_val = _expected_swapped_indices(
-        original_train, original_val, swap_ratio, dm._seed_for("swap")
-    )
-
     dm.setup(stage="fit")
-
-    assert list(dm.train_idx) == list(expected_train)
-    assert list(dm.val_idx) == list(expected_val)
-
-    # Ensure split labels were updated accordingly
-    assert all(dm.attributes_df.loc[idx, "split"] == "train" for idx in dm.train_idx)
-    assert all(dm.attributes_df.loc[idx, "split"] == "val" for idx in dm.val_idx)
-    assert all(dm.attributes_df.loc[idx, "split"] == "test" for idx in dm.test_idx)
+    # Sizes are preserved by the swap; contents change.
+    assert len(dm.train_idx) == 10
+    assert len(dm.val_idx) == 5
+    assert set(dm.train_idx).isdisjoint(set(dm.test_idx))
 
 
-def test_swap_train_val_split_zero_no_change(base_formula_df, attributes_df_full_match, sample_task_configs_dm):
-    dm = CompoundDataModule(
-        formula_desc_source=base_formula_df,
-        attributes_source=attributes_df_full_match,
-        task_configs=sample_task_configs_dm,
-        swap_train_val_split=0.0,
+def test_swap_zero_no_change(descriptors_df, reg_cls_configs):
+    split = ["train"] * 10 + ["val"] * 5 + ["test"] * 5
+    dm = build_dm(
+        descriptors_df, task_frames=_reg_cls_frames(split=split), configs=reg_cls_configs, swap_train_val_split=0.0
     )
-
-    original_train = attributes_df_full_match[attributes_df_full_match["split"] == "train"].index
-    original_val = attributes_df_full_match[attributes_df_full_match["split"] == "val"].index
-
     dm.setup(stage="fit")
-
-    assert list(dm.train_idx) == list(original_train)
-    assert list(dm.val_idx) == list(original_val)
-
-
-def test_datamodule_setup_with_user_predict_idx(base_formula_df, sample_task_configs_no_seq_dm, caplog):
-    """Test setup(stage='predict') with user-provided predict_idx."""
-
-    # --- Loguru to caplog bridge (local to this test) ---
-    class PropagateHandler(logging.Handler):
-        def emit(self, record):
-            logging.getLogger(record.name).handle(record)
-
-    handler_id = loguru_logger.add(PropagateHandler(), format="{message}", level="WARNING")
-    # --- End bridge ---
-
-    try:
-        user_indices = pd.Index([f"s{i}" for i in range(5)])  # s0-s4
-        dm = CompoundDataModule(
-            formula_desc_source=base_formula_df,  # s0-s19
-            attributes_source=None,  # Test with no attributes
-            task_configs=sample_task_configs_no_seq_dm,
-            predict_idx=user_indices,
-        )
-        dm.setup(stage="predict")
-        assert dm.predict_idx.equals(user_indices)
-        assert len(dm.predict_dataset) == 5
-
-        # Test with partially valid predict_idx
-        user_indices_mixed = pd.Index(
-            [f"s{i}" for i in range(3)] + ["non_existent_1", "s19"]
-        )  # s0,s1,s2,non_existent_1,s19
-        expected_valid_mixed = pd.Index(["s0", "s1", "s2", "s19"])
-        caplog.clear()
-        dm_mixed = CompoundDataModule(
-            formula_desc_source=base_formula_df,
-            attributes_source=None,
-            task_configs=sample_task_configs_no_seq_dm,
-            predict_idx=user_indices_mixed,
-        )
-        dm_mixed.setup(stage="predict")
-        assert dm_mixed.predict_idx.equals(expected_valid_mixed)
-        assert len(dm_mixed.predict_dataset) == 4
-        assert any(
-            "User-provided predict_idx contains indices not found" in rec.message
-            for rec in caplog.records  # Corrected from 'record' to 'rec' if that was the var name
-            if rec.levelname == "WARNING"
-        )
-
-        # Test with all invalid predict_idx
-        user_indices_invalid = pd.Index(["invalid1", "invalid2"])
-        caplog.clear()
-        dm_invalid = CompoundDataModule(
-            formula_desc_source=base_formula_df,
-            attributes_source=None,
-            task_configs=sample_task_configs_no_seq_dm,
-            predict_idx=user_indices_invalid,
-        )
-        dm_invalid.setup(stage="predict")
-        assert dm_invalid.predict_idx.empty
-        assert dm_invalid.predict_dataset is None
-        assert any(
-            "User-provided predict_idx resulted in an empty set" in rec.message
-            for rec in caplog.records  # Corrected from 'record' to 'rec' if that was the var name
-            if rec.levelname == "WARNING"
-        )
-    finally:
-        loguru_logger.remove(handler_id)  # Clean up the handler
+    assert list(dm.train_idx) == COMPOSITIONS[:10]
+    assert list(dm.val_idx) == COMPOSITIONS[10:15]
 
 
-def test_datamodule_setup_predict_idx_fallback(
-    base_formula_df, attributes_df_no_split_full_match, sample_task_configs_dm
-):
-    """Test predict_idx fallback logic when init_predict_idx is None."""
-    dm = CompoundDataModule(
-        formula_desc_source=base_formula_df,
-        attributes_source=attributes_df_no_split_full_match,  # s0-s19
-        task_configs=sample_task_configs_dm,
-        test_split=0.1,  # test_idx will be 2 samples
-        val_split=0,  # ensure train_val is not further split for simplicity here
+# --- masking ----------------------------------------------------------------
+
+
+def test_masking_ratio_from_config(descriptors_df):
+    configs = [
+        RegressionTaskConfig(name="task1", data_column="task1", dims=[2, 16, 1], task_masking_ratio=0.5),
+        ClassificationTaskConfig(name="task_cls", data_column="task_cls", num_classes=3, dims=[2, 16, 3]),
+    ]
+    dm = build_dm(
+        descriptors_df, task_frames=_reg_cls_frames(), configs=configs, test_all=False, test_split=0.0, val_split=0.0
     )
-    dm.setup("test")  # Populates test_idx
-    dm.setup("predict")
-    assert dm.predict_idx.equals(dm.test_idx)
-    assert len(dm.predict_idx) == 2  # 0.1 * 20
-
-    dm_no_test = CompoundDataModule(
-        formula_desc_source=base_formula_df,
-        attributes_source=attributes_df_no_split_full_match,
-        task_configs=sample_task_configs_dm,
-        test_split=0.0,  # test_idx will be empty
-    )
-    dm_no_test.setup("test")
-    dm_no_test.setup("predict")
-    assert dm_no_test.predict_idx.equals(base_formula_df.index)  # Fallback to full_idx (from formula_df)
-    assert len(dm_no_test.predict_idx) == 20
+    dm.setup(stage="fit")
+    assert dm.train_dataset is not None
+    assert dm.train_dataset.task_masking_ratios == {"task1": 0.5}
+    # Validation/test/predict never apply training masking.
+    dm.setup(stage="test")
+    if dm.test_dataset is not None:
+        assert dm.test_dataset.task_masking_ratios is None
 
 
-def test_datamodule_init_empty_formula_raises_error(sample_task_configs_dm):
-    with pytest.raises(ValueError, match="formula_desc_source must be successfully loaded and cannot be empty."):
-        CompoundDataModule(formula_desc_source=pd.DataFrame(), task_configs=sample_task_configs_dm)
+# --- prediction -------------------------------------------------------------
 
 
-def test_datamodule_init_attributes_provided_but_empty_raises_error(base_formula_df, sample_task_configs_dm):
-    with pytest.raises(ValueError, match="attributes_source was provided but could not be loaded or is empty."):
-        CompoundDataModule(
-            formula_desc_source=base_formula_df,
-            attributes_source=pd.DataFrame(),  # Provided but empty
-            task_configs=sample_task_configs_dm,
-        )
+def test_predict_default_is_test_split(descriptors_df, reg_cls_configs):
+    split = ["train"] * 10 + ["val"] * 5 + ["test"] * 5
+    dm = build_dm(descriptors_df, task_frames=_reg_cls_frames(split=split), configs=reg_cls_configs)
+    dm.setup(stage="fit")  # populate splits
+    dm.setup(stage="predict")
+    assert sorted(dm.predict_compositions) == sorted(COMPOSITIONS[15:20])
+    assert dm.predict_dataset is not None and len(dm.predict_dataset) == 5
 
 
-def test_datamodule_dataloaders_created(base_formula_df, attributes_df_full_match, sample_task_configs_dm):
-    dm = CompoundDataModule(
-        formula_desc_source=base_formula_df,
-        attributes_source=attributes_df_full_match,
-        task_configs=sample_task_configs_dm,
-    )
-    dm.setup()  # Setup all stages
+def test_predict_literal_all(descriptors_df):
+    configs = [RegressionTaskConfig(name="task1", data_column="task1", dims=[2, 16, 1], predict_idx="all")]
+    dm = build_dm(descriptors_df, task_frames={"task1": _reg_cls_frames()["task1"]}, configs=configs)
+    dm.setup(stage="predict")
+    assert sorted(dm.predict_compositions) == sorted(COMPOSITIONS)
+
+
+def test_predict_explicit_subset_union(descriptors_df):
+    configs = [
+        RegressionTaskConfig(name="task1", data_column="task1", dims=[2, 16, 1], predict_idx=["s0", "s1"]),
+        RegressionTaskConfig(name="task2", data_column="task2", dims=[2, 16, 1], predict_idx=["s2", "s3"]),
+    ]
+    frames = {
+        "task1": pd.DataFrame({"task1": np.arange(20.0)}, index=list(COMPOSITIONS)),
+        "task2": pd.DataFrame({"task2": np.arange(20.0)}, index=list(COMPOSITIONS)),
+    }
+    dm = build_dm(descriptors_df, task_frames=frames, configs=configs)
+    dm.setup(stage="predict")
+    # Union of the two per-task subsets, in master order.
+    assert dm.predict_compositions == ["s0", "s1", "s2", "s3"]
+
+
+def test_predict_explicit_subset_with_predict_only_composition(descriptors_df):
+    # s99 has no task target but is a requested predict composition; it must still get a descriptor.
+    desc = pd.concat([descriptors_df, pd.DataFrame({"f1": [0.5], "f2": [0.5]}, index=["s99"])])
+    configs = [RegressionTaskConfig(name="task1", data_column="task1", dims=[2, 16, 1], predict_idx=["s0", "s99"])]
+    dm = build_dm(desc, task_frames={"task1": _reg_cls_frames()["task1"]}, configs=configs)
+    dm.setup(stage="predict")
+    assert set(dm.predict_compositions) == {"s0", "s99"}
+
+
+# --- dataloaders ------------------------------------------------------------
+
+
+def test_dataloaders_created(descriptors_df, reg_cls_configs):
+    split = ["train"] * 10 + ["val"] * 5 + ["test"] * 5
+    dm = build_dm(descriptors_df, task_frames=_reg_cls_frames(split=split), configs=reg_cls_configs)
+    dm.setup()
     assert dm.train_dataloader() is not None
     assert dm.val_dataloader() is not None
     assert dm.test_dataloader() is not None
-    dm.setup(stage="predict")  # Ensure predict_dataset is created
+    dm.setup(stage="predict")
     assert dm.predict_dataloader() is not None
 
 
-# Keep other existing tests like load_data_from_paths, load_data_numpy_array, etc.
-# They might need fixture updates if they used base_attributes_df directly.
-# For brevity, I'm focusing on the core logic changes.
-# The test_datamodule_empty_dataset_returns_none_dataloader should still be relevant.
-# test_datamodule_task_masking_ratios_propagation needs attributes_df_full_match.
-# test_datamodule_structure_usage_in_dataset needs attributes_df_full_match.
+def test_empty_dataset_returns_none_dataloader(descriptors_df, reg_cls_configs):
+    dm = build_dm(descriptors_df, task_frames=_reg_cls_frames(), configs=reg_cls_configs)
+    dm.train_dataset = None
+    dm.val_dataset = None
+    dm.test_dataset = None
+    dm.predict_dataset = None
+    assert dm.train_dataloader() is None
+    assert dm.val_dataloader() is None
+    assert dm.test_dataloader() is None
+    assert dm.predict_dataloader() is None
 
 
-def test_datamodule_load_data_from_paths(
-    temp_files_dir, base_formula_df, attributes_df_full_match, sample_task_configs_dm
-):
-    formula_pkl_path = os.path.join(temp_files_dir, "formula.pkl")
-    attributes_csv_path = os.path.join(temp_files_dir, "attributes.csv")
-    base_formula_df.to_pickle(formula_pkl_path)
-    attributes_df_full_match.to_csv(attributes_csv_path)
-
-    dm = CompoundDataModule(
-        formula_desc_source=formula_pkl_path,
-        attributes_source=attributes_csv_path,
-        task_configs=sample_task_configs_dm,
-    )
-    assert dm.formula_df is not None
-    pd.testing.assert_frame_equal(dm.formula_df, base_formula_df, check_dtype=False)
-    assert dm.attributes_df is not None
-    # Check that the loaded attributes_df matches the original
-    pd.testing.assert_frame_equal(dm.attributes_df, attributes_df_full_match, check_dtype=False)
+# --- task type behavior -----------------------------------------------------
 
 
-def test_datamodule_task_masking_ratios_propagation(base_formula_df, attributes_df_full_match, sample_task_configs_dm):
-    mask_ratios = {"task1": 0.5}
-    dm = CompoundDataModule(
-        formula_desc_source=base_formula_df,
-        attributes_source=attributes_df_full_match,
-        task_configs=sample_task_configs_dm,
-        task_masking_ratios=mask_ratios,
-    )
-    dm.setup(stage="fit")
-    assert dm.train_dataset is not None
-    assert dm.train_dataset.task_masking_ratios == mask_ratios
-    assert dm.val_dataset is not None
-    assert dm.val_dataset.task_masking_ratios is None
+def test_autoencoder_rides_along_with_supervised(descriptors_df):
+    configs = [
+        AutoEncoderTaskConfig(name="ae_task", dims=[2, 4, 2]),
+        RegressionTaskConfig(name="reg_task", data_column="reg_task", dims=[2, 16, 1]),
+    ]
+    frames = {"reg_task": pd.DataFrame({"reg_task": np.arange(20.0)}, index=list(COMPOSITIONS))}
+    dm = build_dm(descriptors_df, task_frames=frames, configs=configs, test_all=True)
     dm.setup(stage="test")
-    assert dm.test_dataset is not None
-    assert dm.test_dataset.task_masking_ratios is None
-    dm.setup(stage="predict")
-    assert dm.predict_dataset is not None
-    assert dm.predict_dataset.task_masking_ratios is None
-
-
-def test_datamodule_task_masking_ratio_float_applies_all_tasks(
-    base_formula_df, attributes_df_full_match, sample_task_configs_dm
-):
-    mask_ratio = 0.25
-    dm = CompoundDataModule(
-        formula_desc_source=base_formula_df,
-        attributes_source=attributes_df_full_match,
-        task_configs=sample_task_configs_dm,
-        task_masking_ratios=mask_ratio,
-    )
-    dm.setup(stage="fit")
-    assert dm.train_dataset is not None
-    expected = {cfg.name: mask_ratio for cfg in sample_task_configs_dm if getattr(cfg, "enabled", True)}
-    assert dm.train_dataset.task_masking_ratios == expected
-
-
-def test_datamodule_empty_dataset_returns_none_dataloader(base_formula_df, sample_task_configs_no_seq_dm, caplog):
-    # --- Loguru to caplog bridge (local to this test) ---
-    class PropagateHandler(logging.Handler):
-        def emit(self, record):
-            logging.getLogger(record.name).handle(record)
-
-    handler_id = loguru_logger.add(PropagateHandler(), format="{message}", level="INFO")
-    # --- End bridge ---
-
-    try:
-        # Initialize DM with valid, non-empty formula_df to pass __init__
-        dm = CompoundDataModule(
-            formula_desc_source=base_formula_df,
-            attributes_source=None,  # attributes_source can be None
-            task_configs=sample_task_configs_no_seq_dm,
-        )
-
-        # Manually set dataset attributes to None to directly test dataloader guard clauses.
-        # This bypasses the setup logic for creating these datasets, focusing only on the dataloader methods' behavior.
-        dm.train_dataset = None
-        dm.val_dataset = None
-        dm.test_dataset = None
-        dm.predict_dataset = None  # predict_dataset is also an attribute that can be None
-
-        assert dm.train_dataloader() is None, "Train dataloader should be None when train_dataset is None"
-        assert any(
-            "train_dataloader: Train dataset is None or not initialized" in rec.message
-            for rec in caplog.records
-            if rec.levelname == "WARNING"
-        ), "Expected log for None train_dataset not found"
-        caplog.clear()
-
-        assert dm.val_dataloader() is None, "Validation dataloader should be None when val_dataset is None"
-        assert any(
-            "val_dataloader: Validation dataset is None or not initialized" in rec.message
-            for rec in caplog.records
-            if rec.levelname == "INFO"
-        ), "Expected log for None val_dataset not found"
-        caplog.clear()
-
-        assert dm.test_dataloader() is None, "Test dataloader should be None when test_dataset is None"
-        assert any(
-            "test_dataloader: Test dataset is None or not initialized" in rec.message
-            for rec in caplog.records
-            if rec.levelname == "INFO"
-        ), "Expected log for None test_dataset not found"
-        caplog.clear()
-
-        assert dm.predict_dataloader() is None, "Predict dataloader should be None when predict_dataset is None"
-        assert any(
-            "predict_dataloader: Predict dataset is None or not initialized" in rec.message
-            for rec in caplog.records
-            if rec.levelname == "INFO"
-        ), "Expected log for None predict_dataset not found"
-    finally:
-        loguru_logger.remove(handler_id)  # Clean up the handler
-
-
-# ============================================================================
-# Tests for DistributedSampler support (multi-GPU training)
-# ============================================================================
-
-
-class TestDataModuleSingleGPUMode:
-    """Test DataModule behavior in single GPU/CPU mode (no DistributedSampler)."""
-
-    def test_train_dataloader_no_sampler_single_gpu(self, base_formula_df, attributes_df_full_match):
-        """Test that train_dataloader doesn't use sampler in single GPU mode."""
-        from unittest.mock import patch
-
-        # Mock distributed environment as NOT initialized
-        with patch("torch.distributed.is_available", return_value=False):
-            with patch("torch.distributed.is_initialized", return_value=False):
-                dm = CompoundDataModule(
-                    formula_desc_source=base_formula_df,
-                    attributes_source=attributes_df_full_match,
-                    task_configs=[
-                        RegressionTaskConfig(name="r1", data_column="r1", dims=[2, 16, 1]),
-                    ],
-                    batch_size=4,
-                    num_workers=0,
-                    val_split=0.2,
-                    test_split=0.2,
-                    random_seed=42,
-                )
-
-                dm.setup(stage="fit")
-                train_loader = dm.train_dataloader()
-
-                # Verify no DistributedSampler is used
-                # Note: PyTorch DataLoader creates a RandomSampler internally when shuffle=True
-                from torch.utils.data.distributed import DistributedSampler
-
-                assert not isinstance(train_loader.sampler, DistributedSampler), (
-                    "Single GPU should not use DistributedSampler"
-                )
-
-    def test_val_dataloader_no_sampler_single_gpu(self, base_formula_df, attributes_df_full_match):
-        """Test that val_dataloader doesn't use sampler in single GPU mode."""
-        from unittest.mock import patch
-
-        with patch("torch.distributed.is_available", return_value=False):
-            with patch("torch.distributed.is_initialized", return_value=False):
-                dm = CompoundDataModule(
-                    formula_desc_source=base_formula_df,
-                    attributes_source=attributes_df_full_match,
-                    task_configs=[
-                        RegressionTaskConfig(name="r1", data_column="r1", dims=[2, 16, 1]),
-                    ],
-                    batch_size=4,
-                    num_workers=0,
-                    val_split=0.2,
-                    test_split=0.2,
-                    random_seed=42,
-                )
-
-                dm.setup(stage="fit")
-                val_loader = dm.val_dataloader()
-
-                from torch.utils.data.distributed import DistributedSampler
-
-                assert not isinstance(val_loader.sampler, DistributedSampler), (
-                    "Single GPU validation should not use DistributedSampler"
-                )
-
-    def test_test_dataloader_no_sampler_single_gpu(self, base_formula_df, attributes_df_full_match):
-        """Test that test_dataloader doesn't use sampler in single GPU mode."""
-        from unittest.mock import patch
-
-        with patch("torch.distributed.is_available", return_value=False):
-            with patch("torch.distributed.is_initialized", return_value=False):
-                dm = CompoundDataModule(
-                    formula_desc_source=base_formula_df,
-                    attributes_source=attributes_df_full_match,
-                    task_configs=[
-                        RegressionTaskConfig(name="r1", data_column="r1", dims=[2, 16, 1]),
-                    ],
-                    batch_size=4,
-                    num_workers=0,
-                    val_split=0.2,
-                    test_split=0.2,
-                    random_seed=42,
-                )
-
-                dm.setup(stage="test")
-                test_loader = dm.test_dataloader()
-
-                from torch.utils.data.distributed import DistributedSampler
-
-                assert not isinstance(test_loader.sampler, DistributedSampler), (
-                    "Single GPU test should not use DistributedSampler"
-                )
-
-    def test_predict_dataloader_no_sampler_single_gpu(self, base_formula_df, attributes_df_full_match):
-        """Test that predict_dataloader doesn't use DistributedSampler in single GPU mode."""
-        from unittest.mock import patch
-
-        with patch("torch.distributed.is_available", return_value=False):
-            with patch("torch.distributed.is_initialized", return_value=False):
-                dm = CompoundDataModule(
-                    formula_desc_source=base_formula_df,
-                    attributes_source=attributes_df_full_match,
-                    task_configs=[
-                        RegressionTaskConfig(name="r1", data_column="r1", dims=[2, 16, 1]),
-                    ],
-                    batch_size=4,
-                    num_workers=0,
-                    predict_idx="all",
-                    val_split=0.2,
-                    test_split=0.2,
-                    random_seed=42,
-                )
-
-                dm.setup(stage="predict")
-                predict_loader = dm.predict_dataloader()
-
-                from torch.utils.data.distributed import DistributedSampler
-
-                assert not isinstance(predict_loader.sampler, DistributedSampler), (
-                    "Single GPU predict should not use DistributedSampler"
-                )
-
-
-class TestDataModuleDistributedMode:
-    """Test DataModule behavior in distributed (multi-GPU) mode."""
-
-    def test_train_dataloader_uses_distributed_sampler(self, base_formula_df, attributes_df_full_match):
-        """Test that train_dataloader uses DistributedSampler in multi-GPU mode."""
-        from unittest.mock import patch
-
-        from torch.utils.data.distributed import DistributedSampler
-
-        # Patch in foundation_model.data.datamodule where torch.distributed is actually used
-        with patch("foundation_model.data.datamodule.torch.distributed.is_available", return_value=True):
-            with patch("foundation_model.data.datamodule.torch.distributed.is_initialized", return_value=True):
-                with patch("torch.distributed.get_rank", return_value=0):
-                    with patch("torch.distributed.get_world_size", return_value=2):
-                        dm = CompoundDataModule(
-                            formula_desc_source=base_formula_df,
-                            attributes_source=attributes_df_full_match,
-                            task_configs=[
-                                RegressionTaskConfig(name="r1", data_column="r1", dims=[2, 16, 1]),
-                            ],
-                            batch_size=4,
-                            num_workers=0,
-                            val_split=0.2,
-                            test_split=0.2,
-                            random_seed=42,
-                        )
-
-                        dm.setup(stage="fit")
-                        train_loader = dm.train_dataloader()
-
-                        # Verify DistributedSampler is used
-                        assert train_loader.sampler is not None, "Multi-GPU should use sampler"
-                        assert isinstance(train_loader.sampler, DistributedSampler), (
-                            "Should use DistributedSampler in multi-GPU mode"
-                        )
-
-                        # Verify sampler settings
-                        sampler = train_loader.sampler
-                        assert sampler.shuffle is True, "Training sampler should shuffle"
-                        assert sampler.drop_last is False, "Should keep all samples (drop_last=False)"
-
-    def test_val_dataloader_uses_distributed_sampler(self, base_formula_df, attributes_df_full_match):
-        """Test that val_dataloader uses DistributedSampler in multi-GPU mode."""
-        from unittest.mock import patch
-
-        from torch.utils.data.distributed import DistributedSampler
-
-        # Patch in foundation_model.data.datamodule where torch.distributed is actually used
-        with patch("foundation_model.data.datamodule.torch.distributed.is_available", return_value=True):
-            with patch("foundation_model.data.datamodule.torch.distributed.is_initialized", return_value=True):
-                with patch("torch.distributed.get_rank", return_value=0):
-                    with patch("torch.distributed.get_world_size", return_value=2):
-                        dm = CompoundDataModule(
-                            formula_desc_source=base_formula_df,
-                            attributes_source=attributes_df_full_match,
-                            task_configs=[
-                                RegressionTaskConfig(name="r1", data_column="r1", dims=[2, 16, 1]),
-                            ],
-                            batch_size=4,
-                            num_workers=0,
-                            val_split=0.2,
-                            test_split=0.2,
-                            random_seed=42,
-                        )
-
-                        dm.setup(stage="fit")
-                        val_loader = dm.val_dataloader()
-
-                        assert val_loader.sampler is not None
-                        assert isinstance(val_loader.sampler, DistributedSampler)
-
-                        # Verify sampler settings for validation
-                        sampler = val_loader.sampler
-                        assert sampler.shuffle is False, "Validation sampler should not shuffle"
-                        assert sampler.drop_last is False, "Should keep all samples"
-
-    def test_test_dataloader_uses_distributed_sampler(self, base_formula_df, attributes_df_full_match):
-        """Test that test_dataloader uses DistributedSampler in multi-GPU mode."""
-        from unittest.mock import patch
-
-        from torch.utils.data.distributed import DistributedSampler
-
-        # Patch in foundation_model.data.datamodule where torch.distributed is actually used
-        with patch("foundation_model.data.datamodule.torch.distributed.is_available", return_value=True):
-            with patch("foundation_model.data.datamodule.torch.distributed.is_initialized", return_value=True):
-                with patch("torch.distributed.get_rank", return_value=0):
-                    with patch("torch.distributed.get_world_size", return_value=2):
-                        dm = CompoundDataModule(
-                            formula_desc_source=base_formula_df,
-                            attributes_source=attributes_df_full_match,
-                            task_configs=[
-                                RegressionTaskConfig(name="r1", data_column="r1", dims=[2, 16, 1]),
-                            ],
-                            batch_size=4,
-                            num_workers=0,
-                            val_split=0.2,
-                            test_split=0.2,
-                            random_seed=42,
-                        )
-
-                        dm.setup(stage="test")
-                        test_loader = dm.test_dataloader()
-
-                        assert test_loader.sampler is not None
-                        assert isinstance(test_loader.sampler, DistributedSampler)
-
-                        # Verify sampler settings for test
-                        sampler = test_loader.sampler
-                        assert sampler.shuffle is False, "Test sampler should not shuffle"
-                        assert sampler.drop_last is False, "Should keep all samples"
-
-    def test_predict_dataloader_uses_distributed_sampler(self, base_formula_df, attributes_df_full_match):
-        """Test that predict_dataloader uses DistributedSampler in multi-GPU mode."""
-        from unittest.mock import patch
-
-        from torch.utils.data.distributed import DistributedSampler
-
-        # Patch in foundation_model.data.datamodule where torch.distributed is actually used
-        with patch("foundation_model.data.datamodule.torch.distributed.is_available", return_value=True):
-            with patch("foundation_model.data.datamodule.torch.distributed.is_initialized", return_value=True):
-                with patch("torch.distributed.get_rank", return_value=0):
-                    with patch("torch.distributed.get_world_size", return_value=2):
-                        dm = CompoundDataModule(
-                            formula_desc_source=base_formula_df,
-                            attributes_source=attributes_df_full_match,
-                            task_configs=[
-                                RegressionTaskConfig(name="r1", data_column="r1", dims=[2, 16, 1]),
-                            ],
-                            batch_size=4,
-                            num_workers=0,
-                            predict_idx="all",  # Predict on all data
-                            val_split=0.2,
-                            test_split=0.2,
-                            random_seed=42,
-                        )
-
-                        dm.setup(stage="predict")
-                        predict_loader = dm.predict_dataloader()
-
-                        assert predict_loader.sampler is not None
-                        assert isinstance(predict_loader.sampler, DistributedSampler)
-
-                        # Verify sampler settings for predict
-                        sampler = predict_loader.sampler
-                        assert sampler.shuffle is False, "Predict sampler should not shuffle"
-                        assert sampler.drop_last is False, "Should keep all samples"
-
-
-class TestDistributedSamplerDataCoverage:
-    """Test that DistributedSampler covers all data correctly across ranks."""
-
-    def test_all_samples_covered_across_ranks(self, base_formula_df, attributes_df_full_match):
-        """Test that all samples are covered when combining all ranks."""
-        from unittest.mock import patch
-
-        world_size = 3  # Simulate 3 GPUs
-
-        # Setup datamodule first (without distributed mode)
-        dm = CompoundDataModule(
-            formula_desc_source=base_formula_df,
-            attributes_source=attributes_df_full_match,
-            task_configs=[
-                RegressionTaskConfig(name="r1", data_column="r1", dims=[2, 16, 1]),
-            ],
-            batch_size=4,
-            num_workers=0,
-            val_split=0.2,
-            test_split=0.2,
-            random_seed=42,
-        )
-
-        dm.setup(stage="test")
-
-        # Simulate getting samplers for different ranks
-        all_indices = []
-        for rank in range(world_size):
-            # Patch in foundation_model.data.datamodule for each rank
-            with patch("foundation_model.data.datamodule.torch.distributed.is_available", return_value=True):
-                with patch("foundation_model.data.datamodule.torch.distributed.is_initialized", return_value=True):
-                    with patch("torch.distributed.get_rank", return_value=rank):
-                        with patch("torch.distributed.get_world_size", return_value=world_size):
-                            test_loader = dm.test_dataloader()
-                            sampler = test_loader.sampler
-
-                            # Get indices for this rank
-                            indices = list(sampler)
-                            all_indices.extend(indices)
-
-        # Remove duplicates (from padding)
-        unique_indices = sorted(set(all_indices))
-        test_dataset_size = len(dm.test_dataset)
-
-        # Verify all samples are covered
-        assert len(unique_indices) == test_dataset_size, (
-            f"All {test_dataset_size} samples should be covered, but only {len(unique_indices)} unique indices found"
-        )
-        assert unique_indices == list(range(test_dataset_size)), "Should cover indices 0 to n-1"
-
-    def test_no_overlap_between_ranks_except_padding(self, base_formula_df, attributes_df_full_match):
-        """Test that different ranks process different data (except for padding)."""
-        from unittest.mock import patch
-
-        world_size = 3
-
-        # Setup datamodule first (without distributed mode)
-        dm = CompoundDataModule(
-            formula_desc_source=base_formula_df,
-            attributes_source=attributes_df_full_match,
-            task_configs=[
-                RegressionTaskConfig(name="r1", data_column="r1", dims=[2, 16, 1]),
-            ],
-            batch_size=4,
-            num_workers=0,
-            val_split=0.2,
-            test_split=0.2,
-            random_seed=42,
-        )
-
-        dm.setup(stage="test")
-        test_dataset_size = len(dm.test_dataset)
-
-        rank_indices = {}
-        for rank in range(world_size):
-            # Patch in foundation_model.data.datamodule for each rank
-            with patch("foundation_model.data.datamodule.torch.distributed.is_available", return_value=True):
-                with patch("foundation_model.data.datamodule.torch.distributed.is_initialized", return_value=True):
-                    with patch("torch.distributed.get_rank", return_value=rank):
-                        with patch("torch.distributed.get_world_size", return_value=world_size):
-                            test_loader = dm.test_dataloader()
-                            sampler = test_loader.sampler
-                            rank_indices[rank] = list(sampler)
-
-        # Check overlap - should only be padding at the end
-        for rank_a in range(world_size):
-            for rank_b in range(rank_a + 1, world_size):
-                overlap = set(rank_indices[rank_a]) & set(rank_indices[rank_b])
-                # Overlap should only occur due to padding
-                if len(overlap) > 0:
-                    # Verify overlapping indices are due to padding (repeated from beginning)
-                    assert all(idx < (test_dataset_size % world_size) for idx in overlap), (
-                        "Overlap should only be padding indices"
-                    )
-
-    def test_uneven_dataset_distribution(self):
-        """Test correct handling when dataset size is not divisible by world_size."""
-        from unittest.mock import patch
-
-        # Create data with 17 samples (17 % 3 = 2, so 2 samples will be padded)
-        formula_df = pd.DataFrame(
-            {"f1": np.random.rand(17), "f2": np.random.rand(17)}, index=[f"s{i}" for i in range(17)]
-        )
-        attr_df = pd.DataFrame({"r1": np.random.rand(17)}, index=[f"s{i}" for i in range(17)])
-
-        world_size = 3
-
-        # Setup datamodule first (without distributed mode)
-        dm = CompoundDataModule(
-            formula_desc_source=formula_df,
-            attributes_source=attr_df,
-            task_configs=[
-                RegressionTaskConfig(name="r1", data_column="r1", dims=[2, 16, 1]),
-            ],
-            batch_size=4,
-            num_workers=0,
-            val_split=0.2,
-            test_split=0.2,
-            random_seed=42,
-        )
-
-        dm.setup(stage="test")
-        test_dataset_size = len(dm.test_dataset)
-
-        # Collect indices from all ranks
-        all_indices = []
-        samples_per_rank = []
-
-        for rank in range(world_size):
-            # Patch in foundation_model.data.datamodule for each rank
-            with patch("foundation_model.data.datamodule.torch.distributed.is_available", return_value=True):
-                with patch("foundation_model.data.datamodule.torch.distributed.is_initialized", return_value=True):
-                    with patch("torch.distributed.get_rank", return_value=rank):
-                        with patch("torch.distributed.get_world_size", return_value=world_size):
-                            test_loader = dm.test_dataloader()
-                            sampler = test_loader.sampler
-                            indices = list(sampler)
-                            samples_per_rank.append(len(indices))
-                            all_indices.extend(indices)
-
-        # Each rank should have equal samples (with padding)
-        assert all(count == samples_per_rank[0] for count in samples_per_rank), (
-            "All ranks should process equal number of samples (with padding)"
-        )
-
-        # After deduplication, should have exactly test_dataset_size samples
-        unique_indices = set(all_indices)
-        assert len(unique_indices) == test_dataset_size, (
-            f"After deduplication, should have {test_dataset_size} unique samples, got {len(unique_indices)}"
-        )
-
-
-def test_datamodule_with_autoencoder_task(tmp_path):
-    # Create dummy data
-    n_samples = 10
-    input_dim = 5
-    formula_desc = pd.DataFrame(
-        torch.randn(n_samples, input_dim).numpy(), index=[f"sample_{i}" for i in range(n_samples)]
-    )
-
-    # Save to file
-    formula_path = tmp_path / "formula.pkl"
-    formula_desc.to_pickle(formula_path)
-
-    # Task Configs
-    ae_task = AutoEncoderTaskConfig(name="ae_task", dims=[input_dim, 4, input_dim], loss_weight=1.0)
-
-    # Initialize DataModule with ONLY AutoEncoder task
-    # attributes_source is None
-    dm = CompoundDataModule(
-        formula_desc_source=str(formula_path), task_configs=[ae_task], attributes_source=None, batch_size=2
-    )
-
-    dm.setup(stage="fit")
-
-    train_loader = dm.train_dataloader()
-    batch = next(iter(train_loader))
-
-    # Batch structure: x, y_dict_batch, task_masks_batch, task_sequence_data_batch
-    x, y_dict, masks, t_seqs = batch
-
-    assert x.shape == (2, input_dim)
-    # y_dict should be empty for AE task
-    assert "ae_task" not in y_dict
-    # masks should be empty for AE task
-    assert "ae_task" not in masks
-
-
-def test_datamodule_with_mixed_tasks(tmp_path):
-    # Create dummy data
-    n_samples = 10
-    input_dim = 5
-    formula_desc = pd.DataFrame(
-        torch.randn(n_samples, input_dim).numpy(), index=[f"sample_{i}" for i in range(n_samples)]
-    )
-
-    attributes = pd.DataFrame(
-        {"target": torch.randn(n_samples).numpy()}, index=[f"sample_{i}" for i in range(n_samples)]
-    )
-
-    # Save to file
-    formula_path = tmp_path / "formula.pkl"
-    formula_desc.to_pickle(formula_path)
-    attr_path = tmp_path / "attr.pkl"
-    attributes.to_pickle(attr_path)
-
-    # Task Configs
-    ae_task = AutoEncoderTaskConfig(name="ae_task", dims=[input_dim, 4, input_dim], loss_weight=1.0)
-    reg_task = RegressionTaskConfig(name="reg_task", dims=[input_dim, 1], data_column="target")
-
-    # Initialize DataModule with mixed tasks
-    dm = CompoundDataModule(
-        formula_desc_source=str(formula_path),
-        task_configs=[ae_task, reg_task],
-        attributes_source=str(attr_path),
-        batch_size=2,
-    )
-
-    dm.setup(stage="fit")
-
-    train_loader = dm.train_dataloader()
-    batch = next(iter(train_loader))
-
-    x, y_dict, masks, t_seqs = batch
-
-    assert x.shape == (2, input_dim)
-    # y_dict should contain reg_task but not ae_task
+    loader = dm.test_dataloader()
+    x, y_dict, masks, _ = next(iter(loader))
+    assert x.shape[1] == 2
+    # AE task contributes no target/mask; the supervised task does.
+    assert "reg_task" in y_dict and "ae_task" not in y_dict
+    assert "reg_task" in masks and "ae_task" not in masks
+
+
+def test_mixed_tasks_batch_structure(descriptors_df):
+    configs = [
+        AutoEncoderTaskConfig(name="ae_task", dims=[2, 4, 2]),
+        RegressionTaskConfig(name="reg_task", data_column="reg_task", dims=[2, 16, 1]),
+    ]
+    frames = {"reg_task": pd.DataFrame({"reg_task": np.arange(20.0)}, index=list(COMPOSITIONS))}
+    dm = build_dm(descriptors_df, task_frames=frames, configs=configs, batch_size=4, test_all=True)
+    dm.setup(stage="test")
+    x, y_dict, masks, t_seqs = next(iter(dm.test_dataloader()))
+    assert x.shape == (4, 2)
     assert "reg_task" in y_dict
-    assert "ae_task" not in y_dict
 
-    assert "reg_task" in masks
-    assert "ae_task" not in masks
+
+# --- DistributedSampler coverage --------------------------------------------
+
+
+def _ddp_dm(descriptors_df):
+    split = ["train"] * 10 + ["val"] * 5 + ["test"] * 5
+    return build_dm(
+        descriptors_df,
+        task_frames=_reg_cls_frames(split=split),
+        configs=[RegressionTaskConfig(name="task1", data_column="task1", dims=[2, 16, 1])],
+        batch_size=4,
+    )
+
+
+def test_single_gpu_no_distributed_sampler(descriptors_df):
+    with patch("torch.distributed.is_available", return_value=False):
+        with patch("torch.distributed.is_initialized", return_value=False):
+            dm = _ddp_dm(descriptors_df)
+            dm.setup(stage="fit")
+            loader = dm.train_dataloader()
+            assert not isinstance(loader.sampler, DistributedSampler)
+
+
+def test_multi_gpu_uses_distributed_sampler(descriptors_df):
+    with patch("foundation_model.data.datamodule.torch.distributed.is_available", return_value=True):
+        with patch("foundation_model.data.datamodule.torch.distributed.is_initialized", return_value=True):
+            with patch("torch.distributed.get_rank", return_value=0):
+                with patch("torch.distributed.get_world_size", return_value=2):
+                    dm = _ddp_dm(descriptors_df)
+                    dm.setup(stage="fit")
+                    loader = dm.train_dataloader()
+                    assert isinstance(loader.sampler, DistributedSampler)
+                    assert loader.sampler.shuffle is True
+                    assert loader.sampler.drop_last is False
+
+
+def test_multi_gpu_val_sampler_no_shuffle(descriptors_df):
+    with patch("foundation_model.data.datamodule.torch.distributed.is_available", return_value=True):
+        with patch("foundation_model.data.datamodule.torch.distributed.is_initialized", return_value=True):
+            with patch("torch.distributed.get_rank", return_value=0):
+                with patch("torch.distributed.get_world_size", return_value=2):
+                    dm = _ddp_dm(descriptors_df)
+                    dm.setup(stage="fit")
+                    loader = dm.val_dataloader()
+                    assert isinstance(loader.sampler, DistributedSampler)
+                    assert loader.sampler.shuffle is False

--- a/src/foundation_model/data/datamodule_test.py
+++ b/src/foundation_model/data/datamodule_test.py
@@ -98,6 +98,22 @@ def test_init_rejects_bad_swap_ratio(descriptors_df, reg_cls_configs):
         build_dm(descriptors_df, configs=reg_cls_configs, swap_train_val_split=1.5)
 
 
+@pytest.mark.parametrize("kwargs", [{"val_split": -0.1}, {"test_split": 1.5}, {"val_split": 0.6, "test_split": 0.6}])
+def test_init_rejects_bad_split_bounds(descriptors_df, reg_cls_configs, kwargs):
+    with pytest.raises(ValueError, match="split"):
+        build_dm(descriptors_df, configs=reg_cls_configs, **kwargs)
+
+
+def test_in_memory_frame_dedupes_duplicate_compositions(descriptors_df):
+    configs = [RegressionTaskConfig(name="task1", data_column="task1", dims=[2, 16, 1])]
+    # Duplicate composition "s0" with conflicting values; keep-first must win.
+    frame = pd.DataFrame({"task1": [10.0, 99.0, 20.0]}, index=pd.Index(["s0", "s0", "s1"], name="composition"))
+    dm = build_dm(descriptors_df, task_frames={"task1": frame}, configs=configs, test_all=True)
+    dm.setup(stage="test")
+    assert dm._task_frames["task1"].loc["s0", "task1"] == 10.0
+    assert not dm._task_frames["task1"].index.duplicated().any()
+
+
 # --- sources & descriptors --------------------------------------------------
 
 

--- a/src/foundation_model/data/dataset.py
+++ b/src/foundation_model/data/dataset.py
@@ -1,5 +1,5 @@
 import ast  # For safely evaluating string representations of lists/arrays
-from typing import Dict, List
+from typing import Dict, List, Mapping, Sequence
 
 import numpy as np
 import pandas as pd
@@ -86,12 +86,43 @@ def _parse_structured_element(
 
 
 class CompoundDataset(Dataset):
+    """Composition-keyed dataset for the multi-task model.
+
+    Alignment happens at construction: ``descriptors`` and every per-task frame are reindexed
+    to ``compositions`` (the sample order / dataset length for this split). Compositions absent
+    from a task's frame become NaN rows and are masked out for that task. ``__getitem__`` then
+    fetches positionally from these aligned structures, yielding the unchanged batch tuple
+    ``(x_formula, y_dict, task_masks_dict, t_sequences_dict)``.
+
+    Parameters
+    ----------
+    compositions : Sequence[str]
+        Composition keys defining the sample order and dataset length for this split.
+    descriptors : pd.DataFrame
+        Descriptor features indexed by composition. Must cover every entry in ``compositions``.
+    task_frames : Mapping[str, pd.DataFrame]
+        Per-task data frames indexed by composition (each holding the task's ``data_column``,
+        optional ``t_column``, etc.). Tasks absent here (or AUTOENCODER tasks) get placeholders.
+    task_configs : Sequence
+        Task configuration objects.
+    task_masking_ratios : Mapping[str, float] | None
+        Optional per-task keep ratios applied during training only.
+    task_masking_seed : int | None
+        Seed for deterministic random task masking.
+    is_predict_set : bool
+        When True, disables random task masking (masks come from NaN presence only).
+    dataset_name : str
+        Label used in log messages.
+    """
+
     def __init__(
         self,
-        formula_desc: pd.DataFrame | np.ndarray,
-        attributes: pd.DataFrame,  # Contains targets, series, temps, masks
-        task_configs: List,  # List of task configuration objects
-        task_masking_ratios: Dict[str, float] | None = None,
+        compositions: Sequence[str],
+        descriptors: pd.DataFrame,
+        task_frames: Mapping[str, pd.DataFrame],
+        task_configs: List,
+        *,
+        task_masking_ratios: Mapping[str, float] | None = None,
         task_masking_seed: int | None = None,
         is_predict_set: bool = False,
         dataset_name: str = "dataset",
@@ -105,41 +136,46 @@ class CompoundDataset(Dataset):
         if self._task_masking_rng is not None:
             logger.info(f"[{self.dataset_name}] Task masking RNG seeded with {task_masking_seed}.")
 
-        # --- Input Validation (remains largely the same) ---
-        if not isinstance(formula_desc, (pd.DataFrame, np.ndarray)):
-            logger.error(f"[{self.dataset_name}] formula_desc type error: {type(formula_desc)}")
-            raise TypeError("formula_desc must be pd.DataFrame or np.ndarray")
-        if hasattr(formula_desc, "empty") and formula_desc.empty:
-            raise ValueError("formula_desc DataFrame cannot be empty.")
-        if isinstance(formula_desc, np.ndarray) and formula_desc.size == 0:
-            raise ValueError("formula_desc np.ndarray cannot be empty.")
-
-        if not isinstance(attributes, pd.DataFrame):
-            logger.error(f"[{self.dataset_name}] attributes type error: {type(attributes)}")
-            raise TypeError("attributes must be pd.DataFrame")
-
-        if not self.is_predict_set:
-            if len(attributes.index) == 0 and len(attributes.columns) == 0 and len(formula_desc) > 0:
-                logger.error(f"[{self.dataset_name}] attributes is a 0x0 DataFrame, but formula_desc has samples.")
-                raise ValueError("attributes DataFrame cannot be empty when formula_desc is not.")
-            if len(attributes.index) == 0 and len(attributes.columns) > 0 and len(formula_desc) > 0:
-                logger.error(f"[{self.dataset_name}] attributes has columns but 0 rows (empty index).")
-                raise ValueError("attributes DataFrame has columns but an empty index (no samples).")
+        # --- Input validation ---
+        if not isinstance(descriptors, pd.DataFrame):
+            logger.error(f"[{self.dataset_name}] descriptors type error: {type(descriptors)}")
+            raise TypeError("descriptors must be a pd.DataFrame")
         if not task_configs:
             raise ValueError("task_configs list cannot be empty.")
 
-        # Convert formula_desc to tensor
-        if isinstance(formula_desc, pd.DataFrame):
-            self.x_formula = torch.tensor(formula_desc.values, dtype=torch.float32)
-        else:  # np.ndarray
-            self.x_formula = torch.tensor(formula_desc, dtype=torch.float32)
+        self.compositions: List[str] = [str(c) for c in compositions]
+        if len(self.compositions) == 0:
+            raise ValueError("compositions cannot be empty.")
+        if descriptors.empty:
+            raise ValueError("descriptors DataFrame cannot be empty.")
 
+        # --- Align descriptors to the composition order ---
+        descriptor_index = descriptors.index.astype(str)
+        descriptors = descriptors.copy()
+        descriptors.index = descriptor_index
+        missing_desc = [c for c in self.compositions if c not in descriptors.index]
+        if missing_desc:
+            preview = ", ".join(missing_desc[:5])
+            raise ValueError(
+                f"[{self.dataset_name}] descriptors is missing {len(missing_desc)} composition(s) "
+                f"required by this split (e.g. {preview})."
+            )
+        x_formula_df = descriptors.loc[self.compositions]
+        self.x_formula = torch.tensor(x_formula_df.values, dtype=torch.float32)
         self.x_struct: torch.Tensor | None = None
         logger.info(f"[{self.dataset_name}] Final x_formula shape: {self.x_formula.shape}")
+
+        # --- Reindex each provided task frame to the composition order ---
+        self._aligned_frames: Dict[str, pd.DataFrame] = {}
+        for task_name, frame in task_frames.items():
+            if frame is None:
+                continue
+            frame = frame.copy()
+            frame.index = frame.index.astype(str)
+            self._aligned_frames[task_name] = frame.reindex(self.compositions)
+
         self.y_dict: Dict[str, torch.Tensor | List[torch.Tensor]] = {}
-        self.t_sequences_dict: Dict[
-            str, torch.Tensor | List[torch.Tensor]
-        ] = {}  # For t-parameter sequences of KernelRegression tasks
+        self.t_sequences_dict: Dict[str, torch.Tensor | List[torch.Tensor]] = {}
         self.task_masks_dict: Dict[str, torch.Tensor | List[torch.Tensor]] = {}
         self.enabled_task_names: List[str] = []
 
@@ -154,9 +190,10 @@ class CompoundDataset(Dataset):
 
             if task_type == TaskType.AUTOENCODER:
                 # AutoEncoder tasks use the input features as target, so no external data loading is needed.
-                # We skip y_dict and task_masks_dict population for this task.
                 # The model handles target generation (x) and masking (ones) internally.
                 continue
+
+            task_frame = self._aligned_frames.get(task_name)
 
             # --- Primary Data Loading (y_dict) using cfg.data_column ---
             data_col_for_task = cfg.data_column
@@ -165,7 +202,7 @@ class CompoundDataset(Dataset):
             if not data_col_for_task:  # Not specified
                 logger.error(f"[{self.dataset_name}] Task '{task_name}': data_column is not specified in config.")
                 raise ValueError(f"data_column for task '{task_name}' must be specified.")
-            elif data_col_for_task not in attributes.columns:  # Specified but not found
+            elif task_frame is None or data_col_for_task not in task_frame.columns:  # Specified but not found
                 if self.is_predict_set:
                     logger.debug(
                         f"[{self.dataset_name}] Task '{task_name}': data_column '{data_col_for_task}' not found. "
@@ -175,12 +212,12 @@ class CompoundDataset(Dataset):
                     logger.warning(
                         f"[{self.dataset_name}] Task '{task_name}': data_column '{data_col_for_task}' not found. Using placeholder values."
                     )
-                raw_column_data = pd.Series([np.nan] * len(attributes), index=attributes.index)
+                raw_column_data = pd.Series([np.nan] * len(self.compositions), index=self.compositions)
             else:
                 logger.debug(
                     f"[{self.dataset_name}] Task '{task_name}': Loading data from column '{data_col_for_task}'."
                 )
-                raw_column_data = attributes[data_col_for_task]
+                raw_column_data = task_frame[data_col_for_task]
 
             # Process data differently based on task type
 
@@ -216,19 +253,19 @@ class CompoundDataset(Dataset):
                 if not t_col_for_task:  # Not specified
                     logger.error(f"[{self.dataset_name}] Task '{task_name}': t_column is not specified in config.")
                     raise ValueError(f"t_column for KernelRegression task '{task_name}' must be specified.")
-                elif t_col_for_task not in attributes.columns:  # Specified but not found
+                elif task_frame is None or t_col_for_task not in task_frame.columns:  # Specified but not found
                     logger.error(
                         f"[{self.dataset_name}] Task '{task_name}': t_column '{t_col_for_task}' "
-                        f"is specified in config but not found in attributes DataFrame."
+                        f"is specified in config but not found in the task data frame."
                     )
                     raise ValueError(
-                        f"T-parameter column '{t_col_for_task}' for task '{task_name}' not found in attributes data."
+                        f"T-parameter column '{t_col_for_task}' for task '{task_name}' not found in task data."
                     )
                 else:  # Column exists, load data
                     logger.debug(
                         f"[{self.dataset_name}] Task '{task_name}': Loading t-parameters from column '{t_col_for_task}'."
                     )
-                    raw_t_data = attributes[t_col_for_task]
+                    raw_t_data = task_frame[t_col_for_task]
                     current_task_t_list = []
                     for element in raw_t_data:
                         # For KernelRegression, we expect variable-length sequences, so don't use expected_t_len
@@ -300,7 +337,6 @@ class CompoundDataset(Dataset):
             num_valid_after_nan_mask = np.sum(final_mask_np)
 
             if self.task_masking_ratios and task_name in self.task_masking_ratios and not self.is_predict_set:
-                # ... (random masking logic remains the same as original) ...
                 ratio_to_keep = self.task_masking_ratios[task_name]
                 logger.info(
                     f"[{self.dataset_name}] Task '{task_name}': Applying random masking "
@@ -321,8 +357,6 @@ class CompoundDataset(Dataset):
                                 valid_indices, size=len(valid_indices) - num_to_keep, replace=False
                             )
                             final_mask_np[indices_to_set_false] = False
-                    # ... (logging for masking)
-                # ... (handle ratio_to_keep == 0.0 or >= 1.0)
 
             if task_type == TaskType.KERNEL_REGRESSION:
                 # For KernelRegression, store masks as List[Tensor] to match y_dict format

--- a/src/foundation_model/data/dataset_test.py
+++ b/src/foundation_model/data/dataset_test.py
@@ -16,16 +16,26 @@ from foundation_model.models.model_config import (
 
 
 @pytest.fixture
-def sample_formula_desc_df():
-    """Returns a sample formula descriptor DataFrame."""
+def sample_compositions():
+    return [f"id_{i}" for i in range(5)]
+
+
+@pytest.fixture
+def sample_descriptors():
+    """Descriptor features indexed by composition."""
     return pd.DataFrame(
-        {"feat_0": [0.1, 0.2, 0.3, 0.4, 0.5], "feat_1": [1.1, 1.2, 1.3, 1.4, 1.5]}, index=[f"id_{i}" for i in range(5)]
+        {"feat_0": [0.1, 0.2, 0.3, 0.4, 0.5], "feat_1": [1.1, 1.2, 1.3, 1.4, 1.5]},
+        index=[f"id_{i}" for i in range(5)],
     )
 
 
 @pytest.fixture
 def sample_attributes_df():
-    """Returns a sample attributes DataFrame with various data types and NaNs."""
+    """A combined attributes frame (indexed by composition) shared across tasks in tests.
+
+    The dataset reads only each task's own ``data_column`` / ``t_column`` from its frame, so a
+    single combined frame can serve as every task's frame without cross-talk.
+    """
     data = {
         # Regression task
         "task_reg_regression_value": [1.0, 2.0, np.nan, 4.0, 5.0],
@@ -66,16 +76,30 @@ def sample_task_configs():
     ]
 
 
+def _task_frames(task_configs, attributes_df):
+    """Build a per-task frame mapping that shares the combined attributes frame."""
+    return {cfg.name: attributes_df for cfg in task_configs}
+
+
+def _make_dataset(compositions, descriptors, task_configs, attributes_df, **kwargs):
+    return CompoundDataset(
+        compositions=compositions,
+        descriptors=descriptors,
+        task_frames=_task_frames(task_configs, attributes_df),
+        task_configs=task_configs,
+        **kwargs,
+    )
+
+
 # --- Test Cases ---
 
 
-def test_dataset_initialization_basic(sample_formula_desc_df, sample_attributes_df, sample_task_configs):
-    """Test basic initialization with formula and attributes."""
-    dataset = CompoundDataset(
-        formula_desc=sample_formula_desc_df,
-        attributes=sample_attributes_df,
-        task_configs=sample_task_configs,
-        dataset_name="test_basic",
+def test_dataset_initialization_basic(
+    sample_compositions, sample_descriptors, sample_attributes_df, sample_task_configs
+):
+    """Test basic initialization with descriptors and per-task frames."""
+    dataset = _make_dataset(
+        sample_compositions, sample_descriptors, sample_task_configs, sample_attributes_df, dataset_name="test_basic"
     )
     assert len(dataset) == 5
     assert dataset.x_formula.shape == (5, 2)
@@ -86,31 +110,27 @@ def test_dataset_initialization_basic(sample_formula_desc_df, sample_attributes_
     assert "task_disabled" not in dataset.enabled_task_names  # Check disabled task
 
 
-def test_task_data_processing_regression(sample_formula_desc_df, sample_attributes_df, sample_task_configs):
+def test_task_data_processing_regression(
+    sample_compositions, sample_descriptors, sample_attributes_df, sample_task_configs
+):
     """Verify y_dict and masks for a regression task."""
-    dataset = CompoundDataset(
-        formula_desc=sample_formula_desc_df,
-        attributes=sample_attributes_df,
-        task_configs=sample_task_configs,
-        dataset_name="test_reg_processing",
+    dataset = _make_dataset(
+        sample_compositions, sample_descriptors, sample_task_configs, sample_attributes_df, dataset_name="test_reg"
     )
     task_name = "task_reg"
     assert task_name in dataset.y_dict
     assert dataset.y_dict[task_name].shape == (5, 1)
-    # Expected values (NaNs become 0)
     expected_y = torch.tensor([[1.0], [2.0], [0.0], [4.0], [5.0]], dtype=torch.float32)
     assert torch.allclose(dataset.y_dict[task_name], expected_y)
 
     assert task_name in dataset.task_masks_dict
     assert dataset.task_masks_dict[task_name].dtype == torch.bool
-    # Expected mask (True where not NaN)
     expected_mask = torch.tensor([[True], [True], [False], [True], [True]], dtype=torch.bool)
     assert torch.equal(dataset.task_masks_dict[task_name], expected_mask)
 
 
-def test_task_data_processing_sequence(sample_formula_desc_df, sample_attributes_df):
-    """Verify y_dict, temps_dict, and masks for a sequence task."""
-    # Create a task config that only includes valid tasks for this test
+def test_task_data_processing_sequence(sample_compositions, sample_descriptors, sample_attributes_df):
+    """Verify y_dict, t_sequences_dict, and masks for a sequence task."""
     valid_task_configs = [
         RegressionTaskConfig(name="task_reg", type=TaskType.REGRESSION, data_column="task_reg_regression_value"),
         KernelRegressionTaskConfig(
@@ -120,75 +140,80 @@ def test_task_data_processing_sequence(sample_formula_desc_df, sample_attributes
             t_column="task_seq_temps",
         ),
     ]
-    dataset = CompoundDataset(
-        formula_desc=sample_formula_desc_df,
-        attributes=sample_attributes_df,
-        task_configs=valid_task_configs,
-        dataset_name="test_seq_processing",
+    dataset = _make_dataset(
+        sample_compositions, sample_descriptors, valid_task_configs, sample_attributes_df, dataset_name="test_seq"
     )
     task_name = "task_seq"
     assert task_name in dataset.y_dict
-    # For KernelRegression, y_dict stores List[Tensor]
     assert isinstance(dataset.y_dict[task_name], list)
-    assert len(dataset.y_dict[task_name]) == 5  # 5 samples
-    # Check first sample
+    assert len(dataset.y_dict[task_name]) == 5
     expected_y_first = torch.tensor([0.1, 0.2, 0.3], dtype=torch.float32)
     assert torch.allclose(dataset.y_dict[task_name][0], expected_y_first)
-    # Check third sample (all NaN becomes 0)
     expected_y_third = torch.tensor([0.0, 0.0, 0.0], dtype=torch.float32)
     assert torch.allclose(dataset.y_dict[task_name][2], expected_y_third)
 
     assert task_name in dataset.t_sequences_dict
-    # For KernelRegression, t_sequences_dict stores List[Tensor], so check the first sample
-    assert len(dataset.t_sequences_dict[task_name]) == 5  # 5 samples
-    expected_temps = torch.tensor([10, 20, 30], dtype=torch.float32)  # Single sample
+    assert len(dataset.t_sequences_dict[task_name]) == 5
+    expected_temps = torch.tensor([10, 20, 30], dtype=torch.float32)
     assert torch.allclose(dataset.t_sequences_dict[task_name][0], expected_temps)
 
     assert task_name in dataset.task_masks_dict
-    # For KernelRegression, task_masks_dict also stores List[Tensor]
     assert isinstance(dataset.task_masks_dict[task_name], list)
     assert len(dataset.task_masks_dict[task_name]) == 5
-    # Check that first sample mask is all True (valid data)
     assert torch.all(dataset.task_masks_dict[task_name][0])
-    # Check that third sample mask is all False (all NaN data)
     assert torch.all(~dataset.task_masks_dict[task_name][2])
 
 
-def test_task_data_processing_missing_columns(sample_formula_desc_df, sample_attributes_df, sample_task_configs):
+def test_task_data_processing_missing_columns(
+    sample_compositions, sample_descriptors, sample_attributes_df, sample_task_configs
+):
     """Test behavior when expected attribute columns for a task are missing."""
-    configs_with_missing = sample_task_configs + [
-        RegressionTaskConfig(
-            name="task_fully_missing_data_col",
-            type=TaskType.REGRESSION,
-            data_column="non_existent_column",
-        )
-    ]
-    dataset = CompoundDataset(
-        formula_desc=sample_formula_desc_df,
-        attributes=sample_attributes_df,
-        task_configs=configs_with_missing,
+    extra = RegressionTaskConfig(
+        name="task_fully_missing_data_col",
+        type=TaskType.REGRESSION,
+        data_column="non_existent_column",
+    )
+    configs_with_missing = sample_task_configs + [extra]
+    dataset = _make_dataset(
+        sample_compositions,
+        sample_descriptors,
+        configs_with_missing,
+        sample_attributes_df,
         dataset_name="test_missing_cols",
     )
     placeholder = dataset.y_dict["task_fully_missing_data_col"]
-    assert placeholder.shape[0] == len(sample_attributes_df)
+    assert placeholder.shape[0] == len(sample_compositions)
     assert torch.allclose(placeholder, torch.zeros_like(placeholder))
     assert not dataset.task_masks_dict["task_fully_missing_data_col"].any()
 
 
-def test_nan_masking(sample_formula_desc_df, sample_attributes_df, sample_task_configs):
-    """Test that NaNs in attributes correctly generate masks."""
-    # (already covered in specific task tests, but good to have a focused one)
+def test_task_frame_missing_compositions_are_masked(sample_compositions, sample_descriptors, sample_attributes_df):
+    """Compositions absent from a task's frame are reindexed to NaN and masked out."""
+    configs = [RegressionTaskConfig(name="task_reg", data_column="task_reg_regression_value")]
+    # Task frame only covers the first two compositions.
+    partial_frame = sample_attributes_df.loc[["id_0", "id_1"]]
     dataset = CompoundDataset(
-        formula_desc=sample_formula_desc_df,
-        attributes=sample_attributes_df,
-        task_configs=sample_task_configs,
-        dataset_name="test_nan_masking",
+        compositions=sample_compositions,
+        descriptors=sample_descriptors,
+        task_frames={"task_reg": partial_frame},
+        task_configs=configs,
+        dataset_name="test_partial_frame",
     )
-    # Regression task 'task_reg'
+    mask = dataset.task_masks_dict["task_reg"].squeeze()
+    # id_0, id_1 valid; id_2..id_4 absent from frame -> masked False.
+    assert mask.tolist() == [True, True, False, False, False]
+    # y for absent compositions is the 0.0 placeholder.
+    assert dataset.y_dict["task_reg"][3].item() == 0.0
+
+
+def test_nan_masking(sample_compositions, sample_descriptors, sample_attributes_df, sample_task_configs):
+    """Test that NaNs in attributes correctly generate masks."""
+    dataset = _make_dataset(
+        sample_compositions, sample_descriptors, sample_task_configs, sample_attributes_df, dataset_name="test_nan"
+    )
     expected_mask_reg = torch.tensor([[True], [True], [False], [True], [True]], dtype=torch.bool)
     assert torch.equal(dataset.task_masks_dict["task_reg"], expected_mask_reg)
 
-    # Sequence task 'task_seq' (mask based on all-NaN sequences)
     expected_mask_seq = torch.tensor([True, True, False, True, True], dtype=torch.bool)
     seq_masks = dataset.task_masks_dict["task_seq"]
     assert isinstance(seq_masks, list)
@@ -196,19 +221,19 @@ def test_nan_masking(sample_formula_desc_df, sample_attributes_df, sample_task_c
     assert torch.equal(actual_seq_mask, expected_mask_seq)
 
 
-def test_ratio_masking_train(sample_formula_desc_df, sample_attributes_df, sample_task_configs):
+def test_ratio_masking_train(sample_compositions, sample_descriptors, sample_attributes_df, sample_task_configs):
     """Test task_masking_ratios for a training dataset."""
-    task_name_to_mask = "task_reg"  # This task has 4 valid samples initially
-    masking_ratios = {task_name_to_mask: 0.5}  # Keep 50% of valid samples
+    task_name_to_mask = "task_reg"  # 4 valid samples initially
+    masking_ratios = {task_name_to_mask: 0.5}
 
-    # Seed for reproducibility of np.random.choice
     np.random.seed(42)
-    dataset = CompoundDataset(
-        formula_desc=sample_formula_desc_df,
-        attributes=sample_attributes_df,
-        task_configs=sample_task_configs,
+    dataset = _make_dataset(
+        sample_compositions,
+        sample_descriptors,
+        sample_task_configs,
+        sample_attributes_df,
         task_masking_ratios=masking_ratios,
-        is_predict_set=False,  # Training mode
+        is_predict_set=False,
         dataset_name="test_ratio_mask_train",
     )
 
@@ -218,43 +243,43 @@ def test_ratio_masking_train(sample_formula_desc_df, sample_attributes_df, sampl
     final_mask = dataset.task_masks_dict[task_name_to_mask].squeeze()
     num_finally_valid = torch.sum(final_mask).item()
 
-    # Expected number to keep is 50% of 4 = 2
-    assert num_finally_valid == int(np.round(num_originally_valid * 0.5))  # Should be 2
-    # Ensure that the False from NaN is still False
+    assert num_finally_valid == int(np.round(num_originally_valid * 0.5))  # 2
     assert not final_mask[2].item()
-    # Ensure that only originally True items could have been set to False
     assert torch.all(final_mask <= original_valid_mask)
 
 
-def test_ratio_masking_predict(sample_formula_desc_df, sample_attributes_df, sample_task_configs):
+def test_ratio_masking_predict(sample_compositions, sample_descriptors, sample_attributes_df, sample_task_configs):
     """Test task_masking_ratios is ignored for a predict dataset."""
     task_name_to_mask = "task_reg"
     masking_ratios = {task_name_to_mask: 0.5}
 
-    dataset = CompoundDataset(
-        formula_desc=sample_formula_desc_df,
-        attributes=sample_attributes_df,
-        task_configs=sample_task_configs,
+    dataset = _make_dataset(
+        sample_compositions,
+        sample_descriptors,
+        sample_task_configs,
+        sample_attributes_df,
         task_masking_ratios=masking_ratios,
-        is_predict_set=True,  # Predict mode
+        is_predict_set=True,
         dataset_name="test_ratio_mask_predict",
     )
-    # Mask should only be based on NaNs, not the ratio
     expected_mask = torch.tensor([[True], [True], [False], [True], [True]], dtype=torch.bool)
     assert torch.equal(dataset.task_masks_dict[task_name_to_mask], expected_mask)
 
 
-def test_task_masking_seed_controls_rng(sample_formula_desc_df, sample_attributes_df, sample_task_configs):
+def test_task_masking_seed_controls_rng(
+    sample_compositions, sample_descriptors, sample_attributes_df, sample_task_configs
+):
     """Ensure task_masking_seed makes masking deterministic."""
     task_name = "task_reg"
     masking_ratio = 0.5
     masking_ratios = {task_name: masking_ratio}
     masking_seed = 123
 
-    dataset_seeded = CompoundDataset(
-        formula_desc=sample_formula_desc_df,
-        attributes=sample_attributes_df,
-        task_configs=sample_task_configs,
+    dataset_seeded = _make_dataset(
+        sample_compositions,
+        sample_descriptors,
+        sample_task_configs,
+        sample_attributes_df,
         task_masking_ratios=masking_ratios,
         task_masking_seed=masking_seed,
         is_predict_set=False,
@@ -273,12 +298,12 @@ def test_task_masking_seed_controls_rng(sample_formula_desc_df, sample_attribute
         expected_mask[indices_to_drop] = False
     assert np.array_equal(final_mask, expected_mask)
 
-    # Changing the global NumPy RNG should not affect the seeded behavior
     np.random.seed(999)
-    dataset_seeded_repeat = CompoundDataset(
-        formula_desc=sample_formula_desc_df,
-        attributes=sample_attributes_df,
-        task_configs=sample_task_configs,
+    dataset_seeded_repeat = _make_dataset(
+        sample_compositions,
+        sample_descriptors,
+        sample_task_configs,
+        sample_attributes_df,
         task_masking_ratios=masking_ratios,
         task_masking_seed=masking_seed,
         is_predict_set=False,
@@ -288,65 +313,60 @@ def test_task_masking_seed_controls_rng(sample_formula_desc_df, sample_attribute
     assert np.array_equal(final_mask, repeated_mask)
 
 
-def test_getitem_predict_mode(sample_formula_desc_df, sample_attributes_df, sample_task_configs):
+def test_getitem_predict_mode(sample_compositions, sample_descriptors, sample_attributes_df, sample_task_configs):
     """Test __getitem__ when is_predict_set=True."""
-    dataset = CompoundDataset(
-        formula_desc=sample_formula_desc_df,
-        attributes=sample_attributes_df,
-        task_configs=sample_task_configs,
+    dataset = _make_dataset(
+        sample_compositions,
+        sample_descriptors,
+        sample_task_configs,
+        sample_attributes_df,
         is_predict_set=True,
         dataset_name="test_getitem_predict",
     )
     model_input_x, y_dict, masks_dict, temps_dict = dataset[0]
 
-    assert isinstance(model_input_x, torch.Tensor)  # Should be just x_formula as no structure is used here
+    assert isinstance(model_input_x, torch.Tensor)
     assert torch.allclose(model_input_x, dataset.x_formula[0])
     assert "task_reg" in y_dict
     assert "task_reg" in masks_dict
 
 
-def test_getitem_train_mode_no_structure(sample_formula_desc_df, sample_attributes_df, sample_task_configs):
+def test_getitem_train_mode_no_structure(
+    sample_compositions, sample_descriptors, sample_attributes_df, sample_task_configs
+):
     """Test __getitem__ for training without structure."""
-    dataset = CompoundDataset(
-        formula_desc=sample_formula_desc_df,
-        attributes=sample_attributes_df,
-        task_configs=sample_task_configs,
+    dataset = _make_dataset(
+        sample_compositions,
+        sample_descriptors,
+        sample_task_configs,
+        sample_attributes_df,
         is_predict_set=False,
-        dataset_name="test_getitem_train_no_struct",
+        dataset_name="test_getitem_train",
     )
     model_input_x, _, _, _ = dataset[0]
     assert isinstance(model_input_x, torch.Tensor)
     assert torch.allclose(model_input_x, dataset.x_formula[0])
 
 
-def test_attribute_names_property(sample_formula_desc_df, sample_attributes_df, sample_task_configs):
+def test_attribute_names_property(sample_compositions, sample_descriptors, sample_attributes_df, sample_task_configs):
     """Test the attribute_names property."""
-    dataset = CompoundDataset(
-        formula_desc=sample_formula_desc_df,
-        attributes=sample_attributes_df,
-        task_configs=sample_task_configs,
-        dataset_name="test_attr_names",
+    dataset = _make_dataset(
+        sample_compositions, sample_descriptors, sample_task_configs, sample_attributes_df, dataset_name="test_attr"
     )
     expected_names = ["task_reg", "task_seq", "task_another_reg"]
     assert sorted(dataset.attribute_names) == sorted(expected_names)
 
 
-def test_input_dtypes_conversion(sample_attributes_df, sample_task_configs):
-    """Test that input DataFrames with different dtypes are converted to float32."""
-    formula_int_df = pd.DataFrame(
-        {
-            "feat_0": [1, 2, 3, 4, 5],
-            "feat_1": [11, 12, 13, 14, 15],
-        },
+def test_input_dtypes_conversion(sample_compositions, sample_attributes_df, sample_task_configs):
+    """Test that descriptor DataFrames with int dtypes are converted to float32."""
+    descriptors_int = pd.DataFrame(
+        {"feat_0": [1, 2, 3, 4, 5], "feat_1": [11, 12, 13, 14, 15]},
         index=[f"id_{i}" for i in range(5)],
         dtype=np.int32,
     )
 
-    dataset = CompoundDataset(
-        formula_desc=formula_int_df,
-        attributes=sample_attributes_df,
-        task_configs=sample_task_configs,
-        dataset_name="test_dtypes",
+    dataset = _make_dataset(
+        sample_compositions, descriptors_int, sample_task_configs, sample_attributes_df, dataset_name="test_dtypes"
     )
 
     assert dataset.x_formula.dtype == torch.float32
@@ -366,122 +386,125 @@ def test_input_dtypes_conversion(sample_attributes_df, sample_task_configs):
         assert temps_list[0].dtype == torch.float32, f"Task {task_name} t_sequences_dict dtype mismatch"
 
 
-# TODO: Add more tests:
-# - Edge case: empty formula_desc or attributes (should raise error or handle gracefully if allowed by design)
-# - Edge case: task_configs list is empty (should raise error)
-# - Test sequence data where individual items in the list/array are not all numbers
-#   (e.g. strings, though unlikely)
-# - Test when `temps` column is missing for a sequence task.
-
-
-def test_empty_inputs_raise_error(sample_formula_desc_df, sample_attributes_df, sample_task_configs):
-    """Test that empty DataFrames or task_configs list raise ValueError."""
+def test_empty_inputs_raise_error(sample_compositions, sample_descriptors, sample_attributes_df, sample_task_configs):
+    """Test that empty/invalid inputs raise the expected errors."""
     empty_df = pd.DataFrame()
-    non_empty_formula_df = sample_formula_desc_df
-    non_empty_attributes_df = sample_attributes_df
-    non_empty_task_configs = sample_task_configs
 
-    with pytest.raises(ValueError, match="formula_desc DataFrame cannot be empty."):
+    with pytest.raises(ValueError, match="descriptors DataFrame cannot be empty."):
         CompoundDataset(
-            formula_desc=empty_df,
-            attributes=non_empty_attributes_df,
-            task_configs=non_empty_task_configs,
-            dataset_name="test_empty_formula",
+            compositions=sample_compositions,
+            descriptors=empty_df,
+            task_frames=_task_frames(sample_task_configs, sample_attributes_df),
+            task_configs=sample_task_configs,
+            dataset_name="test_empty_descriptors",
         )
 
-    with pytest.raises(ValueError, match="attributes DataFrame cannot be empty."):
+    with pytest.raises(ValueError, match="compositions cannot be empty."):
         CompoundDataset(
-            formula_desc=non_empty_formula_df,
-            attributes=empty_df,
-            task_configs=non_empty_task_configs,
-            dataset_name="test_empty_attributes",
+            compositions=[],
+            descriptors=sample_descriptors,
+            task_frames=_task_frames(sample_task_configs, sample_attributes_df),
+            task_configs=sample_task_configs,
+            dataset_name="test_empty_compositions",
         )
 
     with pytest.raises(ValueError, match="task_configs list cannot be empty."):
         CompoundDataset(
-            formula_desc=non_empty_formula_df,
-            attributes=non_empty_attributes_df,
-            task_configs=[],  # Empty task_configs
+            compositions=sample_compositions,
+            descriptors=sample_descriptors,
+            task_frames={},
+            task_configs=[],
             dataset_name="test_empty_task_configs",
         )
 
-    # Test case where formula_desc or attributes_df might be None (though type hints suggest DataFrame)
-    # This is more about robust handling if None is somehow passed.
-    # The class currently expects DataFrames, so this might be redundant
-    # if type checking is strict.
-    with pytest.raises(TypeError, match="formula_desc must be pd.DataFrame or np.ndarray"):
+    with pytest.raises(TypeError, match="descriptors must be a pd.DataFrame"):
         CompoundDataset(
-            formula_desc=None,  # type: ignore
-            attributes=non_empty_attributes_df,
-            task_configs=non_empty_task_configs,
-            dataset_name="test_none_formula",
+            compositions=sample_compositions,
+            descriptors=None,  # type: ignore
+            task_frames=_task_frames(sample_task_configs, sample_attributes_df),
+            task_configs=sample_task_configs,
+            dataset_name="test_none_descriptors",
         )
 
 
-def test_sequence_data_with_non_numeric(sample_formula_desc_df, sample_attributes_df, sample_task_configs, caplog):
-    """Test that non-numeric data in sequence series is handled by creating NaNs, then converted by nan_to_num."""
+def test_missing_descriptor_composition_raises(sample_descriptors, sample_attributes_df, sample_task_configs):
+    """A composition without a descriptor row must raise a clear error."""
+    compositions = [f"id_{i}" for i in range(5)] + ["id_missing"]
+    with pytest.raises(ValueError, match="missing 1 composition"):
+        CompoundDataset(
+            compositions=compositions,
+            descriptors=sample_descriptors,  # only id_0..id_4
+            task_frames=_task_frames(sample_task_configs, sample_attributes_df),
+            task_configs=sample_task_configs,
+            dataset_name="test_missing_desc",
+        )
+
+
+def test_sequence_data_with_non_numeric(
+    sample_compositions, sample_descriptors, sample_attributes_df, sample_task_configs
+):
+    """Non-numeric sequence data is parsed to NaN then nan_to_num'd to 0."""
     attributes_bad_seq = sample_attributes_df.copy()
     attributes_bad_seq["task_seq_sequence_series"] = attributes_bad_seq["task_seq_sequence_series"].astype("object")
     attributes_bad_seq.at["id_0", "task_seq_sequence_series"] = [0.1, "not_a_number", 0.3]
 
-    dataset_bad_seq = CompoundDataset(
-        formula_desc=sample_formula_desc_df,
-        attributes=attributes_bad_seq,
-        task_configs=sample_task_configs,
-        dataset_name="test_bad_seq_data",
+    dataset_bad_seq = _make_dataset(
+        sample_compositions, sample_descriptors, sample_task_configs, attributes_bad_seq, dataset_name="test_bad_seq"
     )
-    # Check that the problematic entry became [0.1, 0.0, 0.3] after nan_to_num(nan=0.0)
-    # The middle "not_a_number" should have been parsed as np.nan by _parse_structured_element, then 0.0
     assert torch.allclose(dataset_bad_seq.y_dict["task_seq"][0], torch.tensor([0.1, 0.0, 0.3], dtype=torch.float32))
 
     attributes_bad_temps = sample_attributes_df.copy()
     attributes_bad_temps["task_seq_temps"] = attributes_bad_temps["task_seq_temps"].astype("object")
     attributes_bad_temps.at["id_0", "task_seq_temps"] = [10, "bad_temp", 30]
 
-    dataset_bad_temps = CompoundDataset(
-        formula_desc=sample_formula_desc_df,
-        attributes=attributes_bad_temps,
-        task_configs=sample_task_configs,
-        dataset_name="test_bad_temps_data",
+    dataset_bad_temps = _make_dataset(
+        sample_compositions,
+        sample_descriptors,
+        sample_task_configs,
+        attributes_bad_temps,
+        dataset_name="test_bad_temps",
     )
-    # Check that the problematic entry became [10, 0, 30]
     assert torch.allclose(
         dataset_bad_temps.t_sequences_dict["task_seq"][0], torch.tensor([10.0, 0.0, 30.0], dtype=torch.float32)
     )
 
 
-def test_missing_specified_t_column_raises_error(sample_formula_desc_df, sample_attributes_df, sample_task_configs):
+def test_missing_specified_t_column_raises_error(
+    sample_compositions, sample_descriptors, sample_attributes_df, sample_task_configs
+):
     """Test ValueError if a specified t_column is missing for a KernelRegression task."""
     attributes_no_temps = sample_attributes_df.drop(columns=["task_seq_temps"])
 
-    # sample_task_configs already has task_seq configured with t_column="task_seq_temps"
-
     with pytest.raises(
-        ValueError, match="T-parameter column 'task_seq_temps' for task 'task_seq' not found in attributes data."
+        ValueError, match="T-parameter column 'task_seq_temps' for task 'task_seq' not found in task data."
     ):
-        CompoundDataset(
-            formula_desc=sample_formula_desc_df,
-            attributes=attributes_no_temps,
-            task_configs=sample_task_configs,
-            dataset_name="test_missing_specified_t_column",
+        _make_dataset(
+            sample_compositions,
+            sample_descriptors,
+            sample_task_configs,
+            attributes_no_temps,
+            dataset_name="test_missing_t",
         )
 
 
-def test_kernel_regression_task_no_t_column_specified(sample_formula_desc_df, sample_attributes_df, caplog):
-    """Test behavior when t_column is not specified for a KernelRegression task (uses placeholder)."""
-    caplog.set_level(logging.INFO)  # Set caplog level to INFO
+def test_kernel_regression_task_no_t_column_specified(
+    sample_compositions, sample_descriptors, sample_attributes_df, caplog
+):
+    """Test behavior when t_column is not specified for a KernelRegression task."""
+    caplog.set_level(logging.INFO)
 
     task_configs_no_t_spec = [
         RegressionTaskConfig(name="task_reg", type=TaskType.REGRESSION, data_column="task_reg_regression_value"),
         KernelRegressionTaskConfig(
             name="task_seq", type=TaskType.KERNEL_REGRESSION, data_column="task_seq_sequence_series", t_column=""
-        ),  # t_column is empty
+        ),
     ]
 
     with pytest.raises(ValueError, match="t_column for KernelRegression task 'task_seq' must be specified."):
-        CompoundDataset(
-            formula_desc=sample_formula_desc_df,
-            attributes=sample_attributes_df,  # attributes_df still has "task_seq_temps" but it won't be used
-            task_configs=task_configs_no_t_spec,
+        _make_dataset(
+            sample_compositions,
+            sample_descriptors,
+            task_configs_no_t_spec,
+            sample_attributes_df,
             dataset_name="test_no_t_column_spec",
         )

--- a/src/foundation_model/models/flexible_multi_task_model_test.py
+++ b/src/foundation_model/models/flexible_multi_task_model_test.py
@@ -534,15 +534,20 @@ def dummy_compound_datamodule(model_config_mixed_tasks, tmp_path):
         splits.extend(["train"] * (num_samples - len(splits)))  # Add remaining to train
     attributes_df["split"] = splits[:num_samples]
 
+    def descriptor_fn(compositions):
+        present = [c for c in compositions if c in formula_df.index]
+        return formula_df.loc[present]
+
+    # Each supervised task reads its own data_column from the shared attributes frame
+    # (composition-indexed). AUTOENCODER tasks need no frame.
+    task_frames = {cfg.name: attributes_df for cfg in config.task_configs if cfg.type != TaskType.AUTOENCODER}
+
     dm = CompoundDataModule(
-        formula_desc_source=formula_df,
-        attributes_source=attributes_df,
         task_configs=config.task_configs,
+        descriptor_fn=descriptor_fn,
+        task_frames=task_frames,
         batch_size=batch_size,
         num_workers=0,
-        # test_all=False, # Default
-        # val_split and test_split are used if 'split' column is not present.
-        # Since we provide 'split', these will be ignored by the DataModule's logic.
     )
     dm.setup()  # Call setup to prepare datasets
     return dm

--- a/src/foundation_model/models/full_prediction_flow_test.py
+++ b/src/foundation_model/models/full_prediction_flow_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Final
 
+import pandas as pd
 import pytest
 import torch
 
@@ -33,6 +34,7 @@ def test_full_prediction_flow_produces_kernel_regression_outputs() -> None:
             data_column="Density (normalized)",
             dims=[128, 64, 32, 1],
             enabled=True,
+            predict_idx="all",
         ),
         KernelRegressionTaskConfig(
             name="dos",
@@ -43,16 +45,25 @@ def test_full_prediction_flow_produces_kernel_regression_outputs() -> None:
             t_dim=[32, 16],
             t_encoding_method="fc",
             enabled=True,
+            predict_idx="all",
         ),
     ]
 
+    # Descriptor frame and attributes frame are both composition-indexed parquet files.
+    descriptor_df = pd.read_parquet(_DATA_PATHS[0])
+    attributes_df = pd.read_parquet(_DATA_PATHS[1])
+
+    def descriptor_fn(compositions):
+        present = [c for c in compositions if c in descriptor_df.index]
+        return descriptor_df.loc[present]
+
     datamodule = CompoundDataModule(
-        formula_desc_source=str(_DATA_PATHS[0]),
-        attributes_source=str(_DATA_PATHS[1]),
         task_configs=task_configs,
+        descriptor_fn=descriptor_fn,
+        task_frames={cfg.name: attributes_df for cfg in task_configs},
+        composition_column="id",  # join key is the 'id' index (mp-*), not the 'composition' formula column
         batch_size=8,
         num_workers=0,
-        predict_idx="all",
     )
     datamodule.setup(stage="predict")
     assert datamodule.predict_dataset is not None

--- a/src/foundation_model/scripts/callbacks/prediction_writer.py
+++ b/src/foundation_model/scripts/callbacks/prediction_writer.py
@@ -311,18 +311,25 @@ class PredictionDataFrameWriter(BasePredictionWriter):
             logger.warning("Processed DataFrame is empty. No data saved.")
             return
 
-        # Attach composition keys when the DataModule exposes them and the row count matches
-        # the predicted compositions (single-process predict preserves order). In distributed
-        # runs the gathered order may differ, so we only index when the lengths line up.
+        # Attach composition keys only for single-process prediction, where dataloader order is
+        # preserved and matches datamodule.predict_compositions. In distributed runs
+        # _gather_distributed_predictions merges rank-by-rank without restoring dataset order, so
+        # row i no longer corresponds to predict_compositions[i] even when lengths match.
         compositions = getattr(getattr(trainer, "datamodule", None), "predict_compositions", None)
-        if compositions:
+        world_size = getattr(trainer, "world_size", 1) or 1
+        if compositions and world_size == 1:
             if len(compositions) == len(df):
                 df.index = pd.Index(compositions, name="composition")
             else:
                 logger.warning(
                     f"Not attaching composition index: {len(compositions)} predict compositions "
-                    f"but {len(df)} prediction rows (likely distributed gathering or deduplication)."
+                    f"but {len(df)} prediction rows (likely deduplication)."
                 )
+        elif compositions:
+            logger.info(
+                "Not attaching composition index under distributed prediction "
+                f"(world_size={world_size}); gathered row order is not guaranteed to match compositions."
+            )
 
         logger.info(f"Final DataFrame shape: {df.shape}")
 

--- a/src/foundation_model/scripts/callbacks/prediction_writer.py
+++ b/src/foundation_model/scripts/callbacks/prediction_writer.py
@@ -311,6 +311,19 @@ class PredictionDataFrameWriter(BasePredictionWriter):
             logger.warning("Processed DataFrame is empty. No data saved.")
             return
 
+        # Attach composition keys when the DataModule exposes them and the row count matches
+        # the predicted compositions (single-process predict preserves order). In distributed
+        # runs the gathered order may differ, so we only index when the lengths line up.
+        compositions = getattr(getattr(trainer, "datamodule", None), "predict_compositions", None)
+        if compositions:
+            if len(compositions) == len(df):
+                df.index = pd.Index(compositions, name="composition")
+            else:
+                logger.warning(
+                    f"Not attaching composition index: {len(compositions)} predict compositions "
+                    f"but {len(df)} prediction rows (likely distributed gathering or deduplication)."
+                )
+
         logger.info(f"Final DataFrame shape: {df.shape}")
 
         # Save to CSV

--- a/src/foundation_model/scripts/callbacks/prediction_writer_test.py
+++ b/src/foundation_model/scripts/callbacks/prediction_writer_test.py
@@ -107,6 +107,8 @@ def test_prediction_writer_multi_gpu_integration(tmp_path: Path) -> None:
     from foundation_model.models.flexible_multi_task_model import FlexibleMultiTaskModel
     from foundation_model.models.model_config import KernelRegressionTaskConfig, TaskType
 
+    import pandas as pd
+
     task_configs = [
         KernelRegressionTaskConfig(
             name="dos",
@@ -118,18 +120,26 @@ def test_prediction_writer_multi_gpu_integration(tmp_path: Path) -> None:
             t_encoding_method="fc",
             norm=True,
             residual=False,
-            weight=1.0,
+            loss_weight=1.0,
             enabled=True,
+            predict_idx="all",
         )
     ]
 
+    descriptor_df = pd.read_parquet(_INTEGRATION_DATA_PATHS[0])
+    attributes_df = pd.read_parquet(_INTEGRATION_DATA_PATHS[1])
+
+    def descriptor_fn(compositions):
+        present = [c for c in compositions if c in descriptor_df.index]
+        return descriptor_df.loc[present]
+
     datamodule = CompoundDataModule(
-        formula_desc_source=str(_INTEGRATION_DATA_PATHS[0]),
-        attributes_source=str(_INTEGRATION_DATA_PATHS[1]),
         task_configs=task_configs,
+        descriptor_fn=descriptor_fn,
+        task_frames={cfg.name: attributes_df for cfg in task_configs},
+        composition_column="id",  # join key is the 'id' index (mp-*)
         batch_size=256,
         num_workers=0,
-        predict_idx="all",
         val_split=0.1,
         test_split=0.1,
         random_seed=42,

--- a/src/foundation_model/scripts/dynamic_task_suite.py
+++ b/src/foundation_model/scripts/dynamic_task_suite.py
@@ -470,6 +470,27 @@ class DynamicTaskSuiteRunner:
             model.load_state_dict(state_dict)
         return best_path
 
+    @staticmethod
+    def _make_descriptor_fn(features: pd.DataFrame):
+        """Build a descriptor_fn that looks up precomputed descriptor rows by composition."""
+        feats = features.copy()
+        feats.index = feats.index.astype(str)
+
+        def descriptor_fn(compositions):
+            present = [c for c in compositions if c in feats.index]
+            return feats.loc[present]
+
+        return descriptor_fn
+
+    def _task_masking_ratio_for(self, name: str) -> float | None:
+        """Resolve the per-task keep ratio from the (float | dict | None) suite config."""
+        ratios = self.config.task_masking_ratios
+        if ratios is None:
+            return None
+        if isinstance(ratios, dict):
+            return ratios.get(name)
+        return float(ratios)
+
     def _build_pretrain_datamodule(self, task_names: Sequence[str]) -> CompoundDataModule:
         if self.pretrain_features is None or self.pretrain_targets is None:
             raise RuntimeError("Pretrain data is not loaded.")
@@ -478,11 +499,12 @@ class DynamicTaskSuiteRunner:
         if "split" in self.pretrain_targets.columns:
             columns.append("split")
         stage_targets = self.pretrain_targets.loc[:, columns]
+        configs = [self._build_regression_task(name, self.pretrain_target_columns[name]) for name in task_names]
         return CompoundDataModule(
-            formula_desc_source=self.pretrain_features,
-            attributes_source=stage_targets,
-            task_configs=[self._build_regression_task(name, self.pretrain_target_columns[name]) for name in task_names],
-            task_masking_ratios=self.config.task_masking_ratios,
+            task_configs=configs,
+            descriptor_fn=self._make_descriptor_fn(self.pretrain_features),
+            task_frames={cfg.name: stage_targets for cfg in configs},
+            composition_column=self.pretrain_features.index.name or "composition",
             random_seed=self.config.datamodule_random_seed,
             val_split=self.config.val_split,
             test_split=self.config.test_split,
@@ -500,11 +522,12 @@ class DynamicTaskSuiteRunner:
         if "split" in self.finetune_targets.columns:
             columns.append("split")
         target_frame = self.finetune_targets.loc[:, columns]
+        config = self._build_regression_task(task_name, column)
         return CompoundDataModule(
-            formula_desc_source=self.finetune_features,
-            attributes_source=target_frame,
-            task_configs=[self._build_regression_task(task_name, column)],
-            task_masking_ratios=self.config.task_masking_ratios,
+            task_configs=[config],
+            descriptor_fn=self._make_descriptor_fn(self.finetune_features),
+            task_frames={config.name: target_frame},
+            composition_column=self.finetune_features.index.name or "composition",
             random_seed=self.config.datamodule_random_seed,
             val_split=self.config.val_split,
             test_split=self.config.test_split,
@@ -528,6 +551,7 @@ class DynamicTaskSuiteRunner:
             norm=True,
             residual=False,
             optimizer=optimizer,
+            task_masking_ratio=self._task_masking_ratio_for(name),
         )
 
     def _plot_predictions(

--- a/src/foundation_model/scripts/dynamic_task_suite.py
+++ b/src/foundation_model/scripts/dynamic_task_suite.py
@@ -472,13 +472,16 @@ class DynamicTaskSuiteRunner:
 
     @staticmethod
     def _make_descriptor_fn(features: pd.DataFrame):
-        """Build a descriptor_fn that looks up precomputed descriptor rows by composition."""
-        feats = features.copy()
-        feats.index = feats.index.astype(str)
+        """Build a descriptor_fn that looks up precomputed descriptor rows by composition.
+
+        Avoids copying the (potentially large) descriptor matrix: only an index label map is
+        built. The DataModule's descriptor cache stringifies the returned index.
+        """
+        label_by_str = {str(idx): idx for idx in features.index}
 
         def descriptor_fn(compositions):
-            present = [c for c in compositions if c in feats.index]
-            return feats.loc[present]
+            labels = [label_by_str[c] for c in compositions if c in label_by_str]
+            return features.loc[labels]
 
         return descriptor_fn
 

--- a/src/foundation_model/scripts/multi_task_progressive_clf.py
+++ b/src/foundation_model/scripts/multi_task_progressive_clf.py
@@ -330,6 +330,18 @@ class ProgressiveClfRunner:
                 columns.add(tc.t_column)
         return columns
 
+    @staticmethod
+    def _make_descriptor_fn(features: pd.DataFrame):
+        """Build a descriptor_fn that looks up precomputed descriptor rows by composition."""
+        feats = features.copy()
+        feats.index = feats.index.astype(str)
+
+        def descriptor_fn(compositions):
+            present = [c for c in compositions if c in feats.index]
+            return feats.loc[present]
+
+        return descriptor_fn
+
     def _build_pretrain_datamodule(self, task_cfgs: list) -> CompoundDataModule:
         columns = list(self._get_task_columns(task_cfgs))
         if "split" in self.all_data.columns:
@@ -338,9 +350,10 @@ class ProgressiveClfRunner:
         attributes = self.all_data[columns].copy()
 
         return CompoundDataModule(
-            formula_desc_source=self.desc_trans,
-            attributes_source=attributes,
             task_configs=list(task_cfgs),
+            descriptor_fn=self._make_descriptor_fn(self.desc_trans),
+            task_frames={tc.name: attributes for tc in task_cfgs},
+            composition_column=self.desc_trans.index.name or "composition",
             random_seed=self.config.datamodule_random_seed,
             batch_size=self.config.batch_size,
             num_workers=self.config.num_workers,
@@ -354,9 +367,10 @@ class ProgressiveClfRunner:
         attributes = self.all_data[columns].dropna(subset=[data_col]).copy()
 
         return CompoundDataModule(
-            formula_desc_source=self.desc_trans,
-            attributes_source=attributes,
             task_configs=[self.finetune_task_config],
+            descriptor_fn=self._make_descriptor_fn(self.desc_trans),
+            task_frames={self.finetune_task_config.name: attributes},
+            composition_column=self.desc_trans.index.name or "composition",
             random_seed=self.config.datamodule_random_seed,
             batch_size=self.config.batch_size,
             num_workers=self.config.num_workers,

--- a/src/foundation_model/scripts/multi_task_progressive_clf.py
+++ b/src/foundation_model/scripts/multi_task_progressive_clf.py
@@ -332,13 +332,16 @@ class ProgressiveClfRunner:
 
     @staticmethod
     def _make_descriptor_fn(features: pd.DataFrame):
-        """Build a descriptor_fn that looks up precomputed descriptor rows by composition."""
-        feats = features.copy()
-        feats.index = feats.index.astype(str)
+        """Build a descriptor_fn that looks up precomputed descriptor rows by composition.
+
+        Avoids copying the (potentially large) descriptor matrix: only an index label map is
+        built. The DataModule's descriptor cache stringifies the returned index.
+        """
+        label_by_str = {str(idx): idx for idx in features.index}
 
         def descriptor_fn(compositions):
-            present = [c for c in compositions if c in feats.index]
-            return feats.loc[present]
+            labels = [label_by_str[c] for c in compositions if c in label_by_str]
+            return features.loc[labels]
 
         return descriptor_fn
 


### PR DESCRIPTION
## Scope

**PR3** — the atomic core switch of the composition-keyed data refactor (plan: `REFACTOR_composition_datamodule_PLAN.md`; builds on #8 PR1 config fields and #10 PR2 helpers). Hard-removes the old `formula_desc_source` / `attributes_source` / `task_masking_ratios` / `predict_idx` API and migrates **every** caller in sync.

## What changed

### Dataset / DataModule
- **`CompoundDataset`** rewritten for composition-keyed alignment: constructor takes `(compositions, descriptors, task_frames, task_configs, ...)`; each task frame is reindexed to the split's compositions and `x_formula = descriptors.loc[compositions]`. The **4-tuple batch output is unchanged** (`x, y_dict, masks, t_sequences`), so the model/`forward`/steps/collate are untouched. Parsing + masking logic preserved verbatim.
- **`CompoundDataModule`** new API: `CompoundDataModule(task_configs, descriptor_fn, *, task_frames=None, default_data_files=None, composition_column="composition", val_split, test_split, test_all, swap_train_val_split, random_seed, batch_size, num_workers)`. Pipeline: load per-task frames → composition universe (+ explicit predict-only comps) → cached descriptors (drop comps with none) → composition-level split (per-task `split` overlay, precedence `test>val>train`, random fallback) → per-stage datasets. Per-task `predict_idx` union exposed as `predict_compositions`.

### Composition sources (PR2 module, extended)
- `PrecomputedDescriptorSource(path)` — a YAML/CLI-instantiable `descriptor_fn` for composition-indexed descriptor files.
- `load_task_frame` now also accepts files already **indexed** by the composition column (real parquet exports), not only a composition column.

### Callers migrated (hard switch)
- `dynamic_task_suite.py` + `multi_task_progressive_clf.py`: build `descriptor_fn` closures over precomputed descriptors + in-memory `task_frames`; suite routes `task_masking_ratios` into each task's `task_masking_ratio`.
- `prediction_writer.py`: attaches composition keys from `datamodule.predict_compositions` as the output index (single-process / length-matched).
- Model + writer integration tests (`flexible_multi_task_model_test`, `full_prediction_flow_test`, `prediction_writer_test`) migrated to `descriptor_fn` + `task_frames`.
- Samples: `example_config.yaml` + local `fit/predict/test` configs migrated; `AGENTS.md` Data section rewritten.

## Scope decisions (documented)
- **Predict** = union of per-task `predict_idx` subsets; `predict_step` is unchanged (emits all heads over the union) and the writer attaches composition keys for downstream per-task/per-composition joins. Strict per-task output masking within the union is a deliberate follow-up (would require a `predict_step` change; the batch contract is intentionally preserved here).
- **`default_data_files`** added so the legacy "one file holds all targets" case works from YAML without repeating the path on every task.
- AUTOENCODER-only configs (no supervised task / composition source) remain unsupported — AE rides along supervised compositions.

## Validation
- Full suite: **160 passed, 1 skipped** (skip = 2-GPU writer integration). The DOS kernel-regression integration test runs against the real 48,998-composition dataset and passes.
- `ruff format`/`ruff check` clean on all touched files; `mypy` clean on `datamodule.py` + `composition_sources.py` (repo-wide mypy debt unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)