### PR TITLE
test: smoke configs for dynamic task suite + progressive-clf (post-refactor verification)

### DIFF
--- a/samples/dynamic_task_suite_config_smoke.toml
+++ b/samples/dynamic_task_suite_config_smoke.toml
@@ -1,0 +1,45 @@
+# Smoke-test configuration for the dynamic task suite.
+#
+# Tiny end-to-end run (1 pretrain run, 1 epoch, small samples, 2+2 tasks) used to confirm the
+# suite still executes after the composition-keyed data refactor. Reuses the local polymer data.
+#
+#   ./run_dynamic_task_suite.sh samples/dynamic_task_suite_config_smoke.toml
+
+pretrain_data_path = "data/amorphous_polymer_non_PI_properties_20250730.parquet"
+finetune_data_path = "data/PolyInfo_properties_20250712.parquet"
+output_dir = "artifacts/smoke_test"
+
+pretrain_descriptor_path = "data/amorphous_polymer_FFDescriptor_20250730.parquet"
+finetune_descriptor_path = "data/PolyInfo_FFDescriptor_20250712.parquet"
+
+pretrain_scaler_path = "data/amorphous_polymer_properties_scaler_20250730.pkl.z"
+finetune_scaler_path = "data/PolyInfo_properties_scaler_20250712.pkl.z"
+
+# Model and training hyperparameters (kept tiny for a fast smoke test)
+shared_block_dims = [190, 256, 128]
+encoder_config = { type = "mlp" }
+head_hidden_dim = 64
+head_lr = 0.01
+num_pretrain_runs = 1
+pretrain_max_epochs = 1
+finetune_max_epochs = 1
+batch_size = 128
+num_workers = 0
+log_every_n_steps = 10
+random_seed_base = 17290
+datamodule_random_seed = 42
+pretrain_sample = 500
+finetune_sample = 500
+accelerator = "cpu"
+devices = 1
+early_stopping_patience = 5
+
+# A handful of tasks whose (normalized) columns exist in the polymer tables.
+pretrain_tasks = [
+    'density',
+    'Rg',
+]
+finetune_tasks = [
+    'Tg',
+    'Density',
+]

--- a/samples/progressive_clf_config_smoke.toml
+++ b/samples/progressive_clf_config_smoke.toml
@@ -1,0 +1,35 @@
+# Smoke-test configuration for the progressive pretrain -> classification finetune pipeline.
+#
+# Tiny end-to-end run (1 run, 1 epoch, 2 regression source tasks) used to confirm the pipeline
+# still executes after the composition-keyed data refactor. Reuses the local DOS/material data.
+#
+#   ./run_progressive_clf.sh samples/progressive_clf_config_smoke.toml
+
+data_path = "data/qc_ac_te_mp_dos_reformat_20250615_enforce_quaternary_test.pd.parquet"
+descriptor_path = "data/qc_ac_te_mp_dos_composition_desc_trans_20250615.pd.parquet"
+preprocessing_path = "data/preprocessing_objects_20250615.pkl.z"
+output_dir = "artifacts/progressive_clf_smoke"
+
+n_runs = 1
+pretrain_max_epochs = 1
+finetune_max_epochs = 1
+batch_size = 128
+early_stopping_patience = 5
+log_every_n_steps = 10
+
+random_seed_base = 17290
+datamodule_random_seed = 42
+
+latent_dim = 128
+head_hidden_dim = 64
+head_lr = 0.005
+
+# Two regression source tasks (skips kernel-center initialization for a fast smoke run).
+source_tasks = [
+    "density",
+    "formation_energy",
+]
+
+accelerator = "cpu"
+devices = 1
+num_workers = 0


### PR DESCRIPTION
## Scope

Adds two minimal **smoke-test configs** and documents that the prior end-to-end workflows still run after the composition-keyed data refactor (#8/#10/#11/#12). No source changes — config files only.

## Configs

- `samples/dynamic_task_suite_config_smoke.toml` — 1 pretrain run, 1 epoch, 500-sample cap, 2 pretrain (`density`, `Rg`) + 2 finetune (`Tg`, `Density`) tasks on the local polymer data.
- `samples/progressive_clf_config_smoke.toml` — 1 run, 1 epoch, 2 regression source tasks (`density`, `formation_energy`) on the local DOS/material data; finetunes the fixed `material_type` classifier.

Run via the existing wrappers:
```bash
./run_dynamic_task_suite.sh samples/dynamic_task_suite_config_smoke.toml
./run_progressive_clf.sh    samples/progressive_clf_config_smoke.toml
```

## Verification (local)

**Dynamic task suite** — full pipeline executed: progressive pretrain (`Rg` → `density`) → finetune (`Tg`, `Density`) → `predictions.parquet` + `metrics.json` (e.g. Tg R²≈0.44, 1 epoch) + prediction plots; `experiment_records.json` summary written.

**Progressive-clf** — progressive pretrain (2 stages) → `material_type` classification finetune (test_acc 0.98 on full data, 1 epoch); per-stage clf reports + `metrics.json` + `experiment_records.json` written.

Both exercise the refactored data path end-to-end: `descriptor_fn` + in-memory `task_frames`, `composition_column` resolution (incl. the `id`-index vs `composition`-column case), per-task masking, split handling, training, and prediction. Run outputs land under `artifacts/` (gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)