### PR TITLE
feat(data): composition-aware MultiTaskSplitter fallback + docs (refactor PR4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,10 @@ data:
 
 **Splitting.** A single composition-level train/val/test split is derived by overlaying every
 task file's `split` column (precedence `test > val > train`; conflicts warn). Compositions
-without a label fall back to a representative random split (`MultiTaskSplitter`) that keeps each
-task represented across all three sets. `test_all=True` assigns everything to test.
+without a label fall back to a representation-aware random split (`MultiTaskSplitter`) that
+prioritizes rare tasks to improve their val/test representation and preserves the overall
+val/test proportions (it does not guarantee every tiny task appears in every split).
+`test_all=True` assigns everything to test.
 
 **Prediction.** Each task's `predict_idx` selects a composition subset; the predict set is their
 union, exposed as `datamodule.predict_compositions` and attached as the output index by

--- a/README.md
+++ b/README.md
@@ -137,58 +137,82 @@ See [ARCHITECTURE.md](ARCHITECTURE.md#loss-calculation-and-weighting) for a deep
 - Configurable data splitting ratios
 - Property-specific sampling fractions
 
-### Input Data: `attributes_source` Column Naming
+### Input Data: composition-keyed per-task sources
 
-When providing data through the `attributes_source` (typically an `attributes.csv` file or a Pandas DataFrame), it is essential to configure your tasks to point to the correct data columns. This is done via the `data_column` field in each task's configuration and, for sequence tasks, the optional `steps_column`.
+`CompoundDataModule` is **composition-keyed**: each task owns its own data file(s), joined to
+the others by a shared **composition** column. There is no monolithic attributes file — adding
+a new property task means adding one file plus one task config. Descriptors are computed on
+demand from the union of compositions via a user-supplied `descriptor_fn` (results are cached
+per unique composition).
 
-**1. Primary Data Column (`data_column`):**
-   - **Applies to**: `RegressionTaskConfig`, `ClassificationTaskConfig`, `SequenceTaskConfig`.
-   - **Field in Config**: `data_column: str`
-   - **Purpose**: Specifies the exact name of the column in your `attributes_source` file/DataFrame that contains the primary data for the task.
-     - For regression and classification tasks: This column holds the target values.
-     - For sequence tasks: This column holds the main sequence data (e.g., the y-values of a spectrum or time series).
-   - **Example**:
-     ```yaml
-     # In your task configuration list:
-     # - name: "band_gap_prediction"
-     #   type: REGRESSION
-     #   data_column: "actual_band_gap_values" # Points to 'actual_band_gap_values' column in attributes.csv
-     #   ... other task parameters
-     #
-     # - name: "xrd_pattern_analysis"
-     #   type: SEQUENCE
-     #   data_column: "xrd_intensity_series" # Points to 'xrd_intensity_series' column for sequence y-values
-     #   steps_column: "xrd_two_theta_angles" # See below
-     #   ... other task parameters
-     ```
+**DataModule wiring:**
 
-**2. Sequence Steps Column (`steps_column`):**
-   - **Applies to**: `SequenceTaskConfig` only.
-   - **Field in Config**: `steps_column: str` (optional, defaults to `""`)
-   - **Purpose**: Specifies the exact name of the column in your `attributes_source` that contains the steps or x-axis values corresponding to the sequence data (e.g., temperature points, time steps, 2-theta angles).
-   - **Behavior**:
-     - If specified and the column exists: This data will be loaded and passed to the sequence task head (available in `temps_dict` within `CompoundDataset`).
-     - If specified but the column does *not* exist in `attributes_source`: A `ValueError` will be raised during data loading, as this explicitly requested data is missing.
-     - If left as an empty string (default): No specific steps column is loaded. `CompoundDataset` will provide a placeholder (e.g., zeros) for the steps data. The sequence model head should be prepared to handle this (e.g., by assuming a default step interval like `torch.arange(sequence_length)`).
-   - **Example**:
-     ```yaml
-     # - name: "temperature_dependent_property"
-     #   type: SEQUENCE
-     #   data_column: "property_vs_temp_series"
-     #   steps_column: "temperature_points" # Points to 'temperature_points' column for x-axis of the sequence
-     #   ...
-     ```
+```yaml
+data:
+  class_path: foundation_model.data.datamodule.CompoundDataModule
+  init_args:
+    # Computes descriptors from compositions. PrecomputedDescriptorSource looks them up from a
+    # composition-indexed file; supply your own callable to compute them instead.
+    descriptor_fn:
+      class_path: foundation_model.data.composition_sources.PrecomputedDescriptorSource
+      init_args:
+        path: "data/descriptors.parquet"
+        composition_column: null   # null => use the file's index as the composition key
+    composition_column: "composition"   # the join key shared across all task files
+    # default_data_files: "data/all_targets.parquet"  # optional shared fallback for tasks
+    #                                                  # that don't declare their own data_files
+    val_split: 0.1
+    test_split: 0.1
+    random_seed: 42
+    batch_size: 64
+```
 
-**Important Considerations:**
-*   **Exact Column Names**: The values provided for `data_column` and `steps_column` must exactly match the column headers in your `attributes_source` data file.
-*   **Data Format in CSV**: If your `attributes_source` is a CSV file and a column contains list-like data (e.g., for sequence series, multi-dimensional regression targets, or sequence steps), these should be stored as strings that Python's `ast.literal_eval` can parse (e.g., `"[1.0, 2.5, 3.0]"`).
-*   **Missing `data_column` Data**: If a `data_column` is specified in a task config but the column is not found in `attributes_source`, or if the column exists but contains many NaNs, the corresponding samples for that task will be masked out (i.e., not used for training or loss calculation for that specific task). Placeholders (e.g., zeros or -1 for classification) will be used for the target values in `y_dict`.
-*   **`attributes_source` is `None`**:
-    *   If `attributes_source` is not provided to `CompoundDataModule` (typically for prediction scenarios where only input features like `formula_desc_source` are given):
-        *   Any task specifying a `data_column` will have its targets treated as placeholders by `CompoundDataset`.
-        *   If a `SequenceTaskConfig` specifies a non-empty `steps_column`, `CompoundDataModule` will raise a `ValueError` because `attributes_source` is required to load this essential steps data, even for prediction.
+**Per-task data** is configured on each task config (`BaseTaskConfig`):
 
-This explicit column mapping approach provides clarity and flexibility in defining how your task configurations link to your data.
+| Field | Purpose |
+|-------|---------|
+| `data_files` | This task's own source file(s) (`csv` / `parquet` / `pd.xz` / `pkl`), concatenated by rows |
+| `data_column` | Column inside that file holding the target values |
+| `t_column` | (Kernel regression) column holding the sequence x-axis (energy / temperature / time) |
+| `composition_column` | Per-task override of the global composition column |
+| `split_column` | Optional in-file `train` / `val` / `test` labels (default `"split"`) |
+| `task_masking_ratio` | Optional keep-ratio applied to this task's valid training samples |
+| `predict_idx` | Composition subset to predict: a literal `train`/`val`/`test`/`all` or an explicit list |
+
+```yaml
+# In model.init_args.task_configs (linked into the datamodule automatically):
+- name: band_gap
+  type: REGRESSION
+  data_files: "data/band_gap.parquet"
+  data_column: "Band gap"
+  # split_column: "split"        # optional
+  # task_masking_ratio: 0.9      # optional
+  # predict_idx: "test"          # optional
+- name: dos
+  type: KernelRegression
+  data_files: "data/dos.parquet"
+  data_column: "DOS density"
+  t_column: "DOS energy"
+```
+
+**Splitting.** A single composition-level train/val/test split is derived by overlaying every
+task file's `split` column (precedence `test > val > train`; conflicts warn). Compositions
+without a label fall back to a representative random split (`MultiTaskSplitter`) that keeps each
+task represented across all three sets. `test_all=True` assigns everything to test.
+
+**Prediction.** Each task's `predict_idx` selects a composition subset; the predict set is their
+union, exposed as `datamodule.predict_compositions` and attached as the output index by
+`PredictionDataFrameWriter` (single-process runs).
+
+**Important considerations:**
+*   **Exact column names**: `data_column` / `t_column` / `composition_column` must match the
+    source columns exactly. The composition key may be a column or the file's index name.
+*   **List-valued cells**: sequences / multi-dim targets stored in CSV must be strings parseable
+    by `ast.literal_eval`, e.g. `"[1.0, 2.5, 3.0]"`.
+*   **Missing data**: compositions absent from a task's file (or with NaN targets) are **masked
+    out** for that task rather than dropped; placeholders fill `y_dict`.
+*   **Missing descriptors**: compositions for which `descriptor_fn` produces no valid descriptor
+    are dropped from all splits (with a warning).
 
 ## Quick Examples
 
@@ -361,15 +385,16 @@ These examples should provide a more accurate reflection of how to use `train.py
 
 ### Training with Local Data and YAML Configuration (Scaling Law Demo)
 
-This section demonstrates how to train the `FlexibleMultiTaskModel` using local data files (CSV) and a YAML configuration, highlighting how to explore scaling laws by adjusting data availability for specific tasks using `CompoundDataModule`'s `task_masking_ratios`.
+This section demonstrates training `FlexibleMultiTaskModel` from local files with a YAML
+config, and how to explore scaling laws by varying a task's data via its per-task
+`task_masking_ratio`. Each task owns its own file, joined to the descriptors by a
+**composition** column.
 
-**1. Prepare Dummy Data Files:**
+**1. Prepare local data files:**
 
-Create the following CSV files in your project, for example, under an `examples/data/` directory:
-
-*   `examples/data/dummy_formula_descriptors.csv`:
+*   `examples/data/descriptors.csv` — composition-indexed descriptor features:
     ```csv
-    id,comp_feat_1,comp_feat_2
+    composition,comp_feat_1,comp_feat_2
     mat_1,0.1,0.5
     mat_2,0.2,0.6
     mat_3,0.3,0.7
@@ -382,130 +407,99 @@ Create the following CSV files in your project, for example, under an `examples/
     mat_10,0.55,0.95
     ```
 
-*   `examples/data/dummy_attributes.csv`:
-    This file defines the tasks, their target values, and the train/validation/test split. Column names are generic; the mapping to tasks is done in the YAML configuration.
+*   `examples/data/task_A.csv` — a regression task's own file (composition + target + split):
     ```csv
-    id,target_A,series_B_y,series_B_x,split
-    mat_1,1.0,"[0.1,0.2,0.3]","[10,20,30]",train
-    mat_2,2.0,"[0.4,0.5,0.6]","[10,20,30]",train
-    mat_3,3.0,"[0.7,0.8,0.9]","[10,20,30]",train
-    mat_4,1.5,"[0.15,0.25,0.35]","[10,20,30]",train
-    mat_5,2.5,"[0.45,0.55,0.65]","[10,20,30]",train
-    mat_6,3.5,"[0.75,0.85,0.95]","[10,20,30]",train
-    mat_7,4.0,"[0.9,1.0,1.1]","[10,20,30]",val
-    mat_8,4.5,"[1.1,1.2,1.3]","[10,20,30]",val
-    mat_9,5.0,"[1.2,1.3,1.4]","[10,20,30]",test
-    mat_10,5.5,"[1.3,1.4,1.5]","[10,20,30]",test
+    composition,target_A,split
+    mat_1,1.0,train
+    mat_2,2.0,train
+    mat_3,3.0,train
+    mat_4,1.5,train
+    mat_5,2.5,train
+    mat_6,3.5,train
+    mat_7,4.0,val
+    mat_8,4.5,val
+    mat_9,5.0,test
+    mat_10,5.5,test
     ```
-    *Note: For sequence tasks, series data and x-axis (steps) data are represented as strings of lists. `CompoundDataset` will parse these.*
 
-**2. Create YAML Configuration File:**
+*   `examples/data/task_dos.csv` — a kernel-regression task with sequence target + x-axis.
+    List-valued cells are strings parseable by `ast.literal_eval`:
+    ```csv
+    composition,dos_y,dos_x,split
+    mat_1,"[0.1,0.2,0.3]","[10,20,30]",train
+    mat_2,"[0.4,0.5,0.6]","[10,20,30]",train
+    mat_9,"[1.2,1.3,1.4]","[10,20,30]",test
+    mat_10,"[1.3,1.4,1.5]","[10,20,30]",test
+    ```
+    Compositions absent from a task's file (e.g. `mat_3` for `task_dos`) are simply masked
+    out for that task — no need to align files by hand.
 
-Create a YAML file, for example, `examples/configs/demo_scaling_law.yaml`. This example uses the `init_args` structure expected by `LightningCLI`.
+**2. Create the YAML configuration (`examples/configs/demo_scaling_law.yaml`):**
 
 ```yaml
-# examples/configs/demo_scaling_law.yaml
-experiment_name: "scaling_law_demo" # Can be overridden by CLI
-seed_everything: 42 # For reproducibility
+seed_everything: 42
 
-# --- Model Configuration (for FlexibleMultiTaskModel) ---
 model:
-  class_path: foundation_model.models.FlexibleMultiTaskModel
+  class_path: foundation_model.models.flexible_multi_task_model.FlexibleMultiTaskModel
   init_args:
-    shared_block_dims: [2, 128, 256] # Input (dummy_formula_descriptors.csv has 2 features) -> hidden -> latent
+    encoder_config:
+      type: mlp
+      hidden_dims: [2, 128, 256] # hidden_dims[0] == input feature count; [-1] == latent_dim
+      norm: true
     task_configs:
       - name: "task_A"
-        type: "REGRESSION"
-        data_column: "target_A" # Maps to 'target_A' column in dummy_attributes.csv
-        dims: [256, 64, 1]      # Tanh-activated latent_dim -> hidden -> output
+        type: REGRESSION
+        data_files: "examples/data/task_A.csv"
+        data_column: "target_A"
+        dims: [256, 64, 1]            # [latent_dim, hidden, output]
+        task_masking_ratio: 1.0       # vary this to study the scaling law
         optimizer: { lr: 0.001, scheduler_type: "None" }
-      - name: "task_B"
-        type: "SEQUENCE"
-        subtype: "rnn"
-        data_column: "series_B_y"  # Maps to 'series_B_y' for y-values
-        steps_column: "series_B_x" # Maps to 'series_B_x' for x-values (steps)
-        d_in: 256                  # Should match the model's latent_dim for sequence heads
-        hidden: 64
-        cell: "gru"
+      - name: "dos"
+        type: KernelRegression
+        data_files: "examples/data/task_dos.csv"
+        data_column: "dos_y"
+        t_column: "dos_x"
+        x_dim: [256, 64]
+        t_dim: [16, 8]
         optimizer: { lr: 0.001, scheduler_type: "None" }
-    # Add other model.init_args as needed, e.g.:
-    # encoder_config:
-    #   type: mlp
-    #   hidden_dims: [128, 256]
-    #   norm: true
-    #   residual: false
-    shared_block_optimizer: { lr: 0.001, scheduler_type: "None", freeze_parameters: false }
 
-# --- Data Module Configuration (for CompoundDataModule) ---
-data: # Renamed from datamodule for consistency with LightningCLI v2.0+ common practice
-  class_path: foundation_model.data.CompoundDataModule
+data:
+  class_path: foundation_model.data.datamodule.CompoundDataModule
   init_args:
-    formula_desc_source: "examples/data/dummy_formula_descriptors.csv"
-    attributes_source: "examples/data/dummy_attributes.csv"
-    task_configs: ${model.init_args.task_configs} # Dynamically uses task_configs from model
+    descriptor_fn:
+      class_path: foundation_model.data.composition_sources.PrecomputedDescriptorSource
+      init_args:
+        path: "examples/data/descriptors.csv"
+        composition_column: "composition"
+    composition_column: "composition"
+    task_configs: ${model.init_args.task_configs} # linked from the model
     batch_size: 2
     num_workers: 0
-    # train_ratio, val_ratio, test_split are used if 'split' column is NOT in attributes_source
-    # val_split: 0.1 
-    # test_split: 0.1
-    # random_seed: 42
-    # task_masking_ratios: 0.9  # Or provide {"task_A": 0.9, "task_B": 0.5} for per-task control
-    task_masking_ratios:
-      task_A: 1.0 # Experiment with this: 1.0, 0.5, 0.25 etc. for task_A
-      # task_B: 1.0 # Can also apply to other tasks
+    # val_split / test_split / random_seed apply only to compositions lacking a split label
 
-# --- Trainer Configuration (PyTorch Lightning) ---
 trainer:
-  default_root_dir: "results/logs/${experiment_name}" # Organizes logs by experiment name
-  max_epochs: 20 # Adjust as needed for a meaningful demo
+  default_root_dir: "results/logs/scaling_law_demo"
+  max_epochs: 20
   accelerator: "cpu"
   devices: 1
   logger:
     - class_path: lightning.pytorch.loggers.CSVLogger
-      init_args:
-        save_dir: "${trainer.default_root_dir}"
-        name: "" # Logs will be in ${trainer.default_root_dir}/version_X
-    - class_path: lightning.pytorch.loggers.TensorBoardLogger
-      init_args:
-        save_dir: "${trainer.default_root_dir}"
-        name: ""
-  # callbacks:
-  #   - class_path: lightning.pytorch.callbacks.ModelCheckpoint
-  #     init_args:
-  #       monitor: "val_total_loss" # Or a specific task's validation loss
-  #       mode: "min"
-  #   - class_path: lightning.pytorch.callbacks.EarlyStopping
-  #     init_args:
-  #       monitor: "val_total_loss"
-  #       patience: 5
-  #       mode: "min"
+      init_args: { save_dir: "${trainer.default_root_dir}", name: "" }
 ```
-*The `train.py` script, using `LightningCLI`, will parse this YAML. Ensure `train.py` is set up to correctly pass `init_args` to the respective classes.*
 
-**3. Run Training:**
-
-Assuming you have a training script (e.g., `train_flexible.py`) that uses PyTorch Lightning's `CLI` or a similar mechanism to parse the YAML and CLI arguments:
+**3. Run training:**
 
 ```bash
-python src/foundation_model/scripts/train_flexible.py --config examples/configs/demo_scaling_law.yaml
+fm-trainer fit --config examples/configs/demo_scaling_law.yaml
 ```
-*(If using the existing `train.py`, it would require significant modification to load `FlexibleMultiTaskModel` and `CompoundDataModule` from such a YAML configuration.)*
 
-**4. Demonstrating Scaling Law with `task_masking_ratios`:**
+**4. Demonstrating the scaling law via `task_masking_ratio`:**
 
-The `task_masking_ratios` parameter in `CompoundDataModule` (set via the YAML) controls the fraction of *valid* (non-NaN) samples used for each specified task during training. A ratio of `1.0` uses all valid samples, `0.5` uses 50%, and so on. This allows you to simulate different dataset sizes for specific tasks.
-
-To observe a scaling law for `task_A`:
-1.  **Run 1 (Full Data for task_A):**
-    In `demo_scaling_law.yaml`, ensure `task_masking_ratios: { task_A: 1.0 }`. Train the model and note the final validation loss for `task_A`.
-2.  **Run 2 (Reduced Data for task_A):**
-    Modify `demo_scaling_law.yaml` to `task_masking_ratios: { task_A: 0.5 }` (using 50% of `task_A`'s valid training data). Retrain the model (preferably from scratch or ensure fair comparison) and note the final validation loss for `task_A`.
-3.  **Run 3 (Further Reduced Data for task_A):**
-    Modify to `task_masking_ratios: { task_A: 0.2 }` (using 20% of `task_A`'s valid training data). Retrain and note the loss.
-
-**Expected Observation:** Generally, as the `task_masking_ratios` for `task_A` decreases (less data used), the final validation loss for `task_A` is expected to be higher, demonstrating the scaling law principle that model performance often improves with more data. Plotting these losses against the data fraction (1.0, 0.5, 0.2) can visualize this relationship.
-
-This setup provides a controlled way to study the impact of data quantity on individual task performance within a multi-task learning framework.
+Each task's `task_masking_ratio` controls the fraction of its *valid* (non-NaN) training
+samples used (`1.0` = all, `0.5` = half, …), simulating different dataset sizes per task.
+Re-run training with `task_A`'s `task_masking_ratio` set to `1.0`, then `0.5`, then `0.2`, and
+record the final `val_task_A_*` loss each time. As the ratio drops, the validation loss for
+`task_A` generally rises — the expected scaling-law behavior — while other tasks are unaffected.
 
 ## Update History
 

--- a/src/foundation_model/data/composition_sources.py
+++ b/src/foundation_model/data/composition_sources.py
@@ -23,9 +23,10 @@ from __future__ import annotations
 from typing import Callable, Mapping, Sequence
 
 import joblib  # type: ignore[import-untyped]
-import numpy as np
 import pandas as pd
 from loguru import logger
+
+from .splitter import MultiTaskSplitter
 
 DescriptorFn = Callable[[list[str]], pd.DataFrame]
 
@@ -280,34 +281,6 @@ class DescriptorCache:
         return computed.loc[valid], dropped
 
 
-def _random_split(
-    compositions: Sequence[str],
-    *,
-    val_split: float,
-    test_split: float,
-    rng: np.random.Generator,
-) -> dict[str, str]:
-    """Assign train/val/test labels to ``compositions`` by proportional random split."""
-    comps = list(compositions)
-    n = len(comps)
-    if n == 0:
-        return {}
-    order = rng.permutation(n)
-    shuffled = [comps[i] for i in order]
-    n_test = int(round(n * test_split))
-    n_val = int(round(n * val_split))
-    n_test = min(n_test, n)
-    n_val = min(n_val, n - n_test)
-    labels: dict[str, str] = {}
-    for comp in shuffled[:n_test]:
-        labels[comp] = "test"
-    for comp in shuffled[n_test : n_test + n_val]:
-        labels[comp] = "val"
-    for comp in shuffled[n_test + n_val :]:
-        labels[comp] = "train"
-    return labels
-
-
 def resolve_splits(
     task_frames: Mapping[str, pd.DataFrame],
     master_index: Sequence[str],
@@ -381,8 +354,20 @@ def resolve_splits(
 
     unlabeled = [comp for comp in master if comp not in labels]
     if unlabeled:
-        rng = np.random.default_rng(random_seed)
-        labels.update(_random_split(unlabeled, val_split=val_split, test_split=test_split, rng=rng))
+        # Build a composition-availability matrix and split it so each task keeps
+        # representation across train/val/test (proportional for tasks/compositions with none).
+        availability = pd.DataFrame(
+            {task: [comp in frame.index for comp in unlabeled] for task, frame in task_frames.items()},
+            index=pd.Index(unlabeled, name="composition"),
+        )
+        splitter = MultiTaskSplitter(val_ratio=val_split, test_ratio=test_split, random_state=random_seed)
+        train_c, val_c, test_c = splitter.split(availability)
+        for comp in train_c:
+            labels[comp] = "train"
+        for comp in val_c:
+            labels[comp] = "val"
+        for comp in test_c:
+            labels[comp] = "test"
 
     resolved = [labels[comp] for comp in master]
     return pd.Series(resolved, index=pd.Index(master, name="composition"), dtype=object)

--- a/src/foundation_model/data/composition_sources.py
+++ b/src/foundation_model/data/composition_sources.py
@@ -294,8 +294,10 @@ def resolve_splits(
     """Derive a single composition-level train/val/test split.
 
     Per-task ``split`` columns are overlaid (precedence ``test > val > train``; conflicts are
-    warned). Compositions with no label from any task fall back to a proportional random
-    split. With ``test_all=True`` every composition is assigned to ``test``.
+    warned). Compositions with no label from any task fall back to a representation-aware
+    random split (:class:`~foundation_model.data.splitter.MultiTaskSplitter`), which
+    prioritizes rare tasks and preserves global val/test proportions. With ``test_all=True``
+    every composition is assigned to ``test``.
 
     Parameters
     ----------
@@ -307,7 +309,8 @@ def resolve_splits(
         Per-task name of the split column to read (tasks absent from the map, or whose
         column is missing from their frame, contribute no labels).
     val_split, test_split : float
-        Random-fallback proportions for unlabeled compositions.
+        Random-fallback proportions for unlabeled compositions (overall val/test fractions,
+        preserved globally by MultiTaskSplitter's cumulative allocation).
     random_seed : int | None
         Seed for the random fallback.
     test_all : bool

--- a/src/foundation_model/data/splitter.py
+++ b/src/foundation_model/data/splitter.py
@@ -10,24 +10,28 @@ import pandas as pd
 
 
 class MultiTaskSplitter:
-    """Split compositions into train/val/test while keeping every task represented.
+    """Split compositions into train/val/test, prioritizing rare tasks for representation.
 
     Operates on a composition-indexed **availability matrix** (rows = compositions, columns =
-    tasks, truthy where the task has data for that composition). Tasks are allocated rarest
-    first, so a scarce task secures representation in the validation and test splits before
-    common tasks consume the shared pool. Compositions available to no task are split
-    proportionally at the end.
+    tasks, truthy where the task has data for that composition). Compositions are grouped into
+    chunks rarest-task-first (then a leftover chunk for compositions available to no task), and
+    the holdout (val/test) budget is allocated across chunks with a **cumulative** rounding
+    scheme so global proportions are preserved — many tiny chunks no longer round individually
+    to zero and collapse val/test. Processing rare tasks first gives them first claim on that
+    budget, which *improves* their representation in val/test.
 
-    Used as the random fallback in
+    Note: this does not *guarantee* every task appears in every split — a task with very few
+    compositions, or small ratios, may still round to zero for that task (the global val/test
+    proportions are preserved regardless). Used as the random fallback in
     :func:`foundation_model.data.composition_sources.resolve_splits` for compositions that
     carry no explicit ``split`` label.
 
     Parameters
     ----------
     val_ratio : float, default=0.1
-        Fraction of each task's compositions assigned to validation.
+        Overall fraction of compositions assigned to validation.
     test_ratio : float, default=0.1
-        Fraction of each task's compositions assigned to test.
+        Overall fraction of compositions assigned to test.
     random_state : int | None, optional
         Seed for deterministic shuffling.
     """
@@ -46,28 +50,30 @@ class MultiTaskSplitter:
         self.test_ratio = test_ratio
         self.random_state = random_state
 
-    def _allocate(
-        self,
-        compositions: List[str],
-        rng: np.random.Generator,
-        train: List[str],
-        val: List[str],
-        test: List[str],
-    ) -> None:
-        """Shuffle ``compositions`` and append proportional shares to train/val/test."""
-        n = len(compositions)
-        if n == 0:
-            return
-        order = rng.permutation(n)
-        shuffled = [compositions[i] for i in order]
-        n_test = min(int(round(n * self.test_ratio)), n)
-        n_val = min(int(round(n * self.val_ratio)), n - n_test)
-        test.extend(shuffled[:n_test])
-        val.extend(shuffled[n_test : n_test + n_val])
-        train.extend(shuffled[n_test + n_val :])
+    def _chunks(self, availability: pd.DataFrame, index: List[str]) -> List[List[str]]:
+        """Group compositions rarest-task-first, then a leftover chunk for the rest."""
+        assigned: set[str] = set()
+        chunks: List[List[str]] = []
+        if availability.shape[1] > 0:
+            mask = availability.astype(bool)
+            mask.index = pd.Index(index)
+            counts = mask.sum(axis=0).sort_values()  # rarest task first
+            for task in counts.index:
+                column = mask[task]
+                avail = [comp for comp in index if column.loc[comp] and comp not in assigned]
+                if avail:
+                    chunks.append(avail)
+                    assigned.update(avail)
+        leftover = [comp for comp in index if comp not in assigned]
+        if leftover:
+            chunks.append(leftover)
+        return chunks
 
     def split(self, availability: pd.DataFrame) -> Tuple[List[str], List[str], List[str]]:
         """Split the availability matrix into train/val/test composition lists.
+
+        Holdout counts are accumulated across chunks (cumulative rounding) so global val/test
+        proportions are preserved even when chunks are tiny.
 
         Parameters
         ----------
@@ -86,19 +92,26 @@ class MultiTaskSplitter:
         train: List[str] = []
         val: List[str] = []
         test: List[str] = []
-        assigned: set[str] = set()
 
-        if availability.shape[1] > 0:
-            mask = availability.astype(bool)
-            mask.index = pd.Index(index)
-            # Rarest tasks first so scarce tasks secure val/test representation.
-            counts = mask.sum(axis=0).sort_values()
-            for task in counts.index:
-                column = mask[task]
-                avail = [comp for comp in index if column.loc[comp] and comp not in assigned]
-                self._allocate(avail, rng, train, val, test)
-                assigned.update(avail)
+        # Running float targets + already-allocated integer counts implement cumulative
+        # (largest-remainder) rounding, preventing many small chunks from each rounding to 0.
+        cum_test = 0.0
+        cum_val = 0.0
+        alloc_test = 0
+        alloc_val = 0
+        for chunk in self._chunks(availability, index):
+            n = len(chunk)
+            order = rng.permutation(n)
+            shuffled = [chunk[i] for i in order]
 
-        leftover = [comp for comp in index if comp not in assigned]
-        self._allocate(leftover, rng, train, val, test)
+            cum_test += n * self.test_ratio
+            cum_val += n * self.val_ratio
+            n_test = max(0, min(int(round(cum_test)) - alloc_test, n))
+            n_val = max(0, min(int(round(cum_val)) - alloc_val, n - n_test))
+            alloc_test += n_test
+            alloc_val += n_val
+
+            test.extend(shuffled[:n_test])
+            val.extend(shuffled[n_test : n_test + n_val])
+            train.extend(shuffled[n_test + n_val :])
         return train, val, test

--- a/src/foundation_model/data/splitter.py
+++ b/src/foundation_model/data/splitter.py
@@ -1,166 +1,104 @@
-import warnings
-from typing import Optional, Tuple
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Composition-level multi-task train/val/test splitter."""
+
+from typing import List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
 
 
 class MultiTaskSplitter:
-    """
-    A data splitter for multi-task learning that ensures all tasks have representation
-    in train/val/test splits while handling NaN values and limited data scenarios.
+    """Split compositions into train/val/test while keeping every task represented.
+
+    Operates on a composition-indexed **availability matrix** (rows = compositions, columns =
+    tasks, truthy where the task has data for that composition). Tasks are allocated rarest
+    first, so a scarce task secures representation in the validation and test splits before
+    common tasks consume the shared pool. Compositions available to no task are split
+    proportionally at the end.
+
+    Used as the random fallback in
+    :func:`foundation_model.data.composition_sources.resolve_splits` for compositions that
+    carry no explicit ``split`` label.
+
+    Parameters
+    ----------
+    val_ratio : float, default=0.1
+        Fraction of each task's compositions assigned to validation.
+    test_ratio : float, default=0.1
+        Fraction of each task's compositions assigned to test.
+    random_state : int | None, optional
+        Seed for deterministic shuffling.
     """
 
     def __init__(
         self,
-        train_ratio: float = 0.8,
         val_ratio: float = 0.1,
         test_ratio: float = 0.1,
         random_state: Optional[int] = None,
     ):
-        """
-        Initialize the splitter with desired split ratios.
-
-        Parameters
-        ----------
-        train_ratio : float, default=0.8
-            Ratio of data to use for training
-        val_ratio : float, default=0.1
-            Ratio of data to use for validation
-        test_ratio : float, default=0.1
-            Ratio of data to use for testing
-        random_state : int, optional
-            Random seed for reproducibility
-        """
-        # Validate ratios
-        total_ratio = train_ratio + val_ratio + test_ratio
-        if not np.isclose(total_ratio, 1.0):
-            raise ValueError(
-                f"Split ratios must sum to 1.0, got {total_ratio} ({train_ratio}, {val_ratio}, {test_ratio})"
-            )
-
-        self.train_ratio = train_ratio
+        if val_ratio < 0.0 or test_ratio < 0.0:
+            raise ValueError("val_ratio and test_ratio must be non-negative.")
+        if val_ratio + test_ratio > 1.0:
+            raise ValueError(f"val_ratio + test_ratio must not exceed 1.0 (got {val_ratio} + {test_ratio}).")
         self.val_ratio = val_ratio
         self.test_ratio = test_ratio
         self.random_state = random_state
 
-        if random_state is not None:
-            np.random.seed(random_state)
+    def _allocate(
+        self,
+        compositions: List[str],
+        rng: np.random.Generator,
+        train: List[str],
+        val: List[str],
+        test: List[str],
+    ) -> None:
+        """Shuffle ``compositions`` and append proportional shares to train/val/test."""
+        n = len(compositions)
+        if n == 0:
+            return
+        order = rng.permutation(n)
+        shuffled = [compositions[i] for i in order]
+        n_test = min(int(round(n * self.test_ratio)), n)
+        n_val = min(int(round(n * self.val_ratio)), n - n_test)
+        test.extend(shuffled[:n_test])
+        val.extend(shuffled[n_test : n_test + n_val])
+        train.extend(shuffled[n_test + n_val :])
 
-    def _get_task_data_counts(self, data: pd.DataFrame) -> pd.Series:
-        """
-        Count number of non-NaN values for each task.
-
-        Parameters
-        ----------
-        data : pd.DataFrame
-            DataFrame containing task data with possible NaN values
-
-        Returns
-        -------
-        pd.Series
-            Series containing non-NaN counts for each task, sorted ascending
-        """
-        return data.notna().sum().sort_values()
-
-    def _get_required_counts(self, total_count: int) -> Tuple[int, int, int]:
-        """
-        Calculate required counts for each split based on ratios.
-
-        Parameters
-        ----------
-        total_count : int
-            Total number of samples available
-
-        Returns
-        -------
-        Tuple[int, int, int]
-            Required counts for train, val, and test splits
-        """
-        train_count = int(np.floor(total_count * self.train_ratio))
-        val_count = int(np.floor(total_count * self.val_ratio))
-        test_count = total_count - train_count - val_count
-        return train_count, val_count, test_count
-
-    def split(self, data: pd.DataFrame) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-        """
-        Split data ensuring all tasks have representation in splits.
+    def split(self, availability: pd.DataFrame) -> Tuple[List[str], List[str], List[str]]:
+        """Split the availability matrix into train/val/test composition lists.
 
         Parameters
         ----------
-        data : pd.DataFrame
-            DataFrame where each column is a task and may contain NaN values
+        availability : pd.DataFrame
+            Indexed by composition; each column is a task with truthy values where the task
+            has data for that composition. May have zero columns (then every composition is
+            split proportionally).
 
         Returns
         -------
-        Tuple[np.ndarray, np.ndarray, np.ndarray]
-            Arrays of indices for train, validation, and test splits
+        Tuple[List[str], List[str], List[str]]
+            ``(train, val, test)`` composition keys (each composition appears exactly once).
         """
-        # Get task counts and sort by available data (ascending)
-        task_counts = self._get_task_data_counts(data)
+        rng = np.random.default_rng(self.random_state)
+        index = [str(c) for c in availability.index]
+        train: List[str] = []
+        val: List[str] = []
+        test: List[str] = []
+        assigned: set[str] = set()
 
-        # Initialize split sets for train/val/test
-        train_indices = set()
-        val_indices = set()
-        test_indices = set()
+        if availability.shape[1] > 0:
+            mask = availability.astype(bool)
+            mask.index = pd.Index(index)
+            # Rarest tasks first so scarce tasks secure val/test representation.
+            counts = mask.sum(axis=0).sort_values()
+            for task in counts.index:
+                column = mask[task]
+                avail = [comp for comp in index if column.loc[comp] and comp not in assigned]
+                self._allocate(avail, rng, train, val, test)
+                assigned.update(avail)
 
-        # Track allocated indices for each task
-        allocated_indices = set()
-
-        for task, count in task_counts.items():
-            # Get valid indices for this task (non-NaN values)
-            task_valid_indices = np.where(data[task].notna())[0]
-
-            # Remove already allocated indices
-            available_indices = np.array([idx for idx in task_valid_indices if idx not in allocated_indices])
-
-            if len(available_indices) == 0:
-                warnings.warn(f"Task {task} has no unallocated data points. Using already allocated indices.")
-                available_indices = task_valid_indices
-
-            # Shuffle available indices
-            np.random.shuffle(available_indices)
-
-            # Calculate required counts
-            train_needed, val_needed, test_needed = self._get_required_counts(len(available_indices))
-
-            # Calculate target samples for val/test
-            available_count = len(available_indices)
-            val_target = int(np.floor(available_count * self.val_ratio))
-            test_target = int(np.floor(available_count * self.test_ratio))
-            holdout_size = val_target + test_target
-
-            # First allocate validation and test sets
-            if holdout_size > 0:
-                # Reserve validation set
-                if self.val_ratio > 0:
-                    val_indices.update(available_indices[-val_target:])
-
-                # Reserve test set (can overlap with val if needed)
-                if self.test_ratio > 0:
-                    test_indices.update(available_indices[:test_target])
-
-                # Remaining data goes to train (ensuring no overlap with val/test)
-                if self.val_ratio > 0:
-                    train_indices.update(available_indices[:-val_target])
-                else:
-                    train_indices.update(available_indices[test_target:])
-            else:
-                # No validation or test needed, use all for training
-                train_indices.update(available_indices)
-
-            # Update allocated indices
-            allocated_indices.update(available_indices)
-
-        # Convert sets to sorted arrays
-        train_indices_arr = np.array(sorted(train_indices))
-        val_indices_arr = np.array(sorted(val_indices))
-        test_indices_arr = np.array(sorted(test_indices))
-
-        # Verify we have data in required splits
-        if len(train_indices_arr) == 0:
-            raise ValueError("No training data available after splitting")
-        if self.val_ratio > 0 and len(val_indices_arr) == 0:
-            raise ValueError("No validation data available after splitting")
-
-        return train_indices_arr, val_indices_arr, test_indices_arr
+        leftover = [comp for comp in index if comp not in assigned]
+        self._allocate(leftover, rng, train, val, test)
+        return train, val, test

--- a/src/foundation_model/data/splitter_test.py
+++ b/src/foundation_model/data/splitter_test.py
@@ -67,6 +67,24 @@ def test_rare_task_is_represented_in_each_split():
     assert sorted(train + val + test) == sorted(avail.index)
 
 
+def test_many_size_one_chunks_preserve_global_holdouts():
+    """Disjoint single-composition tasks must not collapse all holdouts to train (PR12 P1)."""
+    # 20 tasks, each owning exactly one distinct composition -> 20 size-1 chunks.
+    n = 20
+    rows = {}
+    for i in range(n):
+        flags = [False] * n
+        flags[i] = True
+        rows[f"t{i}"] = flags
+    avail = _availability(rows)
+    train, val, test = MultiTaskSplitter(val_ratio=0.1, test_ratio=0.1, random_state=0).split(avail)
+    # Per-chunk independent rounding would give 0 here; cumulative allocation preserves ~10%.
+    assert len(test) == 2
+    assert len(val) == 2
+    assert len(train) == 16
+    assert sorted(train + val + test) == sorted(avail.index)
+
+
 def test_no_columns_splits_proportionally():
     avail = pd.DataFrame(index=pd.Index([f"c{i}" for i in range(10)], name="composition"))
     train, val, test = MultiTaskSplitter(val_ratio=0.1, test_ratio=0.1, random_state=0).split(avail)

--- a/src/foundation_model/data/splitter_test.py
+++ b/src/foundation_model/data/splitter_test.py
@@ -1,0 +1,83 @@
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the composition-level MultiTaskSplitter (refactor PR4)."""
+
+import pandas as pd
+import pytest
+
+from foundation_model.data.splitter import MultiTaskSplitter
+
+
+def _availability(rows: dict[str, list[bool]]) -> pd.DataFrame:
+    """Build a composition-indexed availability matrix from {task: per-composition flags}."""
+    index = [f"c{i}" for i in range(len(next(iter(rows.values()))))]
+    return pd.DataFrame(rows, index=pd.Index(index, name="composition"))
+
+
+def test_rejects_negative_ratio():
+    with pytest.raises(ValueError, match="non-negative"):
+        MultiTaskSplitter(val_ratio=-0.1, test_ratio=0.1)
+
+
+def test_rejects_ratio_sum_above_one():
+    with pytest.raises(ValueError, match="must not exceed 1.0"):
+        MultiTaskSplitter(val_ratio=0.6, test_ratio=0.6)
+
+
+def test_partition_is_complete_and_disjoint():
+    avail = _availability({"t1": [True] * 10})
+    train, val, test = MultiTaskSplitter(val_ratio=0.2, test_ratio=0.2, random_state=0).split(avail)
+    combined = sorted(train + val + test)
+    assert combined == sorted(avail.index)
+    assert len(set(train) & set(val)) == 0
+    assert len(set(train) & set(test)) == 0
+    assert len(set(val) & set(test)) == 0
+
+
+def test_proportional_counts_single_task():
+    avail = _availability({"t1": [True] * 10})
+    train, val, test = MultiTaskSplitter(val_ratio=0.2, test_ratio=0.2, random_state=42).split(avail)
+    assert len(test) == 2
+    assert len(val) == 2
+    assert len(train) == 6
+
+
+def test_deterministic_with_seed():
+    avail = _availability({"t1": [True] * 12})
+    a = MultiTaskSplitter(val_ratio=0.25, test_ratio=0.25, random_state=7).split(avail)
+    b = MultiTaskSplitter(val_ratio=0.25, test_ratio=0.25, random_state=7).split(avail)
+    assert a == b
+
+
+def test_rare_task_is_represented_in_each_split():
+    """A scarce task (allocated first) should land in val and test, not only train."""
+    # t_rare has 6 compositions; t_common covers all 60. With 0.2/0.2 the rare task alone
+    # must contribute to val and test.
+    rare = [True] * 6 + [False] * 54
+    common = [True] * 60
+    avail = _availability({"t_common": common, "t_rare": rare})
+    splitter = MultiTaskSplitter(val_ratio=0.2, test_ratio=0.2, random_state=1)
+    train, val, test = splitter.split(avail)
+
+    rare_comps = {c for c, flag in zip(avail.index, rare) if flag}
+    assert rare_comps & set(val), "rare task should appear in validation"
+    assert rare_comps & set(test), "rare task should appear in test"
+    # Whole set still partitioned exactly once.
+    assert sorted(train + val + test) == sorted(avail.index)
+
+
+def test_no_columns_splits_proportionally():
+    avail = pd.DataFrame(index=pd.Index([f"c{i}" for i in range(10)], name="composition"))
+    train, val, test = MultiTaskSplitter(val_ratio=0.1, test_ratio=0.1, random_state=0).split(avail)
+    assert len(test) == 1
+    assert len(val) == 1
+    assert len(train) == 8
+
+
+def test_all_train_when_ratios_zero():
+    avail = _availability({"t1": [True] * 5})
+    train, val, test = MultiTaskSplitter(val_ratio=0.0, test_ratio=0.0, random_state=0).split(avail)
+    assert sorted(train) == sorted(avail.index)
+    assert val == []
+    assert test == []


### PR DESCRIPTION
## Scope

**PR4** — the final step of the composition-keyed data refactor (plan: `REFACTOR_composition_datamodule_PLAN.md` §3.5; follows #8/#10/#11). Gives `MultiTaskSplitter` a real, tested purpose as the representative random fallback, and refreshes the user-facing docs.

## What changed

### MultiTaskSplitter (`data/splitter.py`)
Previously exported but **unused and untested**. Rewritten to split a **composition-indexed availability matrix** (rows = compositions, columns = tasks, truthy where a task has data for that composition):
- Allocates **rarest tasks first** so a scarce task secures representation in val/test before common tasks consume the shared pool.
- Compositions available to no task are split proportionally at the end.
- Validates ratio bounds; deterministic under `random_state`.
- New `splitter_test.py`: partition completeness/disjointness, proportional counts, determinism, **rare-task representation**, zero-column → proportional, zero-ratio → all-train.

### resolve_splits (`data/composition_sources.py`)
- The random fallback (compositions with no explicit `split` label) now uses `MultiTaskSplitter` instead of the proportional `_random_split` (removed), so each task keeps representation across train/val/test. Existing `resolve_splits` tests (which assert split *counts*) still pass.

### Docs (`README.md`)
- Rewrote the data-input section for the composition-keyed API (`descriptor_fn` / `PrecomputedDescriptorSource` / per-task `data_files` / `split_column` / `task_masking_ratio` / `predict_idx`; split + prediction semantics).
- Rewrote the end-to-end scaling-law example (was doubly stale: old data API **and** removed `shared_block_dims`/`SEQUENCE`/`steps_column`) into a correct, concise composition-keyed walkthrough using per-task `task_masking_ratio`.
- (`AGENTS.md` Data section was already updated in #11.)

## Validation
- Full suite: **172 passed, 1 skipped** (skip = 2-GPU writer integration).
- `ruff` clean on touched files; `mypy` clean on `splitter.py` / `composition_sources.py` / `datamodule.py`.

## Note
Two unrelated `shared_block_dims` references remain in other (model-config) README example sections; they predate this refactor and are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)