### PR TITLE
feat: continual multi-task rehearsal demo + KMD inverse design (all inorganic datasets/task types)

### DIFF
--- a/run_continual_rehearsal_demo.sh
+++ b/run_continual_rehearsal_demo.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Convenience wrapper for the continual multi-task rehearsal demo.
+# Usage:
+#   ./run_continual_rehearsal_demo.sh [CONFIG_PATH] [-- additional CLI args...]
+#
+# If CONFIG_PATH is omitted, the default sample config in samples/ is used.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${SCRIPT_DIR}"
+
+DEFAULT_CONFIG="${REPO_ROOT}/samples/continual_rehearsal_demo_config.toml"
+
+CONFIG_FILE="${1:-${DEFAULT_CONFIG}}"
+shift || true
+EXTRA_ARGS=()
+if [[ $# -gt 0 ]]; then
+  EXTRA_ARGS=("$@")
+fi
+
+if [[ ! -f "${CONFIG_FILE}" ]]; then
+  echo "Config file not found: ${CONFIG_FILE}" >&2
+  exit 1
+fi
+
+python3 -m foundation_model.scripts.continual_rehearsal_demo --config-file "${CONFIG_FILE}" "${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}"

--- a/run_continual_rehearsal_demo.sh
+++ b/run_continual_rehearsal_demo.sh
@@ -24,4 +24,45 @@ if [[ ! -f "${CONFIG_FILE}" ]]; then
   exit 1
 fi
 
-python3 -m foundation_model.scripts.continual_rehearsal_demo --config-file "${CONFIG_FILE}" "${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}"
+DATE_SUFFIX="$(date +"%y%m%d")"
+
+function has_flag() {
+  local flag="$1"
+  for arg in "${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}"; do
+    if [[ "${arg}" == "${flag}" || "${arg}" == ${flag}=* ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Append a date suffix to the config's output_dir so repeated runs don't clobber prior artifacts.
+OUTPUT_OVERRIDE=()
+if ! has_flag "--output-dir"; then
+  OUTPUT_BASE="$(python3 - "$CONFIG_FILE" <<'PY'
+import sys
+from pathlib import Path
+
+try:
+    import tomllib  # type: ignore[attr-defined]
+except ModuleNotFoundError:  # pragma: no cover
+    try:
+        import tomli as tomllib  # type: ignore
+    except ModuleNotFoundError:
+        print("", end="")
+        sys.exit(0)
+
+loaded = tomllib.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+value = loaded.get("output_dir") if isinstance(loaded, dict) else None
+if isinstance(value, str) and value.strip():
+    print(value.strip(), end="")
+PY
+)"
+  if [[ -z "${OUTPUT_BASE}" ]]; then
+    OUTPUT_BASE="${REPO_ROOT}/artifacts/continual_rehearsal"
+  fi
+  OUTPUT_BASE="${OUTPUT_BASE%/}"
+  OUTPUT_OVERRIDE=(--output-dir "${OUTPUT_BASE}_${DATE_SUFFIX}")
+fi
+
+python3 -m foundation_model.scripts.continual_rehearsal_demo --config-file "${CONFIG_FILE}" "${OUTPUT_OVERRIDE[@]+"${OUTPUT_OVERRIDE[@]}"}" "${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}"

--- a/samples/continual_rehearsal_demo_config.toml
+++ b/samples/continual_rehearsal_demo_config.toml
@@ -1,0 +1,35 @@
+# Continual multi-task learning demo with 5% rehearsal.
+#
+# Adds tasks one at a time (2 regression, 2 kernel regression, 1 classification); the built-in
+# autoencoder head stays on the whole time. When a new task head is appended, previously learned
+# tasks keep only ~replay_ratio of their valid training targets active (per-task masking), to
+# balance catastrophic forgetting against training cost.
+#
+#   ./run_continual_rehearsal_demo.sh samples/continual_rehearsal_demo_config.toml
+
+data_path = "data/qc_ac_te_mp_dos_reformat_20250615_enforce_quaternary_test.pd.parquet"
+descriptor_path = "data/qc_ac_te_mp_dos_composition_desc_trans_20250615.pd.parquet"
+preprocessing_path = "data/preprocessing_objects_20250615.pkl.z"
+output_dir = "artifacts/continual_rehearsal"
+
+task_sequence = ["density", "formation_energy", "dos_density", "power_factor", "material_type"]
+replay_ratio = 0.05
+
+max_epochs_per_step = 20
+batch_size = 256
+early_stopping_patience = 0
+
+latent_dim = 128
+encoder_hidden = 256
+head_hidden_dim = 64
+head_lr = 0.005
+encoder_lr = 0.005
+n_kernel = 15
+kr_lr = 5e-4
+kr_decay = 5e-5
+
+random_seed = 2025
+datamodule_random_seed = 42
+accelerator = "auto"
+devices = 1
+num_workers = 0

--- a/samples/continual_rehearsal_demo_config.toml
+++ b/samples/continual_rehearsal_demo_config.toml
@@ -14,9 +14,10 @@ qc_data_path = "data/qc_ac_te_mp_dos_reformat_20250615_enforce_quaternary_test.p
 qc_preprocessing_path = "data/preprocessing_objects_20250615.pkl.z"
 superconductor_path = "data/NEMAD_superconductor_20260425.parquet"
 magnetic_path = "data/NEMAD_magnetic_20260419.parquet"
+phonix_path = "data/phonix-db-filtered_20260425.parquet"
 output_dir = "artifacts/continual_rehearsal"
 
-task_sequence = ["density", "formation_energy", "dos_density", "power_factor", "material_type", "tc", "pressure", "curie", "magnetization"]
+task_sequence = ["density", "formation_energy", "dos_density", "power_factor", "material_type", "tc", "pressure", "curie", "magnetization", "neel", "kp", "klat"]
 replay_ratio = 0.05
 # sample_per_dataset = 8000  # uncomment to cap rows per dataset for a faster run
 

--- a/samples/continual_rehearsal_demo_config.toml
+++ b/samples/continual_rehearsal_demo_config.toml
@@ -1,7 +1,8 @@
 # Continual multi-task rehearsal + inverse-design demo (full run, 20 epochs/step).
 #
 # All inorganic datasets + all task types: 2 reg + 2 kernel reg + 1 clf (qc_ac_te_mp) +
-# 2 reg (NEMAD superconductor) + 2 reg (NEMAD magnetic) + always-on autoencoder. Tasks are
+# 2 reg (NEMAD superconductor: tc, pressure) + 3 reg (NEMAD magnetic: curie, magnetization, neel) +
+# 2 reg (phonix-db: kp, klat) + always-on autoencoder. Tasks are
 # added incrementally with 5% rehearsal of learned tasks; KMD-1d descriptors (invertible) are
 # computed on the fly. A final inverse-design stage optimizes the latent toward 2 regression
 # targets + increased quasicrystal probability and decodes the descriptor back to a composition.

--- a/samples/continual_rehearsal_demo_config.toml
+++ b/samples/continual_rehearsal_demo_config.toml
@@ -1,24 +1,28 @@
-# Continual multi-task learning demo with 5% rehearsal.
+# Continual multi-task rehearsal + inverse-design demo (full run, 20 epochs/step).
 #
-# Adds tasks one at a time (2 regression, 2 kernel regression, 1 classification); the built-in
-# autoencoder head stays on the whole time. When a new task head is appended, previously learned
-# tasks keep only ~replay_ratio of their valid training targets active (per-task masking), to
-# balance catastrophic forgetting against training cost.
+# All inorganic datasets + all task types: 2 reg + 2 kernel reg + 1 clf (qc_ac_te_mp) +
+# 2 reg (NEMAD superconductor) + 2 reg (NEMAD magnetic) + always-on autoencoder. Tasks are
+# added incrementally with 5% rehearsal of learned tasks; KMD-1d descriptors (invertible) are
+# computed on the fly. A final inverse-design stage optimizes the latent toward 2 regression
+# targets + increased quasicrystal probability and decodes the descriptor back to a composition.
 #
 #   ./run_continual_rehearsal_demo.sh samples/continual_rehearsal_demo_config.toml
+#
+# sample_per_dataset = null uses every row (heavier); set an integer to cap per dataset for speed.
 
-data_path = "data/qc_ac_te_mp_dos_reformat_20250615_enforce_quaternary_test.pd.parquet"
-descriptor_path = "data/qc_ac_te_mp_dos_composition_desc_trans_20250615.pd.parquet"
-preprocessing_path = "data/preprocessing_objects_20250615.pkl.z"
+qc_data_path = "data/qc_ac_te_mp_dos_reformat_20250615_enforce_quaternary_test.pd.parquet"
+qc_preprocessing_path = "data/preprocessing_objects_20250615.pkl.z"
+superconductor_path = "data/NEMAD_superconductor_20260425.parquet"
+magnetic_path = "data/NEMAD_magnetic_20260419.parquet"
 output_dir = "artifacts/continual_rehearsal"
 
-task_sequence = ["density", "formation_energy", "dos_density", "power_factor", "material_type"]
+task_sequence = ["density", "formation_energy", "dos_density", "power_factor", "material_type", "tc", "pressure", "curie", "magnetization"]
 replay_ratio = 0.05
+# sample_per_dataset = 8000  # uncomment to cap rows per dataset for a faster run
 
 max_epochs_per_step = 20
 batch_size = 256
-early_stopping_patience = 0
-
+n_grids = 8
 latent_dim = 128
 encoder_hidden = 256
 head_hidden_dim = 64
@@ -27,6 +31,12 @@ encoder_lr = 0.005
 n_kernel = 15
 kr_lr = 5e-4
 kr_decay = 5e-5
+
+inverse_n_seeds = 16
+inverse_steps = 300
+inverse_lr = 0.05
+inverse_reg_tasks = ["density", "formation_energy"]
+inverse_reg_targets = [1.5, -1.5]
 
 random_seed = 2025
 datamodule_random_seed = 42

--- a/samples/continual_rehearsal_demo_config_smoke.toml
+++ b/samples/continual_rehearsal_demo_config_smoke.toml
@@ -1,28 +1,32 @@
-# Smoke-test configuration for the continual rehearsal demo.
+# Smoke-test config for the continual rehearsal + inverse-design demo.
 #
-# Tiny end-to-end run (1500-sample cap, 1 epoch per step) to confirm the full pipeline executes:
-# 2 regression + 2 kernel regression + 1 classification added incrementally, AE always on, 5%
-# rehearsal of learned tasks, per-step + forgetting plots.
+# Tiny end-to-end run (500 rows/dataset, 1 epoch/step) over all inorganic datasets and task types:
+# 2 reg + 2 kernel reg + 1 clf (qc_ac_te_mp) + 2 reg (NEMAD superconductor) + 2 reg (NEMAD magnetic),
+# AE always on, 5% rehearsal, then a short inverse-design stage. KMD-1d descriptors (invertible).
 #
 #   ./run_continual_rehearsal_demo.sh samples/continual_rehearsal_demo_config_smoke.toml
 
-data_path = "data/qc_ac_te_mp_dos_reformat_20250615_enforce_quaternary_test.pd.parquet"
-descriptor_path = "data/qc_ac_te_mp_dos_composition_desc_trans_20250615.pd.parquet"
-preprocessing_path = "data/preprocessing_objects_20250615.pkl.z"
+qc_data_path = "data/qc_ac_te_mp_dos_reformat_20250615_enforce_quaternary_test.pd.parquet"
+qc_preprocessing_path = "data/preprocessing_objects_20250615.pkl.z"
+superconductor_path = "data/NEMAD_superconductor_20260425.parquet"
+magnetic_path = "data/NEMAD_magnetic_20260419.parquet"
 output_dir = "artifacts/continual_rehearsal_smoke"
 
-task_sequence = ["density", "formation_energy", "dos_density", "power_factor", "material_type"]
+task_sequence = ["density", "formation_energy", "dos_density", "power_factor", "material_type", "tc", "pressure", "curie", "magnetization"]
 replay_ratio = 0.05
+sample_per_dataset = 500
 
-sample = 1500
 max_epochs_per_step = 1
 batch_size = 256
-early_stopping_patience = 0
-
+n_grids = 8
 latent_dim = 128
 encoder_hidden = 256
 head_hidden_dim = 64
 n_kernel = 15
+
+inverse_n_seeds = 8
+inverse_steps = 50
+inverse_lr = 0.05
 
 random_seed = 2025
 datamodule_random_seed = 42

--- a/samples/continual_rehearsal_demo_config_smoke.toml
+++ b/samples/continual_rehearsal_demo_config_smoke.toml
@@ -1,7 +1,8 @@
 # Smoke-test config for the continual rehearsal + inverse-design demo.
 #
 # Tiny end-to-end run (500 rows/dataset, 1 epoch/step) over all inorganic datasets and task types:
-# 2 reg + 2 kernel reg + 1 clf (qc_ac_te_mp) + 2 reg (NEMAD superconductor) + 2 reg (NEMAD magnetic),
+# 2 reg + 2 kernel reg + 1 clf (qc_ac_te_mp) + 2 reg (NEMAD superconductor) +
+# 3 reg (NEMAD magnetic: curie, magnetization, neel) + 2 reg (phonix-db: kp, klat),
 # AE always on, 5% rehearsal, then a short inverse-design stage. KMD-1d descriptors (invertible).
 #
 #   ./run_continual_rehearsal_demo.sh samples/continual_rehearsal_demo_config_smoke.toml

--- a/samples/continual_rehearsal_demo_config_smoke.toml
+++ b/samples/continual_rehearsal_demo_config_smoke.toml
@@ -10,9 +10,10 @@ qc_data_path = "data/qc_ac_te_mp_dos_reformat_20250615_enforce_quaternary_test.p
 qc_preprocessing_path = "data/preprocessing_objects_20250615.pkl.z"
 superconductor_path = "data/NEMAD_superconductor_20260425.parquet"
 magnetic_path = "data/NEMAD_magnetic_20260419.parquet"
+phonix_path = "data/phonix-db-filtered_20260425.parquet"
 output_dir = "artifacts/continual_rehearsal_smoke"
 
-task_sequence = ["density", "formation_energy", "dos_density", "power_factor", "material_type", "tc", "pressure", "curie", "magnetization"]
+task_sequence = ["density", "formation_energy", "dos_density", "power_factor", "material_type", "tc", "pressure", "curie", "magnetization", "neel", "kp", "klat"]
 replay_ratio = 0.05
 sample_per_dataset = 500
 

--- a/samples/continual_rehearsal_demo_config_smoke.toml
+++ b/samples/continual_rehearsal_demo_config_smoke.toml
@@ -1,0 +1,31 @@
+# Smoke-test configuration for the continual rehearsal demo.
+#
+# Tiny end-to-end run (1500-sample cap, 1 epoch per step) to confirm the full pipeline executes:
+# 2 regression + 2 kernel regression + 1 classification added incrementally, AE always on, 5%
+# rehearsal of learned tasks, per-step + forgetting plots.
+#
+#   ./run_continual_rehearsal_demo.sh samples/continual_rehearsal_demo_config_smoke.toml
+
+data_path = "data/qc_ac_te_mp_dos_reformat_20250615_enforce_quaternary_test.pd.parquet"
+descriptor_path = "data/qc_ac_te_mp_dos_composition_desc_trans_20250615.pd.parquet"
+preprocessing_path = "data/preprocessing_objects_20250615.pkl.z"
+output_dir = "artifacts/continual_rehearsal_smoke"
+
+task_sequence = ["density", "formation_energy", "dos_density", "power_factor", "material_type"]
+replay_ratio = 0.05
+
+sample = 1500
+max_epochs_per_step = 1
+batch_size = 256
+early_stopping_patience = 0
+
+latent_dim = 128
+encoder_hidden = 256
+head_hidden_dim = 64
+n_kernel = 15
+
+random_seed = 2025
+datamodule_random_seed = 42
+accelerator = "cpu"
+devices = 1
+num_workers = 0

--- a/src/foundation_model/models/flexible_multi_task_model.py
+++ b/src/foundation_model/models/flexible_multi_task_model.py
@@ -1742,10 +1742,11 @@ class FlexibleMultiTaskModel(L.LightningModule):
 
         Parameters
         ----------
-        task_name : str
-            Regression task to optimise. Ignored when ``task_targets`` is provided.
+        task_name : str | None
+            Regression task to optimise (legacy single-task path). Optional — and ignored — when
+            ``task_targets`` or ``class_targets`` is provided; required otherwise.
         initial_input : torch.Tensor
-            Seed inputs, shape (B, input_dim).
+            Seed inputs, shape (B, input_dim). Always required (raises ``ValueError`` if ``None``).
         mode : str, optional
             ``"max"`` or ``"min"``. Ignored when ``target_value`` / ``task_targets`` is set.
         steps : int, optional
@@ -1816,11 +1817,18 @@ class FlexibleMultiTaskModel(L.LightningModule):
                     raise ValueError(
                         f"Task '{name}' not found in model. Available tasks: {list(self.task_heads.keys())}"
                     )
-                if self.task_configs_map[name].type != TaskType.CLASSIFICATION:
+                cls_cfg = self.task_configs_map[name]
+                if cls_cfg.type != TaskType.CLASSIFICATION:
                     raise ValueError(f"class_targets task '{name}' must be a classification task.")
                 idxs = [int(classes)] if isinstance(classes, int) else [int(c) for c in classes]
                 if not idxs:
                     raise ValueError(f"class_targets['{name}'] must specify at least one class index.")
+                num_classes = getattr(cls_cfg, "num_classes", None)
+                if num_classes is not None and any(not 0 <= i < num_classes for i in idxs):
+                    raise ValueError(
+                        f"class_targets['{name}'] indices {idxs} out of range for a "
+                        f"{num_classes}-class head; valid indices are [0, {num_classes})."
+                    )
                 class_target_map[name] = idxs
 
         # Legacy single-task path (mode / target_value) only when no target maps are given
@@ -1896,7 +1904,7 @@ class FlexibleMultiTaskModel(L.LightningModule):
             """Stack per-task scores to (B, T); return (B, 0) when there are no regression tasks."""
             if vals:
                 return torch.stack(vals, dim=-1)
-            return torch.zeros((input_tensor.shape[0], 0), device=device)
+            return torch.zeros((input_tensor.shape[0], 0), device=device, dtype=input_tensor.dtype)
 
         def _class_loss_terms(h_task: torch.Tensor) -> list[torch.Tensor]:
             """``-log P(target classes)`` per classification objective (maximize that prob)."""

--- a/src/foundation_model/models/flexible_multi_task_model.py
+++ b/src/foundation_model/models/flexible_multi_task_model.py
@@ -1718,8 +1718,8 @@ class FlexibleMultiTaskModel(L.LightningModule):
 
     def optimize_latent(
         self,
-        task_name: str,
-        initial_input: torch.Tensor,
+        task_name: str | None = None,
+        initial_input: torch.Tensor | None = None,
         mode: str = "max",
         steps: int = 200,
         lr: float = 0.1,
@@ -1727,6 +1727,7 @@ class FlexibleMultiTaskModel(L.LightningModule):
         perturbation_std: float = 0.0,
         target_value: torch.Tensor | float | None = None,
         task_targets: Mapping[str, torch.Tensor | float] | None = None,
+        class_targets: Mapping[str, int | Sequence[int]] | None = None,
         optimize_space: str = "input",
     ) -> OptimizationResult:
         """
@@ -1758,7 +1759,11 @@ class FlexibleMultiTaskModel(L.LightningModule):
         target_value : float | Tensor | None, optional
             Minimise MSE to this scalar target (single task). Overrides ``mode``.
         task_targets : Mapping[str, float | Tensor] | None, optional
-            Multi-task targets. When provided, ``mode`` and ``target_value`` are ignored.
+            Multi-task regression targets. When provided, ``mode`` and ``target_value`` are ignored.
+        class_targets : Mapping[str, int | Sequence[int]] | None, optional
+            Classification objectives: maps a classification task name to the class index (or
+            indices) whose combined probability should be *maximized*. Adds a ``-log P(target
+            classes)`` term to the objective and may be combined with ``task_targets``.
         optimize_space : str, optional
             ``"input"`` or ``"latent"``. Default ``"input"``.
 
@@ -1783,7 +1788,7 @@ class FlexibleMultiTaskModel(L.LightningModule):
         if optimize_space not in {"input", "latent"}:
             raise ValueError(f"optimize_space must be 'input' or 'latent', got '{optimize_space}'")
 
-        # Validate task configurations
+        # Validate regression targets
         target_tasks: dict[str, torch.Tensor | float] | None = None
         if task_targets is not None:
             if not isinstance(task_targets, Mapping) or len(task_targets) == 0:
@@ -1799,8 +1804,28 @@ class FlexibleMultiTaskModel(L.LightningModule):
                 cfg = self.task_configs_map[name]
                 if cfg.type != TaskType.REGRESSION:
                     raise ValueError(f"Task '{name}' must be a regression task for optimization, got {cfg.type}")
-        else:
-            if task_name not in self.task_heads:
+
+        # Validate classification objectives (maximize combined class probability)
+        class_target_map: dict[str, list[int]] | None = None
+        if class_targets is not None:
+            if not isinstance(class_targets, Mapping) or len(class_targets) == 0:
+                raise ValueError("class_targets must be a non-empty mapping of task_name -> class index/indices")
+            class_target_map = {}
+            for name, classes in class_targets.items():
+                if name not in self.task_heads:
+                    raise ValueError(
+                        f"Task '{name}' not found in model. Available tasks: {list(self.task_heads.keys())}"
+                    )
+                if self.task_configs_map[name].type != TaskType.CLASSIFICATION:
+                    raise ValueError(f"class_targets task '{name}' must be a classification task.")
+                idxs = [int(classes)] if isinstance(classes, int) else [int(c) for c in classes]
+                if not idxs:
+                    raise ValueError(f"class_targets['{name}'] must specify at least one class index.")
+                class_target_map[name] = idxs
+
+        # Legacy single-task path (mode / target_value) only when no target maps are given
+        if target_tasks is None and class_target_map is None:
+            if task_name is None or task_name not in self.task_heads:
                 raise ValueError(
                     f"Task '{task_name}' not found in model. Available tasks: {list(self.task_heads.keys())}"
                 )
@@ -1813,16 +1838,14 @@ class FlexibleMultiTaskModel(L.LightningModule):
         # Validate autoencoder availability for latent-space mode
         if optimize_space == "latent":
             if _AE_TASK not in self.task_heads:
-                raise ValueError(
-                    "optimize_space='latent' requires the model to be built with enable_autoencoder=True."
-                )
+                raise ValueError("optimize_space='latent' requires the model to be built with enable_autoencoder=True.")
             if not isinstance(self.task_heads[_AE_TASK], AutoEncoderHead):
                 raise ValueError(
                     f"Task '{_AE_TASK}' exists but is not an AutoEncoderHead; "
                     "latent-space optimization requires the built-in reconstruction head."
                 )
 
-        if target_tasks is None and mode not in {"max", "min"}:
+        if target_tasks is None and class_target_map is None and mode not in {"max", "min"}:
             raise ValueError(f"mode must be 'max' or 'min', got '{mode}'")
 
         if num_restarts < 1:
@@ -1857,13 +1880,41 @@ class FlexibleMultiTaskModel(L.LightningModule):
         elif target_value is not None:
             target_tensor = torch.as_tensor(target_value, device=device, dtype=input_tensor.dtype)
 
+        class_index_map: dict[str, torch.Tensor] = {}
+        if class_target_map is not None:
+            class_index_map = {
+                name: torch.as_tensor(idxs, device=device, dtype=torch.long) for name, idxs in class_target_map.items()
+            }
+
         # Helper to reduce predictions to scalar per task/batch
         def _reduce_pred(pred: torch.Tensor) -> torch.Tensor:
             if pred.ndim == 1:
                 return pred
             return pred.mean(dim=tuple(range(1, pred.ndim)))
 
-        tasks_for_optimization = list(target_tasks.keys()) if target_tasks is not None else [task_name]
+        def _stack_scores(vals: list[torch.Tensor]) -> torch.Tensor:
+            """Stack per-task scores to (B, T); return (B, 0) when there are no regression tasks."""
+            if vals:
+                return torch.stack(vals, dim=-1)
+            return torch.zeros((input_tensor.shape[0], 0), device=device)
+
+        def _class_loss_terms(h_task: torch.Tensor) -> list[torch.Tensor]:
+            """``-log P(target classes)`` per classification objective (maximize that prob)."""
+            terms: list[torch.Tensor] = []
+            for cname, cidx in class_index_map.items():
+                logits = self.task_heads[cname](h_task)
+                log_probs = F.log_softmax(logits, dim=-1)
+                combined = torch.logsumexp(log_probs.index_select(-1, cidx), dim=-1)
+                terms.append(-combined.mean())
+            return terms
+
+        if target_tasks is not None:
+            tasks_for_optimization = list(target_tasks.keys())
+        elif class_target_map is not None:
+            tasks_for_optimization = []  # classification-only objective
+        else:
+            assert task_name is not None  # guaranteed by validation above
+            tasks_for_optimization = [task_name]
         num_targets = len(tasks_for_optimization)
 
         optimized_inputs: list[torch.Tensor] = []
@@ -1886,7 +1937,7 @@ class FlexibleMultiTaskModel(L.LightningModule):
                     for name in tasks_for_optimization:
                         pred = self.task_heads[name](h_task)
                         initial_vals.append(_reduce_pred(pred).detach())
-                    initial_vals = torch.stack(initial_vals, dim=-1)  # (B, T)
+                    initial_vals = _stack_scores(initial_vals)  # (B, T)
                     initial_score = initial_vals
                     initial_scores_list.append(initial_score)
 
@@ -1929,7 +1980,8 @@ class FlexibleMultiTaskModel(L.LightningModule):
                                 expanded_target = expanded_target.expand(pred.shape)
                             loss_terms.append(F.mse_loss(pred, expanded_target))
 
-                    per_task_values_tensor = torch.stack(per_task_values, dim=-1)  # (B, T)
+                    loss_terms.extend(_class_loss_terms(h_task))
+                    per_task_values_tensor = _stack_scores(per_task_values)  # (B, T)
 
                     if loss_terms:
                         loss = torch.stack(loss_terms).mean()
@@ -1954,7 +2006,7 @@ class FlexibleMultiTaskModel(L.LightningModule):
                     for name in tasks_for_optimization:
                         pred = self.task_heads[name](h_task)
                         per_task_final.append(_reduce_pred(pred).detach())
-                    per_task_final_tensor = torch.stack(per_task_final, dim=-1)  # (B, T)
+                    per_task_final_tensor = _stack_scores(per_task_final)  # (B, T)
                     optimized_input = optim_input.detach()
 
                 optimized_inputs.append(optimized_input.detach())  # (B, D)
@@ -1979,7 +2031,7 @@ class FlexibleMultiTaskModel(L.LightningModule):
                     for name in tasks_for_optimization:
                         pred = self.task_heads[name](h_task)
                         initial_vals.append(_reduce_pred(pred).detach())
-                    initial_vals = torch.stack(initial_vals, dim=-1)  # (B, T)
+                    initial_vals = _stack_scores(initial_vals)  # (B, T)
                     initial_score = initial_vals
                     initial_scores_list.append(initial_score)
 
@@ -2024,7 +2076,8 @@ class FlexibleMultiTaskModel(L.LightningModule):
                                 expanded_target = expanded_target.expand(pred.shape)
                             loss_terms.append(F.mse_loss(pred, expanded_target))
 
-                    per_task_values_tensor = torch.stack(per_task_values, dim=-1)  # (B, T)
+                    loss_terms.extend(_class_loss_terms(h_task))
+                    per_task_values_tensor = _stack_scores(per_task_values)  # (B, T)
 
                     if loss_terms:
                         loss = torch.stack(loss_terms).mean()
@@ -2049,7 +2102,7 @@ class FlexibleMultiTaskModel(L.LightningModule):
                     for name in tasks_for_optimization:
                         pred = self.task_heads[name](final_h_task)
                         per_task_final.append(_reduce_pred(pred).detach())
-                    per_task_final_tensor = torch.stack(per_task_final, dim=-1)  # (B, T)
+                    per_task_final_tensor = _stack_scores(per_task_final)  # (B, T)
 
                     # Reconstruct input via the built-in reconstruction head
                     reconstructed_input = self.task_heads[_AE_TASK](final_h_task)

--- a/src/foundation_model/models/flexible_multi_task_model_test.py
+++ b/src/foundation_model/models/flexible_multi_task_model_test.py
@@ -961,6 +961,17 @@ def test_optimize_latent_class_targets_rejects_regression_task():
         )
 
 
+def test_optimize_latent_class_targets_rejects_out_of_range_index():
+    model = _make_reg_clf_model()  # "cls" head has num_classes=3 → valid indices [0, 3)
+    for bad in ([3], [-1]):
+        with pytest.raises(ValueError, match="out of range"):
+            model.optimize_latent(
+                initial_input=torch.randn(2, INPUT_DIM),
+                class_targets={"cls": bad},
+                optimize_space="input",
+            )
+
+
 def test_optimize_latent_class_targets_only_no_regression():
     torch.manual_seed(0)
     model = _make_reg_clf_model()

--- a/src/foundation_model/models/flexible_multi_task_model_test.py
+++ b/src/foundation_model/models/flexible_multi_task_model_test.py
@@ -903,6 +903,73 @@ def test_optimize_latent_space_requires_ae():
         )
 
 
+# --- optimize_latent classification objective (class_targets) ---------------
+
+
+def _make_reg_clf_model():
+    enc = MLPEncoderConfig(hidden_dims=[INPUT_DIM, 16, LATENT_DIM])
+    tasks = [
+        RegressionTaskConfig(name="prop", data_column="prop", dims=[LATENT_DIM, 8, 1]),
+        ClassificationTaskConfig(name="cls", data_column="cls", num_classes=3, dims=[LATENT_DIM, 8, 3]),
+    ]
+    return FlexibleMultiTaskModel(task_configs=tasks, encoder_config=enc, enable_autoencoder=True)
+
+
+def _target_class_prob(model, x, classes):
+    with torch.no_grad():
+        h = torch.tanh(model.encoder(x))
+        probs = torch.softmax(model.task_heads["cls"](h), dim=-1)
+        return probs[:, classes].sum(dim=-1).mean().item()
+
+
+def test_optimize_latent_class_target_input_space_increases_prob():
+    torch.manual_seed(0)
+    model = _make_reg_clf_model()
+    model.eval()  # match optimize_latent's internal eval mode (consistent BatchNorm stats)
+    x = torch.randn(8, INPUT_DIM)
+    target_classes = [2]
+    before = _target_class_prob(model, x, target_classes)
+    res = model.optimize_latent(
+        initial_input=x, class_targets={"cls": target_classes}, optimize_space="input", steps=100, lr=0.2
+    )
+    after = _target_class_prob(model, res.optimized_input[:, 0, :], target_classes)
+    assert after > before  # objective drives the target-class probability up
+
+
+def test_optimize_latent_combined_reg_and_class_targets():
+    torch.manual_seed(0)
+    model = _make_reg_clf_model()
+    x = torch.randn(5, INPUT_DIM)
+    res = model.optimize_latent(
+        initial_input=x,
+        task_targets={"prop": 1.0},
+        class_targets={"cls": [0, 1]},
+        optimize_space="latent",
+        steps=20,
+    )
+    assert res.optimized_input.shape == (5, 1, INPUT_DIM)  # reconstructed via AE
+    assert res.optimized_target.shape == (5, 1, 1)  # one regression task tracked
+
+
+def test_optimize_latent_class_targets_rejects_regression_task():
+    model = _make_reg_clf_model()
+    with pytest.raises(ValueError, match="must be a classification task"):
+        model.optimize_latent(
+            initial_input=torch.randn(2, INPUT_DIM),
+            class_targets={"prop": [0]},
+            optimize_space="input",
+        )
+
+
+def test_optimize_latent_class_targets_only_no_regression():
+    torch.manual_seed(0)
+    model = _make_reg_clf_model()
+    x = torch.randn(4, INPUT_DIM)
+    res = model.optimize_latent(initial_input=x, class_targets={"cls": [1]}, optimize_space="input", steps=10)
+    assert res.optimized_input.shape == (4, 1, INPUT_DIM)
+    assert res.optimized_target.shape == (4, 1, 0)  # no regression tasks tracked
+
+
 def test_optimize_latent_space_with_ae():
     model = _make_model()
     model.eval()

--- a/src/foundation_model/scripts/continual_rehearsal_demo.py
+++ b/src/foundation_model/scripts/continual_rehearsal_demo.py
@@ -2,21 +2,30 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Continual multi-task learning demo with rehearsal (5% replay).
+Continual multi-task learning demo with rehearsal (5% replay) + inverse design.
 
-Comprehensive end-to-end exercise of the composition-keyed data stack + FlexibleMultiTaskModel
-across all task types. Tasks are added one at a time (mimicking dynamic finetuning); the
-built-in autoencoder head stays on the whole time, and each time a new task head is appended,
-previously learned tasks are *not* fully retrained — instead each keeps only ~``replay_ratio``
-of its valid training targets active per epoch (via per-task ``task_masking_ratio``), striking a
-balance between catastrophic forgetting and training cost.
+Comprehensive end-to-end exercise of the composition-keyed data stack +
+FlexibleMultiTaskModel across every task type and every inorganic dataset:
 
-After every step the new head's performance and the degradation of all previously learned heads
-are evaluated on the fixed test split and plotted.
+* 2 regression + 2 kernel regression + 1 classification from the qc_ac_te_mp DOS/material set,
+* 2 regression from the NEMAD superconductor set, 2 regression from the NEMAD magnetic set,
+* the built-in autoencoder head (always on).
 
-Run via the wrapper:
+All compositions are featurized **on the fly** with the invertible KMD-1d descriptor
+(:mod:`foundation_model.utils.kmd_plus`), joined across datasets by composition formula.
+
+Tasks are added one at a time (dynamic finetuning). The AE head stays on the whole time; when a
+new head is appended, previously learned tasks keep only ~``replay_ratio`` of their valid
+training targets active (per-task ``task_masking_ratio``) — balancing forgetting against cost.
+Every step evaluates *all* active heads on the fixed test split and plots the new head plus the
+per-task forgetting trajectory.
+
+After all tasks are learned, an **inverse-design** stage optimizes the latent space toward a
+condition (2 regression targets + increased quasicrystal probability) and decodes the optimized
+KMD descriptor back to a composition via ``KMD.inverse``.
+
+Run:
     ./run_continual_rehearsal_demo.sh samples/continual_rehearsal_demo_config_smoke.toml
-or directly:
     python -m foundation_model.scripts.continual_rehearsal_demo --config-file <toml>
 """
 
@@ -39,7 +48,6 @@ import numpy as np
 import pandas as pd
 import torch
 from lightning import Trainer, seed_everything
-from lightning.pytorch.callbacks import EarlyStopping
 from loguru import logger
 from sklearn.metrics import accuracy_score, f1_score, mean_absolute_error, r2_score  # type: ignore[import-untyped]
 
@@ -52,37 +60,51 @@ from foundation_model.models.model_config import (
     OptimizerConfig,
     RegressionTaskConfig,
 )
+from foundation_model.utils.kmd_plus import DEFAULT_ELEMENTS, KMD, element_features, formula_to_composition
 
-# --- Task catalogue (columns in the qc_ac_te_mp DOS/material dataset) ---------
-# Each task owns its target column; kernel-regression tasks add a t (x-axis) column.
+# --- Task catalogue ----------------------------------------------------------
+# source: which dataset the task's targets come from ("qc" / "superconductor" / "magnetic").
+# qc columns are pre-normalized; NEMAD raw columns are z-scored at load time.
 TASK_SPECS: dict[str, dict[str, Any]] = {
-    "density": {"kind": "reg", "column": "Density (normalized)"},
-    "formation_energy": {"kind": "reg", "column": "Formation energy per atom (normalized)"},
-    "dos_density": {"kind": "kr", "column": "DOS density (normalized)", "t_column": "DOS energy"},
-    "power_factor": {"kind": "kr", "column": "Power factor (normalized)", "t_column": "Power factor (T/K)"},
-    "material_type": {"kind": "clf", "column": "Material type (label)", "num_classes": 5},
+    "density": {"source": "qc", "kind": "reg", "column": "Density (normalized)"},
+    "formation_energy": {"source": "qc", "kind": "reg", "column": "Formation energy per atom (normalized)"},
+    "dos_density": {"source": "qc", "kind": "kr", "column": "DOS density (normalized)", "t_column": "DOS energy"},
+    "power_factor": {
+        "source": "qc",
+        "kind": "kr",
+        "column": "Power factor (normalized)",
+        "t_column": "Power factor (T/K)",
+    },
+    "material_type": {"source": "qc", "kind": "clf", "column": "Material type (label)", "num_classes": 5},
+    "tc": {"source": "superconductor", "kind": "reg", "column": "Transition temperature[K]"},
+    "pressure": {"source": "superconductor", "kind": "reg", "column": "Pressure[GPa]"},
+    "curie": {"source": "magnetic", "kind": "reg", "column": "Curie temperature[K]"},
+    "magnetization": {"source": "magnetic", "kind": "reg", "column": "Magnetization[A·m²/mol]"},
 }
-DEFAULT_SEQUENCE = ["density", "formation_energy", "dos_density", "power_factor", "material_type"]
+DEFAULT_SEQUENCE = list(TASK_SPECS.keys())
+# Quasicrystal classes for the material_type label encoder (DAC=0, DQC=1, IAC=2, IQC=3, others=4).
+QC_CLASSES = [1, 3]
 
 
 @dataclass
 class ContinualRehearsalConfig:
-    """Configuration for the continual rehearsal demo."""
+    """Configuration for the continual rehearsal + inverse-design demo."""
 
-    data_path: Path = Path("data/qc_ac_te_mp_dos_reformat_20250615_enforce_quaternary_test.pd.parquet")
-    descriptor_path: Path = Path("data/qc_ac_te_mp_dos_composition_desc_trans_20250615.pd.parquet")
-    preprocessing_path: Path | None = Path("data/preprocessing_objects_20250615.pkl.z")
+    qc_data_path: Path = Path("data/qc_ac_te_mp_dos_reformat_20250615_enforce_quaternary_test.pd.parquet")
+    qc_preprocessing_path: Path | None = Path("data/preprocessing_objects_20250615.pkl.z")
+    superconductor_path: Path = Path("data/NEMAD_superconductor_20260425.parquet")
+    magnetic_path: Path = Path("data/NEMAD_magnetic_20260419.parquet")
     output_dir: Path = Path("artifacts/continual_rehearsal")
 
     task_sequence: list[str] = field(default_factory=lambda: list(DEFAULT_SEQUENCE))
-    replay_ratio: float = 0.05  # fraction of a learned task's valid train targets kept per step
-    sample: int | None = None  # optional cap on total compositions (for fast runs)
+    replay_ratio: float = 0.05
+    sample_per_dataset: int | None = None  # cap rows per dataset (for fast runs)
 
     max_epochs_per_step: int = 10
     batch_size: int = 256
     num_workers: int = 0
-    early_stopping_patience: int = 0  # 0 disables early stopping (fixed epochs)
 
+    n_grids: int = 8  # KMD-1d grid points per element feature; descriptor dim = 58 * n_grids
     latent_dim: int = 128
     encoder_hidden: int = 256
     head_hidden_dim: int = 64
@@ -91,6 +113,13 @@ class ContinualRehearsalConfig:
     n_kernel: int = 15
     kr_lr: float = 5e-4
     kr_decay: float = 5e-5
+
+    # Inverse-design stage
+    inverse_n_seeds: int = 16
+    inverse_steps: int = 300
+    inverse_lr: float = 0.05
+    inverse_reg_tasks: list[str] = field(default_factory=lambda: ["density", "formation_energy"])
+    inverse_reg_targets: list[float] = field(default_factory=lambda: [1.5, -1.5])
 
     random_seed: int = 2025
     datamodule_random_seed: int = 42
@@ -103,25 +132,41 @@ class ContinualRehearsalConfig:
             raise ValueError(f"Unknown task(s) {unknown}. Available: {sorted(TASK_SPECS)}")
         if not 0.0 < self.replay_ratio <= 1.0:
             raise ValueError("replay_ratio must be in (0, 1].")
+        if len(self.inverse_reg_tasks) != len(self.inverse_reg_targets):
+            raise ValueError("inverse_reg_tasks and inverse_reg_targets must have equal length.")
 
 
 def _as_float_array(cell: Any) -> np.ndarray:
-    """Coerce a sequence cell (ndarray/list/str) to a 1D float array."""
     if isinstance(cell, str):
         cell = ast.literal_eval(cell)
     return np.asarray(cell, dtype=float).ravel()
 
 
+def _composition_key(raw: Any) -> str | None:
+    """Canonical reduced-formula key for a composition dict (qc) or formula string (NEMAD)."""
+    from pymatgen.core.composition import Composition  # local import; pymatgen is heavy
+
+    try:
+        if isinstance(raw, dict):
+            cleaned = {k: v for k, v in raw.items() if v is not None and float(v) > 0}
+            if not cleaned:
+                return None
+            comp = Composition(cleaned)
+        else:
+            comp = Composition(str(raw))
+        return comp.reduced_formula
+    except Exception:
+        return None
+
+
 def _init_kernels(t_values: np.ndarray, n_kernel: int) -> tuple[list[float], list[float]]:
-    """Quantile-spaced kernel centres + uniform sigmas from the training t distribution."""
     t = np.asarray(t_values, dtype=float)
     t = t[np.isfinite(t)]
     if t.size == 0:
         return [], []
     centers = np.quantile(t, np.linspace(0.0, 1.0, n_kernel))
     span = max((float(t.max()) - float(t.min())) / max(n_kernel - 1, 1), 1e-3)
-    sigmas = np.full(n_kernel, span, dtype=float)
-    return centers.tolist(), sigmas.tolist()
+    return centers.tolist(), np.full(n_kernel, span).tolist()
 
 
 class ContinualRehearsalRunner:
@@ -129,55 +174,100 @@ class ContinualRehearsalRunner:
         self.config = config
         self.output_dir = Path(config.output_dir)
         self.output_dir.mkdir(parents=True, exist_ok=True)
+        # KMD-1d featurizer over the bundled element features (invertible: descriptor -> composition).
+        self._kmd = KMD(element_features.values, method="1d", n_grids=config.n_grids, sigma="auto", scale=True)
+        self.x_dim = int(self._kmd.transform(np.eye(1, len(DEFAULT_ELEMENTS))).shape[1])
+        self._desc_cache: dict[str, np.ndarray] = {}
         self._load_data()
 
     # ------------------------------------------------------------------ data
 
     def _load_data(self) -> None:
         cfg = self.config
-        logger.info("Loading descriptors and properties...")
-        descriptors = pd.read_parquet(cfg.descriptor_path)
-        properties = pd.read_parquet(cfg.data_path)
+        rng = np.random.default_rng(cfg.datamodule_random_seed)
+        # task_frames[task] -> DataFrame indexed by composition key with [column(+t), "split"]
+        self.task_frames: dict[str, pd.DataFrame] = {}
+        split_by_key: dict[str, str] = {}
 
-        if cfg.preprocessing_path is not None and Path(cfg.preprocessing_path).exists():
-            dropped = joblib.load(cfg.preprocessing_path).get("dropped_idx", [])
-            properties = properties.loc[~properties.index.isin(dropped)]
-            logger.info(f"Dropped {len(dropped)} preprocessing-flagged rows.")
+        sources = {
+            "qc": self._load_qc(),
+            "superconductor": pd.read_parquet(cfg.superconductor_path),
+            "magnetic": pd.read_parquet(cfg.magnetic_path),
+        }
 
-        common = descriptors.index.intersection(properties.index)
-        if cfg.sample is not None and cfg.sample < len(common):
-            common = pd.Index(
-                pd.Series(common).sample(n=cfg.sample, random_state=cfg.datamodule_random_seed).to_numpy()
-            )
-        descriptors = descriptors.loc[common]
-        properties = properties.loc[common]
-        descriptors.index = descriptors.index.astype(str)
-        properties.index = properties.index.astype(str)
+        # Build a composition key per row for each source, capping rows for speed.
+        keyed: dict[str, pd.DataFrame] = {}
+        for name, df in sources.items():
+            df = df.copy()
+            if cfg.sample_per_dataset is not None and cfg.sample_per_dataset < len(df):
+                df = df.iloc[rng.choice(len(df), size=cfg.sample_per_dataset, replace=False)]
+            comp_col = "composition" if name != "qc" else "composition"
+            df["__key__"] = [_composition_key(v) for v in df[comp_col]]
+            df = df.dropna(subset=["__key__"]).drop_duplicates(subset="__key__", keep="first").set_index("__key__")
+            keyed[name] = df
+            # Record split: qc uses its own split column; NEMAD gets a random split.
+            if "split" in df.columns:
+                for k, s in df["split"].items():
+                    split_by_key.setdefault(str(k), str(s))
+            else:
+                for k in df.index:
+                    split_by_key.setdefault(str(k), rng.choice(["train", "val", "test"], p=[0.7, 0.15, 0.15]))
 
-        self.descriptors = descriptors
-        self.properties = properties
-        self.x_dim = descriptors.shape[1]
-        self.composition_column: str = str(descriptors.index.name) if descriptors.index.name is not None else "id"
-        logger.info(f"Aligned {len(common)} compositions; descriptor dim = {self.x_dim}.")
-        if "split" in properties.columns:
-            logger.info(f"Split counts: {properties['split'].value_counts().to_dict()}")
+        # Build per-task frames; z-score raw NEMAD regression columns.
+        for task_name in cfg.task_sequence:
+            spec = TASK_SPECS[task_name]
+            df = keyed[spec["source"]]
+            col = spec["column"]
+            if col not in df.columns:
+                raise KeyError(f"Task '{task_name}': column '{col}' missing in {spec['source']} data.")
+            frame = pd.DataFrame(index=df.index)
+            values = df[col]
+            if spec["source"] != "qc" and spec["kind"] == "reg":
+                v = df[col].astype(float)
+                mean = float(v.mean())
+                std = float(v.std(ddof=0)) or 1.0
+                values = (v - mean) / std
+            frame[col] = values
+            if spec["kind"] == "kr":
+                frame[spec["t_column"]] = df[spec["t_column"]]
+            frame["split"] = [split_by_key.get(str(k), "train") for k in frame.index]
+            self.task_frames[task_name] = frame
 
-        # Precompute a label -> original-index map for the descriptor_fn (no matrix copy).
-        self._label_by_str = {str(idx): idx for idx in self.descriptors.index}
+        self.split_by_key = split_by_key
+        n_keys = len(set().union(*[set(f.index) for f in self.task_frames.values()]))
+        logger.info(f"Built {len(self.task_frames)} task frames over {n_keys} unique compositions; x_dim={self.x_dim}.")
+
+    def _load_qc(self) -> pd.DataFrame:
+        cfg = self.config
+        df = pd.read_parquet(cfg.qc_data_path)
+        if cfg.qc_preprocessing_path is not None and Path(cfg.qc_preprocessing_path).exists():
+            dropped = joblib.load(cfg.qc_preprocessing_path).get("dropped_idx", [])
+            df = df.loc[~df.index.isin(dropped)]
+        return df
 
     def descriptor_fn(self, compositions: list[str]) -> pd.DataFrame:
-        labels = [self._label_by_str[c] for c in compositions if c in self._label_by_str]
-        return self.descriptors.loc[labels]
-
-    def _task_frame(self, task_name: str) -> pd.DataFrame:
-        """Composition-indexed frame holding this task's column(s) + split."""
-        spec = TASK_SPECS[task_name]
-        cols = [spec["column"]]
-        if spec["kind"] == "kr":
-            cols.append(spec["t_column"])
-        if "split" in self.properties.columns:
-            cols.append("split")
-        return self.properties[cols].copy()
+        """KMD-1d descriptors for composition keys (computed once per unique key, cached)."""
+        uncached = [c for c in dict.fromkeys(compositions) if c not in self._desc_cache]
+        if uncached:
+            weights = np.zeros((len(uncached), len(DEFAULT_ELEMENTS)), dtype=float)
+            valid: list[str] = []
+            for key in uncached:
+                try:
+                    w = formula_to_composition(key)
+                except Exception:
+                    w = None
+                if w is None or float(w.sum()) <= 0:
+                    continue
+                weights[len(valid)] = w
+                valid.append(key)
+            if valid:
+                desc = self._kmd.transform(weights[: len(valid)])
+                for j, key in enumerate(valid):
+                    self._desc_cache[key] = desc[j]
+        present = [c for c in compositions if c in self._desc_cache]
+        if not present:
+            return pd.DataFrame()
+        return pd.DataFrame(np.stack([self._desc_cache[c] for c in present]), index=present)
 
     # ------------------------------------------------------------------ configs
 
@@ -200,7 +290,6 @@ class ContinualRehearsalRunner:
                 num_classes=spec["num_classes"],
                 optimizer=OptimizerConfig(lr=cfg.head_lr, weight_decay=1e-5),
             )
-        # kernel regression
         train_t = self._collect_train_t(task_name)
         centers, sigmas = _init_kernels(train_t, cfg.n_kernel)
         return KernelRegressionTaskConfig(
@@ -220,14 +309,12 @@ class ContinualRehearsalRunner:
 
     def _collect_train_t(self, task_name: str) -> np.ndarray:
         spec = TASK_SPECS[task_name]
-        frame = self.properties
-        mask = frame[spec["column"]].notna()
-        if "split" in frame.columns:
-            mask &= frame["split"] == "train"
-        t_cells = frame.loc[mask, spec["t_column"]].dropna()
-        if t_cells.empty:
+        frame = self.task_frames[task_name]
+        mask = frame[spec["column"]].notna() & (frame["split"] == "train")
+        cells = frame.loc[mask, spec["t_column"]].dropna()
+        if cells.empty:
             return np.array([])
-        return np.concatenate([_as_float_array(c) for c in t_cells])
+        return np.concatenate([_as_float_array(c) for c in cells])
 
     # ------------------------------------------------------------------ run
 
@@ -244,17 +331,14 @@ class ContinualRehearsalRunner:
         )
 
         task_configs: dict[str, Any] = {}
-        # metric_history[task] = list of (step_index, metric_value)
         metric_history: dict[str, list[tuple[int, float]]] = {name: [] for name in cfg.task_sequence}
         records: list[dict[str, Any]] = []
 
         for step, task_name in enumerate(cfg.task_sequence):
             logger.info(f"=== Step {step + 1}/{len(cfg.task_sequence)}: add task '{task_name}' ===")
-            new_cfg = self._build_task_config(task_name)
-            task_configs[task_name] = new_cfg
-            model.add_task(new_cfg)
+            task_configs[task_name] = self._build_task_config(task_name)
+            model.add_task(task_configs[task_name])
 
-            # Rehearsal: new task full, previously learned tasks keep replay_ratio of train targets.
             active = cfg.task_sequence[: step + 1]
             for name in active:
                 task_configs[name].task_masking_ratio = 1.0 if name == task_name else cfg.replay_ratio
@@ -262,16 +346,12 @@ class ContinualRehearsalRunner:
             datamodule = CompoundDataModule(
                 task_configs=[task_configs[name] for name in active],
                 descriptor_fn=self.descriptor_fn,
-                task_frames={name: self._task_frame(name) for name in active},
-                composition_column=self.composition_column,
+                task_frames={name: self.task_frames[name] for name in active},
+                composition_column="composition",
                 random_seed=cfg.datamodule_random_seed,
                 batch_size=cfg.batch_size,
                 num_workers=cfg.num_workers,
             )
-
-            callbacks: list[Any] = []
-            if cfg.early_stopping_patience > 0:
-                callbacks.append(EarlyStopping(monitor="val_final_loss", patience=cfg.early_stopping_patience))
             trainer = Trainer(
                 max_epochs=cfg.max_epochs_per_step,
                 accelerator=cfg.accelerator,
@@ -279,7 +359,6 @@ class ContinualRehearsalRunner:
                 logger=False,
                 enable_checkpointing=False,
                 enable_progress_bar=False,
-                callbacks=callbacks,
             )
             trainer.fit(model, datamodule=datamodule)
 
@@ -287,66 +366,66 @@ class ContinualRehearsalRunner:
             step_dir.mkdir(parents=True, exist_ok=True)
             step_metrics: dict[str, dict[str, float]] = {}
             for name in active:
-                metric, primary = self._evaluate_task(model, name, step_dir, is_new=(name == task_name))
+                metric = self._evaluate_task(model, name, step_dir, is_new=(name == task_name))
                 step_metrics[name] = metric
-                metric_history[name].append((step + 1, primary))
-
-            records.append(
-                {"step": step + 1, "new_task": task_name, "active_tasks": list(active), "metrics": step_metrics}
-            )
-            logger.info(f"Step {step + 1} metrics: { {k: round(v['primary'], 4) for k, v in step_metrics.items()} }")
+                metric_history[name].append((step + 1, metric["primary"]))
+            records.append({"step": step + 1, "new_task": task_name, "metrics": step_metrics})
+            summary = ", ".join(f"{k}={v['primary']:.3f}" for k, v in step_metrics.items())
+            logger.info(f"Step {step + 1}: {summary}")
 
         self._plot_forgetting(metric_history)
-        summary_path = self.output_dir / "experiment_records.json"
-        summary_path.write_text(json.dumps(records, indent=2))
-        logger.info(f"Done. Summary: {summary_path}")
+        (self.output_dir / "experiment_records.json").write_text(json.dumps(records, indent=2))
+
+        inverse = self._inverse_design(model)
+        (self.output_dir / "inverse_design.json").write_text(json.dumps(inverse, indent=2))
+        logger.info(f"Done. Outputs in {self.output_dir}")
 
     # ------------------------------------------------------------------ eval
 
-    def _test_rows(self, task_name: str) -> pd.Index:
+    def _test_rows(self, task_name: str) -> list[str]:
         spec = TASK_SPECS[task_name]
-        frame = self.properties
-        mask = frame[spec["column"]].notna()
-        if "split" in frame.columns:
-            mask &= frame["split"] == "test"
-        return frame.index[mask]
+        frame = self.task_frames[task_name]
+        mask = frame[spec["column"]].notna() & (frame["split"] == "test")
+        return list(frame.index[mask])
 
-    def _evaluate_task(
-        self, model: FlexibleMultiTaskModel, task_name: str, step_dir: Path, *, is_new: bool
-    ) -> tuple[dict[str, float], float]:
+    def _descriptor_tensor(self, comps: list[str], device) -> tuple[torch.Tensor, list[str]]:
+        desc = self.descriptor_fn(comps)
+        comps = [c for c in comps if c in desc.index]
+        return torch.tensor(desc.loc[comps].values, dtype=torch.float32, device=device), comps
+
+    def _evaluate_task(self, model, task_name, step_dir, *, is_new) -> dict[str, float]:
         spec = TASK_SPECS[task_name]
         kind = spec["kind"]
-        comps = list(self._test_rows(task_name))
         model.eval()
         device = next(model.parameters()).device
+        comps = self._test_rows(task_name)
         if not comps:
-            return {"primary": float("nan"), "samples": 0}, float("nan")
-
-        x = torch.tensor(self.descriptors.loc[comps].values, dtype=torch.float32, device=device)
+            return {"primary": float("nan"), "samples": 0}
+        frame = self.task_frames[task_name]
         head = model.task_heads[task_name]
 
         with torch.no_grad():
-            # Evaluate the target head directly off the shared latent so other (e.g. kernel)
-            # heads — which require their own t_sequences — are not invoked.
-            h_task = torch.tanh(model.encoder(x))
-
-            if kind == "reg":
-                pred = head(h_task).squeeze(-1).cpu().numpy()
-                true = self.properties.loc[comps, spec["column"]].astype(float).to_numpy()
-                metric = {
-                    "r2": float(r2_score(true, pred)),
-                    "mae": float(mean_absolute_error(true, pred)),
-                    "samples": len(comps),
-                }
-                metric["primary"] = metric["r2"]
-                if is_new:
-                    self._plot_parity(true, pred, task_name, metric["r2"], step_dir)
-                return metric, metric["r2"]
-
-            if kind == "clf":
-                logits = head(h_task)
+            if kind in ("reg", "clf"):
+                x, comps = self._descriptor_tensor(comps, device)
+                if not comps:
+                    return {"primary": float("nan"), "samples": 0}
+                h = torch.tanh(model.encoder(x))
+                if kind == "reg":
+                    pred = head(h).squeeze(-1).cpu().numpy()
+                    true = frame.loc[comps, spec["column"]].astype(float).to_numpy()
+                    r2 = float(r2_score(true, pred))
+                    metric = {
+                        "r2": r2,
+                        "mae": float(mean_absolute_error(true, pred)),
+                        "samples": len(comps),
+                        "primary": r2,
+                    }
+                    if is_new:
+                        self._plot_parity(true, pred, task_name, r2, step_dir)
+                    return metric
+                logits = head(h)
                 pred = logits.argmax(dim=-1).cpu().numpy()
-                true = self.properties.loc[comps, spec["column"]].astype(int).to_numpy()
+                true = frame.loc[comps, spec["column"]].astype(int).to_numpy()
                 acc = float(accuracy_score(true, pred))
                 metric = {
                     "accuracy": acc,
@@ -356,39 +435,125 @@ class ContinualRehearsalRunner:
                 }
                 if is_new:
                     self._plot_confusion(true, pred, task_name, acc, step_dir, spec["num_classes"])
-                return metric, acc
+                return metric
 
-            # kernel regression: build per-sample t lists, evaluate concatenated points
-            t_col = spec["t_column"]
+            # kernel regression
             keep, t_list, true_parts = [], [], []
             for comp in comps:
-                y_cell = self.properties.at[comp, spec["column"]]
-                t_cell = self.properties.at[comp, t_col]
-                if y_cell is None or t_cell is None:
+                if comp not in self._desc_cache and self.descriptor_fn([comp]).empty:
                     continue
-                y_arr, t_arr = _as_float_array(y_cell), _as_float_array(t_cell)
+                y_arr = _as_float_array(frame.at[comp, spec["column"]])
+                t_arr = _as_float_array(frame.at[comp, spec["t_column"]])
                 if y_arr.size == 0 or y_arr.size != t_arr.size:
                     continue
                 keep.append(comp)
                 t_list.append(torch.tensor(t_arr, dtype=torch.float32, device=device))
                 true_parts.append(y_arr)
             if not keep:
-                return {"primary": float("nan"), "samples": 0}, float("nan")
-            xk = torch.tensor(self.descriptors.loc[keep].values, dtype=torch.float32, device=device)
+                return {"primary": float("nan"), "samples": 0}
+            xk, _ = self._descriptor_tensor(keep, device)
             h_k = torch.tanh(model.encoder(xk))
             expanded_h, expanded_t = model._expand_for_kernel_regression(h_k, t_list)
             pred = head(expanded_h, t=expanded_t).squeeze(-1).cpu().numpy()
             true = np.concatenate(true_parts)
+            r2 = float(r2_score(true, pred))
             metric = {
-                "r2": float(r2_score(true, pred)),
+                "r2": r2,
                 "mae": float(mean_absolute_error(true, pred)),
                 "samples": len(keep),
                 "points": int(true.size),
-                "primary": float(r2_score(true, pred)),
+                "primary": r2,
             }
             if is_new:
-                self._plot_kr_sequences(keep, t_list, true_parts, pred, task_name, metric["r2"], step_dir)
-            return metric, metric["primary"]
+                self._plot_kr_sequences(keep, t_list, true_parts, pred, task_name, r2, step_dir)
+            return metric
+
+    # ------------------------------------------------------------------ inverse design
+
+    def _inverse_design(self, model) -> dict[str, Any]:
+        cfg = self.config
+        logger.info("=== Inverse design: latent optimization toward conditions ===")
+        device = next(model.parameters()).device
+        model.eval()
+
+        # Seed from qc test compositions (material_type is defined there).
+        seeds = self._test_rows("material_type")[: cfg.inverse_n_seeds]
+        x_seed, seeds = self._descriptor_tensor(seeds, device)
+        if not seeds:
+            logger.warning("No seeds available for inverse design.")
+            return {}
+
+        reg_targets = {t: v for t, v in zip(cfg.inverse_reg_tasks, cfg.inverse_reg_targets)}
+
+        def _qc_prob(x: torch.Tensor) -> np.ndarray:
+            with torch.no_grad():
+                h = torch.tanh(model.encoder(x))
+                probs = torch.softmax(model.task_heads["material_type"](h), dim=-1)
+                return probs[:, QC_CLASSES].sum(dim=-1).cpu().numpy()
+
+        def _reg_preds(x: torch.Tensor) -> dict[str, np.ndarray]:
+            with torch.no_grad():
+                h = torch.tanh(model.encoder(x))
+                return {t: model.task_heads[t](h).squeeze(-1).cpu().numpy() for t in reg_targets}
+
+        before_qc = _qc_prob(x_seed)
+        before_reg = _reg_preds(x_seed)
+
+        result = model.optimize_latent(
+            initial_input=x_seed,
+            task_targets=reg_targets,
+            class_targets={"material_type": QC_CLASSES},
+            optimize_space="latent",
+            steps=cfg.inverse_steps,
+            lr=cfg.inverse_lr,
+        )
+        # Regression values achieved *in latent space* (before AE decode) — the direct optimization result.
+        reg_names = list(reg_targets.keys())
+        achieved = result.optimized_target[:, 0, :].cpu().numpy()  # (B, len(reg_names)) in reg_targets order
+        reg_latent = {t: achieved[:, j] for j, t in enumerate(reg_names)}
+
+        optimized_desc = result.optimized_input[:, 0, :]  # (B, x_dim) reconstructed KMD descriptor
+        after_qc = _qc_prob(optimized_desc)  # round-trip (decode -> re-encode) condition fidelity
+        after_reg = _reg_preds(optimized_desc)
+
+        # Decode optimized descriptors back to compositions via KMD.inverse.
+        decoded = self._decode_compositions(optimized_desc.cpu().numpy())
+
+        self._plot_inverse_design(before_qc, after_qc, before_reg, reg_latent, after_reg, reg_targets)
+
+        records = []
+        for i, seed in enumerate(seeds):
+            records.append(
+                {
+                    "seed_composition": seed,
+                    "qc_prob_before": float(before_qc[i]),
+                    "qc_prob_after_decode": float(after_qc[i]),
+                    "reg_before": {t: float(before_reg[t][i]) for t in reg_names},
+                    "reg_achieved_latent": {t: float(reg_latent[t][i]) for t in reg_names},
+                    "reg_after_decode": {t: float(after_reg[t][i]) for t in reg_names},
+                    "decoded_composition": decoded[i],
+                }
+            )
+        latent_summary = ", ".join(
+            f"{t}:{before_reg[t].mean():.2f}->{reg_latent[t].mean():.2f}(tgt {reg_targets[t]})" for t in reg_names
+        )
+        logger.info(f"Inverse design in-latent regression: {latent_summary}")
+        logger.info(f"Inverse design QC prob (round-trip): {before_qc.mean():.3f} -> {after_qc.mean():.3f}")
+        return {"reg_targets": reg_targets, "qc_classes": QC_CLASSES, "n_seeds": len(seeds), "records": records}
+
+    def _decode_compositions(self, descriptors: np.ndarray) -> list[str]:
+        """KMD.inverse: descriptor -> element weights -> compact formula string."""
+        try:
+            weights = self._kmd.inverse(descriptors)
+        except Exception as exc:  # pragma: no cover - QP edge cases
+            logger.warning(f"KMD.inverse failed ({exc}); skipping composition decoding.")
+            return ["<undecodable>"] * descriptors.shape[0]
+        out = []
+        for w in weights:
+            order = np.argsort(w)[::-1]
+            parts = [f"{DEFAULT_ELEMENTS[i]}{w[i]:.3f}" for i in order[:6] if w[i] > 1e-3]
+            out.append(" ".join(parts) if parts else "<empty>")
+        return out
 
     # ------------------------------------------------------------------ plots
 
@@ -420,7 +585,6 @@ class ContinualRehearsalRunner:
         plt.close(fig)
 
     def _plot_kr_sequences(self, comps, t_list, true_parts, pred, task_name, r2, step_dir):
-        # Split the concatenated prediction back into per-sample chunks.
         fig, ax = plt.subplots(figsize=(6, 4), dpi=130)
         offset = 0
         for i in range(min(3, len(comps))):
@@ -430,15 +594,15 @@ class ContinualRehearsalRunner:
             ax.plot(t, pred[offset : offset + n], lw=1.0, ls="--", alpha=0.8, label=f"pred #{i}")
             offset += n
         ax.set_xlabel("t")
-        ax.set_ylabel("value (normalized)")
-        ax.set_title(f"{task_name} (new) — R²={r2:.3f} over all points")
+        ax.set_ylabel("value (norm)")
+        ax.set_title(f"{task_name} (new) — R²={r2:.3f}")
         ax.legend(fontsize=7, ncol=2)
         fig.tight_layout()
         fig.savefig(step_dir / f"{task_name}_sequences.png")
         plt.close(fig)
 
-    def _plot_forgetting(self, metric_history: dict[str, list[tuple[int, float]]]):
-        fig, ax = plt.subplots(figsize=(7, 4.5), dpi=130)
+    def _plot_forgetting(self, metric_history):
+        fig, ax = plt.subplots(figsize=(8, 5), dpi=130)
         for task_name, points in metric_history.items():
             if not points:
                 continue
@@ -447,13 +611,36 @@ class ContinualRehearsalRunner:
             ax.plot(steps, vals, marker="o", label=task_name)
         ax.set_xlabel("finetuning step")
         ax.set_ylabel("primary metric (R² / accuracy)")
-        ax.set_title("Per-task performance vs continual finetuning step (forgetting)")
+        ax.set_title("Per-task performance vs continual finetuning step")
         ax.grid(True, alpha=0.3)
-        ax.legend(fontsize=8)
+        ax.legend(fontsize=8, ncol=2)
         fig.tight_layout()
         fig.savefig(self.output_dir / "forgetting_trajectory.png")
         plt.close(fig)
         logger.info(f"Saved forgetting trajectory to {self.output_dir / 'forgetting_trajectory.png'}")
+
+    def _plot_inverse_design(self, before_qc, after_qc, before_reg, reg_latent, after_reg, reg_targets):
+        n_panels = 1 + len(reg_targets)
+        fig, axes = plt.subplots(1, n_panels, figsize=(5 * n_panels, 4), dpi=130)
+        axes = np.atleast_1d(axes)
+        idx = np.arange(len(before_qc))
+        axes[0].bar(idx - 0.2, before_qc, width=0.4, label="before")
+        axes[0].bar(idx + 0.2, after_qc, width=0.4, label="after (decode)")
+        axes[0].set_title("Quasicrystal probability")
+        axes[0].set_xlabel("seed")
+        axes[0].legend(fontsize=8)
+        for ax, (t, tgt) in zip(axes[1:], reg_targets.items()):
+            ax.bar(idx - 0.25, before_reg[t], width=0.25, label="before")
+            ax.bar(idx, reg_latent[t], width=0.25, label="achieved (latent)")
+            ax.bar(idx + 0.25, after_reg[t], width=0.25, label="after (decode)")
+            ax.axhline(tgt, color="r", ls="--", lw=1, label=f"target={tgt}")
+            ax.set_title(f"{t} prediction")
+            ax.set_xlabel("seed")
+            ax.legend(fontsize=7)
+        fig.tight_layout()
+        fig.savefig(self.output_dir / "inverse_design.png")
+        plt.close(fig)
+        logger.info(f"Saved inverse-design plot to {self.output_dir / 'inverse_design.png'}")
 
 
 # --- CLI ---------------------------------------------------------------------
@@ -468,34 +655,22 @@ def _load_toml(path: Path) -> dict[str, Any]:
 
 
 def _parse_args(argv: list[str] | None = None) -> ContinualRehearsalConfig:
-    parser = argparse.ArgumentParser(description="Continual multi-task rehearsal demo.")
-    parser.add_argument("--config-file", type=Path, default=None, help="TOML config path.")
+    parser = argparse.ArgumentParser(description="Continual rehearsal + inverse-design demo.")
+    parser.add_argument("--config-file", type=Path, default=None)
     parser.add_argument("--output-dir", type=Path, default=None)
-    parser.add_argument("--sample", type=int, default=None)
+    parser.add_argument("--sample-per-dataset", type=int, default=None)
     parser.add_argument("--max-epochs-per-step", type=int, default=None)
-    parser.add_argument("--replay-ratio", type=float, default=None)
-    parser.add_argument("--batch-size", type=int, default=None)
     parser.add_argument("--accelerator", type=str, default=None)
-    parser.add_argument("--task-sequence", nargs="+", default=None)
     args = parser.parse_args(argv)
 
     data = _load_toml(args.config_file) if args.config_file else {}
-    # CLI overrides take precedence over the config file.
-    for key in (
-        "output_dir",
-        "sample",
-        "max_epochs_per_step",
-        "replay_ratio",
-        "batch_size",
-        "accelerator",
-        "task_sequence",
-    ):
+    for key in ("output_dir", "sample_per_dataset", "max_epochs_per_step", "accelerator"):
         val = getattr(args, key)
         if val is not None:
             data[key] = val
 
-    field_names = {f for f in ContinualRehearsalConfig.__dataclass_fields__}
-    path_fields = {"data_path", "descriptor_path", "preprocessing_path", "output_dir"}
+    field_names = set(ContinualRehearsalConfig.__dataclass_fields__)
+    path_fields = {"qc_data_path", "qc_preprocessing_path", "superconductor_path", "magnetic_path", "output_dir"}
     kwargs: dict[str, Any] = {}
     for key, value in data.items():
         if key not in field_names:
@@ -506,8 +681,7 @@ def _parse_args(argv: list[str] | None = None) -> ContinualRehearsalConfig:
 
 
 def main(argv: list[str] | None = None) -> None:
-    config = _parse_args(argv)
-    ContinualRehearsalRunner(config).run()
+    ContinualRehearsalRunner(_parse_args(argv)).run()
 
 
 if __name__ == "__main__":

--- a/src/foundation_model/scripts/continual_rehearsal_demo.py
+++ b/src/foundation_model/scripts/continual_rehearsal_demo.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import base64
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -80,7 +81,13 @@ TASK_SPECS: dict[str, dict[str, Any]] = {
     "pressure": {"source": "superconductor", "kind": "reg", "column": "Pressure[GPa]"},
     "curie": {"source": "magnetic", "kind": "reg", "column": "Curie temperature[K]"},
     "magnetization": {"source": "magnetic", "kind": "reg", "column": "Magnetization[A·m²/mol]"},
+    "neel": {"source": "magnetic", "kind": "reg", "column": "Neel temperature[K]"},
+    "kp": {"source": "phonix", "kind": "reg", "column": "kp[W/mK]"},
+    "klat": {"source": "phonix", "kind": "reg", "column": "klat[W/mK]"},
 }
+# Raw (non-qc) regression targets span orders of magnitude (thermal conductivity, magnetization);
+# they are log1p-compressed, z-scored, then clipped to tame heavy tails.
+_RAW_TARGET_CLIP = 5.0
 DEFAULT_SEQUENCE = list(TASK_SPECS.keys())
 # Quasicrystal classes for the material_type label encoder (DAC=0, DQC=1, IAC=2, IQC=3, others=4).
 QC_CLASSES = [1, 3]
@@ -94,6 +101,7 @@ class ContinualRehearsalConfig:
     qc_preprocessing_path: Path | None = Path("data/preprocessing_objects_20250615.pkl.z")
     superconductor_path: Path = Path("data/NEMAD_superconductor_20260425.parquet")
     magnetic_path: Path = Path("data/NEMAD_magnetic_20260419.parquet")
+    phonix_path: Path = Path("data/phonix-db-filtered_20260425.parquet")
     output_dir: Path = Path("artifacts/continual_rehearsal")
 
     task_sequence: list[str] = field(default_factory=lambda: list(DEFAULT_SEQUENCE))
@@ -193,6 +201,7 @@ class ContinualRehearsalRunner:
             "qc": self._load_qc(),
             "superconductor": pd.read_parquet(cfg.superconductor_path),
             "magnetic": pd.read_parquet(cfg.magnetic_path),
+            "phonix": pd.read_parquet(cfg.phonix_path),
         }
 
         # Build a composition key per row for each source, capping rows for speed.
@@ -223,10 +232,11 @@ class ContinualRehearsalRunner:
             frame = pd.DataFrame(index=df.index)
             values = df[col]
             if spec["source"] != "qc" and spec["kind"] == "reg":
-                v = df[col].astype(float)
+                # log1p compresses the orders-of-magnitude range, then z-score + clip tails.
+                v = np.log1p(df[col].astype(float).clip(lower=0.0))
                 mean = float(v.mean())
                 std = float(v.std(ddof=0)) or 1.0
-                values = (v - mean) / std
+                values = ((v - mean) / std).clip(-_RAW_TARGET_CLIP, _RAW_TARGET_CLIP)
             frame[col] = values
             if spec["kind"] == "kr":
                 frame[spec["t_column"]] = df[spec["t_column"]]
@@ -378,6 +388,8 @@ class ContinualRehearsalRunner:
 
         inverse = self._inverse_design(model)
         (self.output_dir / "inverse_design.json").write_text(json.dumps(inverse, indent=2))
+
+        self._write_report_html(records, inverse)
         logger.info(f"Done. Outputs in {self.output_dir}")
 
     # ------------------------------------------------------------------ eval
@@ -641,6 +653,168 @@ class ContinualRehearsalRunner:
         fig.savefig(self.output_dir / "inverse_design.png")
         plt.close(fig)
         logger.info(f"Saved inverse-design plot to {self.output_dir / 'inverse_design.png'}")
+
+    # ------------------------------------------------------------------ report
+
+    def _img_b64(self, rel: str) -> str | None:
+        path = self.output_dir / rel
+        if not path.exists():
+            return None
+        return "data:image/png;base64," + base64.b64encode(path.read_bytes()).decode("ascii")
+
+    def _write_report_html(self, records: list[dict[str, Any]], inverse: dict[str, Any]) -> None:
+        """Emit a self-contained, white-background HTML slide deck summarizing the run."""
+        final = records[-1]["metrics"] if records else {}
+        intro = {r["new_task"]: r["metrics"][r["new_task"]]["primary"] for r in records}
+        kind_label = {"reg": "regression", "kr": "kernel regression", "clf": "classification"}
+
+        rows = []
+        for task in self.config.task_sequence:
+            spec = TASK_SPECS[task]
+            metric_name = "acc" if spec["kind"] == "clf" else "R²"
+            rows.append(
+                f"<tr><td>{task}</td><td>{kind_label[spec['kind']]}</td><td>{spec['source']}</td>"
+                f"<td>{intro.get(task, float('nan')):+.3f}</td>"
+                f"<td>{final.get(task, {}).get('primary', float('nan')):+.3f}</td><td>{metric_name}</td></tr>"
+            )
+        task_table = "\n".join(rows)
+
+        # Per-type example plots (first reg / kr / clf in the sequence).
+        examples = []
+        seen: set[str] = set()
+        for i, task in enumerate(self.config.task_sequence, start=1):
+            kind = TASK_SPECS[task]["kind"]
+            if kind in seen:
+                continue
+            suffix = {"reg": "parity", "kr": "sequences", "clf": "confusion"}[kind]
+            img = self._img_b64(f"step{i:02d}_{task}/{task}_{suffix}.png")
+            if img:
+                examples.append(
+                    f'<figure><img src="{img}"/><figcaption>{task} ({kind_label[kind]})</figcaption></figure>'
+                )
+                seen.add(kind)
+
+        forget_img = self._img_b64("forgetting_trajectory.png")
+        inv_img = self._img_b64("inverse_design.png")
+
+        recs = inverse.get("records", [])
+        reg_targets = inverse.get("reg_targets", {})
+
+        def _mean(field: str, sub: str) -> float:
+            vals = [r[field][sub] for r in recs if sub in r.get(field, {})]
+            return float(np.mean(vals)) if vals else float("nan")
+
+        inv_lines = "".join(
+            f"<li><b>{t}</b>: {_mean('reg_before', t):+.2f} → <b>{_mean('reg_achieved_latent', t):+.2f}</b> "
+            f"(target {reg_targets[t]:+.1f})</li>"
+            for t in reg_targets
+        )
+        qc_before = float(np.mean([r["qc_prob_before"] for r in recs])) if recs else float("nan")
+        qc_after = float(np.mean([r["qc_prob_after_decode"] for r in recs])) if recs else float("nan")
+        decoded = "".join(f"<li><code>{r['decoded_composition']}</code></li>" for r in recs[:4])
+
+        n_tasks = len(self.config.task_sequence)
+        n_reg = sum(1 for t in self.config.task_sequence if TASK_SPECS[t]["kind"] == "reg")
+        n_kr = sum(1 for t in self.config.task_sequence if TASK_SPECS[t]["kind"] == "kr")
+        n_clf = sum(1 for t in self.config.task_sequence if TASK_SPECS[t]["kind"] == "clf")
+
+        def slide(body: str) -> str:
+            return f'<section class="slide">{body}</section>'
+
+        slides = [
+            slide(
+                "<h1>Continual Multi-Task Learning + Inverse Design</h1>"
+                "<p class='sub'>Composition-keyed FlexibleMultiTaskModel across all inorganic datasets &amp; task types</p>"
+                f"<p class='meta'>{n_tasks} supervised tasks ({n_reg} regression · {n_kr} kernel regression · "
+                f"{n_clf} classification) + always-on autoencoder · KMD-1d descriptors</p>"
+            ),
+            slide(
+                "<h2>Setup</h2><ul>"
+                "<li><b>Datasets</b>: qc_ac_te_mp (DOS/material), NEMAD superconductor, NEMAD magnetic, phonix-db — joined by composition formula.</li>"
+                "<li><b>Descriptor</b>: invertible KMD-1d, computed on the fly (descriptor → composition via <code>KMD.inverse</code>).</li>"
+                "<li><b>Continual finetuning</b>: tasks added one at a time; AE head always on.</li>"
+                f"<li><b>Rehearsal</b>: learned tasks keep only {self.config.replay_ratio:.0%} of their training targets per step.</li>"
+                "<li><b>Inverse design</b>: optimize the latent toward regression targets + quasicrystal probability, then decode a composition.</li>"
+                "</ul>"
+            ),
+            slide(
+                "<h2>Tasks &amp; performance</h2>"
+                "<table><thead><tr><th>task</th><th>type</th><th>dataset</th>"
+                "<th>at intro</th><th>final</th><th>metric</th></tr></thead>"
+                f"<tbody>{task_table}</tbody></table>"
+                "<p class='meta'>“at intro” = score the step a task is added; “final” = after all tasks learned.</p>"
+            ),
+            slide(
+                "<h2>Forgetting under 5% rehearsal</h2>"
+                + (f"<img class='wide' src='{forget_img}'/>" if forget_img else "<p>(plot unavailable)</p>")
+            ),
+            slide("<h2>Per-task-type examples</h2><div class='row'>" + "".join(examples) + "</div>"),
+            slide(
+                "<h2>Inverse design</h2><div class='row'>"
+                + (f"<img class='wide' src='{inv_img}'/>" if inv_img else "")
+                + "<div class='panel'><h3>Latent optimization reached targets</h3><ul>"
+                + inv_lines
+                + f"</ul><p>Quasicrystal probability (round-trip): <b>{qc_before:.3f} → {qc_after:.3f}</b></p>"
+                + "<h3>Decoded compositions (KMD.inverse)</h3><ul>"
+                + decoded
+                + "</ul></div></div>"
+            ),
+            slide(
+                "<h2>Takeaways</h2><ul>"
+                "<li>One shared encoder serves regression, kernel regression, classification &amp; reconstruction across 4 inorganic datasets.</li>"
+                "<li>5% rehearsal keeps well-learned tasks (density, formation energy, material type) near their peak while new heads are added.</li>"
+                "<li>Latent-space optimization with regression + classification conditions hits the targets and decodes back to real compositions via the invertible KMD descriptor.</li>"
+                "</ul>"
+            ),
+        ]
+
+        html = _REPORT_TEMPLATE.replace("__SLIDES__", "\n".join(slides)).replace("__N__", str(len(slides)))
+        (self.output_dir / "report.html").write_text(html, encoding="utf-8")
+        logger.info(f"Saved HTML report to {self.output_dir / 'report.html'}")
+
+
+_REPORT_TEMPLATE = """<!doctype html>
+<html lang="en"><head><meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Continual Multi-Task Demo — Summary</title>
+<style>
+  :root { --fg:#1a1a1a; --muted:#6b7280; --accent:#2563eb; --line:#e5e7eb; }
+  * { box-sizing: border-box; }
+  html,body { margin:0; height:100%; background:#ffffff; color:var(--fg);
+    font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif; }
+  .deck { height:100vh; overflow-y:scroll; scroll-snap-type:y mandatory; }
+  .slide { min-height:100vh; scroll-snap-align:start; display:flex; flex-direction:column;
+    justify-content:center; padding:6vh 9vw; border-bottom:1px solid var(--line); }
+  h1 { font-size:2.6rem; margin:0 0 .4rem; }
+  h2 { font-size:2rem; margin:0 0 1.2rem; color:var(--accent); }
+  h3 { font-size:1.15rem; margin:1rem 0 .4rem; }
+  p.sub { font-size:1.3rem; color:var(--fg); margin:.2rem 0; }
+  p.meta { color:var(--muted); font-size:1rem; }
+  ul { font-size:1.15rem; line-height:1.7; }
+  table { border-collapse:collapse; font-size:1rem; }
+  th,td { border-bottom:1px solid var(--line); padding:.45rem .9rem; text-align:right; }
+  th:first-child, td:first-child, th:nth-child(2), td:nth-child(2), th:nth-child(3), td:nth-child(3) { text-align:left; }
+  thead th { color:var(--muted); font-weight:600; }
+  img.wide { max-height:62vh; max-width:62vw; }
+  .row { display:flex; gap:1.5rem; align-items:center; flex-wrap:wrap; }
+  figure { margin:0; text-align:center; } figure img { max-height:46vh; max-width:30vw; }
+  figcaption { color:var(--muted); font-size:.95rem; margin-top:.4rem; }
+  .panel { max-width:34vw; } code { background:#f3f4f6; padding:.1rem .35rem; border-radius:4px; }
+  .nav { position:fixed; bottom:14px; right:18px; color:var(--muted); font-size:.85rem; }
+</style></head>
+<body><div class="deck" id="deck">
+__SLIDES__
+</div>
+<div class="nav">↑/↓ or scroll · <span id="pos">1</span>/__N__</div>
+<script>
+  const deck=document.getElementById('deck'), slides=[...document.querySelectorAll('.slide')], pos=document.getElementById('pos');
+  let i=0;
+  function go(n){ i=Math.max(0,Math.min(slides.length-1,n)); slides[i].scrollIntoView({behavior:'smooth'}); }
+  document.addEventListener('keydown',e=>{ if(e.key==='ArrowDown'||e.key==='ArrowRight'||e.key===' '){e.preventDefault();go(i+1);}
+    else if(e.key==='ArrowUp'||e.key==='ArrowLeft'){e.preventDefault();go(i-1);} });
+  deck.addEventListener('scroll',()=>{ i=Math.round(deck.scrollTop/window.innerHeight); pos.textContent=i+1; });
+</script></body></html>
+"""
 
 
 # --- CLI ---------------------------------------------------------------------

--- a/src/foundation_model/scripts/continual_rehearsal_demo.py
+++ b/src/foundation_model/scripts/continual_rehearsal_demo.py
@@ -5,10 +5,12 @@
 Continual multi-task learning demo with rehearsal (5% replay) + inverse design.
 
 Comprehensive end-to-end exercise of the composition-keyed data stack +
-FlexibleMultiTaskModel across every task type and every inorganic dataset:
+FlexibleMultiTaskModel across every task type and every inorganic dataset (default sequence):
 
 * 2 regression + 2 kernel regression + 1 classification from the qc_ac_te_mp DOS/material set,
-* 2 regression from the NEMAD superconductor set, 2 regression from the NEMAD magnetic set,
+* 2 regression from the NEMAD superconductor set (tc, pressure),
+* 3 regression from the NEMAD magnetic set (curie, magnetization, neel),
+* 2 regression from the phonix-db set (kp, klat),
 * the built-in autoencoder head (always on).
 
 All compositions are featurized **on the fly** with the invertible KMD-1d descriptor
@@ -16,7 +18,8 @@ All compositions are featurized **on the fly** with the invertible KMD-1d descri
 
 Tasks are added one at a time (dynamic finetuning). The AE head stays on the whole time; when a
 new head is appended, previously learned tasks keep only ~``replay_ratio`` of their valid
-training targets active (per-task ``task_masking_ratio``) — balancing forgetting against cost.
+training targets active (per-task ``task_masking_ratio``). The mask is drawn once per step when
+the training dataset is built (it is not resampled each epoch) — balancing forgetting against cost.
 Every step evaluates *all* active heads on the fixed test split and plots the new head plus the
 per-task forgetting trajectory.
 
@@ -138,8 +141,8 @@ class ContinualRehearsalConfig:
         unknown = [t for t in self.task_sequence if t not in TASK_SPECS]
         if unknown:
             raise ValueError(f"Unknown task(s) {unknown}. Available: {sorted(TASK_SPECS)}")
-        if not 0.0 < self.replay_ratio <= 1.0:
-            raise ValueError("replay_ratio must be in (0, 1].")
+        if not 0.0 <= self.replay_ratio <= 1.0:
+            raise ValueError("replay_ratio must be in [0, 1] (0 = no rehearsal).")
         if len(self.inverse_reg_tasks) != len(self.inverse_reg_targets):
             raise ValueError("inverse_reg_tasks and inverse_reg_targets must have equal length.")
 
@@ -233,9 +236,12 @@ class ContinualRehearsalRunner:
             values = df[col]
             if spec["source"] != "qc" and spec["kind"] == "reg":
                 # log1p compresses the orders-of-magnitude range, then z-score + clip tails.
+                # Scaling stats come from *train* rows only to avoid leaking val/test distribution.
                 v = np.log1p(df[col].astype(float).clip(lower=0.0))
-                mean = float(v.mean())
-                std = float(v.std(ddof=0)) or 1.0
+                is_train = np.array([split_by_key.get(str(k)) == "train" for k in df.index])
+                ref = v[is_train] if is_train.any() else v
+                mean = float(ref.mean())
+                std = float(ref.std(ddof=0)) or 1.0
                 values = ((v - mean) / std).clip(-_RAW_TARGET_CLIP, _RAW_TARGET_CLIP)
             frame[col] = values
             if spec["kind"] == "kr":
@@ -372,11 +378,19 @@ class ContinualRehearsalRunner:
             )
             trainer.fit(model, datamodule=datamodule)
 
+            # Evaluate on the DataModule's *resolved* test compositions so the metrics use exactly
+            # the rows held out of training (not the raw per-task split column, which can diverge
+            # from the global overlay/random-fallback split the DataModule actually trained on).
+            test_keys: set[str] | None = None
+            if datamodule.split_series is not None:
+                resolved = datamodule.split_series
+                test_keys = set(resolved.index[resolved == "test"].astype(str))
+
             step_dir = self.output_dir / f"step{step + 1:02d}_{task_name}"
             step_dir.mkdir(parents=True, exist_ok=True)
             step_metrics: dict[str, dict[str, float]] = {}
             for name in active:
-                metric = self._evaluate_task(model, name, step_dir, is_new=(name == task_name))
+                metric = self._evaluate_task(model, name, step_dir, is_new=(name == task_name), test_keys=test_keys)
                 step_metrics[name] = metric
                 metric_history[name].append((step + 1, metric["primary"]))
             records.append({"step": step + 1, "new_task": task_name, "metrics": step_metrics})
@@ -384,20 +398,26 @@ class ContinualRehearsalRunner:
             logger.info(f"Step {step + 1}: {summary}")
 
         self._plot_forgetting(metric_history)
-        (self.output_dir / "experiment_records.json").write_text(json.dumps(records, indent=2))
+        (self.output_dir / "experiment_records.json").write_text(json.dumps(records, indent=2), encoding="utf-8")
 
         inverse = self._inverse_design(model)
-        (self.output_dir / "inverse_design.json").write_text(json.dumps(inverse, indent=2))
+        (self.output_dir / "inverse_design.json").write_text(json.dumps(inverse, indent=2), encoding="utf-8")
 
         self._write_report_html(records, inverse)
         logger.info(f"Done. Outputs in {self.output_dir}")
 
     # ------------------------------------------------------------------ eval
 
-    def _test_rows(self, task_name: str) -> list[str]:
+    def _test_rows(self, task_name: str, test_keys: set[str] | None = None) -> list[str]:
+        """Test compositions with a non-null target for ``task_name``.
+
+        When ``test_keys`` is given (the DataModule's resolved test split) it is the source of
+        truth; otherwise fall back to the per-task ``split`` column (used for inverse-design seeds).
+        """
         spec = TASK_SPECS[task_name]
         frame = self.task_frames[task_name]
-        mask = frame[spec["column"]].notna() & (frame["split"] == "test")
+        mask = frame[spec["column"]].notna()
+        mask &= frame.index.isin(test_keys) if test_keys is not None else (frame["split"] == "test")
         return list(frame.index[mask])
 
     def _descriptor_tensor(self, comps: list[str], device) -> tuple[torch.Tensor, list[str]]:
@@ -405,12 +425,12 @@ class ContinualRehearsalRunner:
         comps = [c for c in comps if c in desc.index]
         return torch.tensor(desc.loc[comps].values, dtype=torch.float32, device=device), comps
 
-    def _evaluate_task(self, model, task_name, step_dir, *, is_new) -> dict[str, float]:
+    def _evaluate_task(self, model, task_name, step_dir, *, is_new, test_keys=None) -> dict[str, float]:
         spec = TASK_SPECS[task_name]
         kind = spec["kind"]
         model.eval()
         device = next(model.parameters()).device
-        comps = self._test_rows(task_name)
+        comps = self._test_rows(task_name, test_keys)
         if not comps:
             return {"primary": float("nan"), "samples": 0}
         frame = self.task_frames[task_name]
@@ -844,7 +864,14 @@ def _parse_args(argv: list[str] | None = None) -> ContinualRehearsalConfig:
             data[key] = val
 
     field_names = set(ContinualRehearsalConfig.__dataclass_fields__)
-    path_fields = {"qc_data_path", "qc_preprocessing_path", "superconductor_path", "magnetic_path", "output_dir"}
+    path_fields = {
+        "qc_data_path",
+        "qc_preprocessing_path",
+        "superconductor_path",
+        "magnetic_path",
+        "phonix_path",
+        "output_dir",
+    }
     kwargs: dict[str, Any] = {}
     for key, value in data.items():
         if key not in field_names:

--- a/src/foundation_model/scripts/continual_rehearsal_demo.py
+++ b/src/foundation_model/scripts/continual_rehearsal_demo.py
@@ -1,0 +1,514 @@
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Continual multi-task learning demo with rehearsal (5% replay).
+
+Comprehensive end-to-end exercise of the composition-keyed data stack + FlexibleMultiTaskModel
+across all task types. Tasks are added one at a time (mimicking dynamic finetuning); the
+built-in autoencoder head stays on the whole time, and each time a new task head is appended,
+previously learned tasks are *not* fully retrained — instead each keeps only ~``replay_ratio``
+of its valid training targets active per epoch (via per-task ``task_masking_ratio``), striking a
+balance between catastrophic forgetting and training cost.
+
+After every step the new head's performance and the degradation of all previously learned heads
+are evaluated on the fixed test split and plotted.
+
+Run via the wrapper:
+    ./run_continual_rehearsal_demo.sh samples/continual_rehearsal_demo_config_smoke.toml
+or directly:
+    python -m foundation_model.scripts.continual_rehearsal_demo --config-file <toml>
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless
+
+import joblib  # type: ignore[import-untyped]
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import torch
+from lightning import Trainer, seed_everything
+from lightning.pytorch.callbacks import EarlyStopping
+from loguru import logger
+from sklearn.metrics import accuracy_score, f1_score, mean_absolute_error, r2_score  # type: ignore[import-untyped]
+
+from foundation_model.data.datamodule import CompoundDataModule
+from foundation_model.models.flexible_multi_task_model import FlexibleMultiTaskModel
+from foundation_model.models.model_config import (
+    ClassificationTaskConfig,
+    KernelRegressionTaskConfig,
+    MLPEncoderConfig,
+    OptimizerConfig,
+    RegressionTaskConfig,
+)
+
+# --- Task catalogue (columns in the qc_ac_te_mp DOS/material dataset) ---------
+# Each task owns its target column; kernel-regression tasks add a t (x-axis) column.
+TASK_SPECS: dict[str, dict[str, Any]] = {
+    "density": {"kind": "reg", "column": "Density (normalized)"},
+    "formation_energy": {"kind": "reg", "column": "Formation energy per atom (normalized)"},
+    "dos_density": {"kind": "kr", "column": "DOS density (normalized)", "t_column": "DOS energy"},
+    "power_factor": {"kind": "kr", "column": "Power factor (normalized)", "t_column": "Power factor (T/K)"},
+    "material_type": {"kind": "clf", "column": "Material type (label)", "num_classes": 5},
+}
+DEFAULT_SEQUENCE = ["density", "formation_energy", "dos_density", "power_factor", "material_type"]
+
+
+@dataclass
+class ContinualRehearsalConfig:
+    """Configuration for the continual rehearsal demo."""
+
+    data_path: Path = Path("data/qc_ac_te_mp_dos_reformat_20250615_enforce_quaternary_test.pd.parquet")
+    descriptor_path: Path = Path("data/qc_ac_te_mp_dos_composition_desc_trans_20250615.pd.parquet")
+    preprocessing_path: Path | None = Path("data/preprocessing_objects_20250615.pkl.z")
+    output_dir: Path = Path("artifacts/continual_rehearsal")
+
+    task_sequence: list[str] = field(default_factory=lambda: list(DEFAULT_SEQUENCE))
+    replay_ratio: float = 0.05  # fraction of a learned task's valid train targets kept per step
+    sample: int | None = None  # optional cap on total compositions (for fast runs)
+
+    max_epochs_per_step: int = 10
+    batch_size: int = 256
+    num_workers: int = 0
+    early_stopping_patience: int = 0  # 0 disables early stopping (fixed epochs)
+
+    latent_dim: int = 128
+    encoder_hidden: int = 256
+    head_hidden_dim: int = 64
+    head_lr: float = 5e-3
+    encoder_lr: float = 5e-3
+    n_kernel: int = 15
+    kr_lr: float = 5e-4
+    kr_decay: float = 5e-5
+
+    random_seed: int = 2025
+    datamodule_random_seed: int = 42
+    accelerator: str = "cpu"
+    devices: int = 1
+
+    def __post_init__(self) -> None:
+        unknown = [t for t in self.task_sequence if t not in TASK_SPECS]
+        if unknown:
+            raise ValueError(f"Unknown task(s) {unknown}. Available: {sorted(TASK_SPECS)}")
+        if not 0.0 < self.replay_ratio <= 1.0:
+            raise ValueError("replay_ratio must be in (0, 1].")
+
+
+def _as_float_array(cell: Any) -> np.ndarray:
+    """Coerce a sequence cell (ndarray/list/str) to a 1D float array."""
+    if isinstance(cell, str):
+        cell = ast.literal_eval(cell)
+    return np.asarray(cell, dtype=float).ravel()
+
+
+def _init_kernels(t_values: np.ndarray, n_kernel: int) -> tuple[list[float], list[float]]:
+    """Quantile-spaced kernel centres + uniform sigmas from the training t distribution."""
+    t = np.asarray(t_values, dtype=float)
+    t = t[np.isfinite(t)]
+    if t.size == 0:
+        return [], []
+    centers = np.quantile(t, np.linspace(0.0, 1.0, n_kernel))
+    span = max((float(t.max()) - float(t.min())) / max(n_kernel - 1, 1), 1e-3)
+    sigmas = np.full(n_kernel, span, dtype=float)
+    return centers.tolist(), sigmas.tolist()
+
+
+class ContinualRehearsalRunner:
+    def __init__(self, config: ContinualRehearsalConfig):
+        self.config = config
+        self.output_dir = Path(config.output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self._load_data()
+
+    # ------------------------------------------------------------------ data
+
+    def _load_data(self) -> None:
+        cfg = self.config
+        logger.info("Loading descriptors and properties...")
+        descriptors = pd.read_parquet(cfg.descriptor_path)
+        properties = pd.read_parquet(cfg.data_path)
+
+        if cfg.preprocessing_path is not None and Path(cfg.preprocessing_path).exists():
+            dropped = joblib.load(cfg.preprocessing_path).get("dropped_idx", [])
+            properties = properties.loc[~properties.index.isin(dropped)]
+            logger.info(f"Dropped {len(dropped)} preprocessing-flagged rows.")
+
+        common = descriptors.index.intersection(properties.index)
+        if cfg.sample is not None and cfg.sample < len(common):
+            common = pd.Index(
+                pd.Series(common).sample(n=cfg.sample, random_state=cfg.datamodule_random_seed).to_numpy()
+            )
+        descriptors = descriptors.loc[common]
+        properties = properties.loc[common]
+        descriptors.index = descriptors.index.astype(str)
+        properties.index = properties.index.astype(str)
+
+        self.descriptors = descriptors
+        self.properties = properties
+        self.x_dim = descriptors.shape[1]
+        self.composition_column: str = str(descriptors.index.name) if descriptors.index.name is not None else "id"
+        logger.info(f"Aligned {len(common)} compositions; descriptor dim = {self.x_dim}.")
+        if "split" in properties.columns:
+            logger.info(f"Split counts: {properties['split'].value_counts().to_dict()}")
+
+        # Precompute a label -> original-index map for the descriptor_fn (no matrix copy).
+        self._label_by_str = {str(idx): idx for idx in self.descriptors.index}
+
+    def descriptor_fn(self, compositions: list[str]) -> pd.DataFrame:
+        labels = [self._label_by_str[c] for c in compositions if c in self._label_by_str]
+        return self.descriptors.loc[labels]
+
+    def _task_frame(self, task_name: str) -> pd.DataFrame:
+        """Composition-indexed frame holding this task's column(s) + split."""
+        spec = TASK_SPECS[task_name]
+        cols = [spec["column"]]
+        if spec["kind"] == "kr":
+            cols.append(spec["t_column"])
+        if "split" in self.properties.columns:
+            cols.append("split")
+        return self.properties[cols].copy()
+
+    # ------------------------------------------------------------------ configs
+
+    def _build_task_config(self, task_name: str):
+        cfg = self.config
+        spec = TASK_SPECS[task_name]
+        ld, hd = cfg.latent_dim, cfg.head_hidden_dim
+        if spec["kind"] == "reg":
+            return RegressionTaskConfig(
+                name=task_name,
+                data_column=spec["column"],
+                dims=[ld, hd, 1],
+                optimizer=OptimizerConfig(lr=cfg.head_lr, weight_decay=1e-5),
+            )
+        if spec["kind"] == "clf":
+            return ClassificationTaskConfig(
+                name=task_name,
+                data_column=spec["column"],
+                dims=[ld, hd, 32],
+                num_classes=spec["num_classes"],
+                optimizer=OptimizerConfig(lr=cfg.head_lr, weight_decay=1e-5),
+            )
+        # kernel regression
+        train_t = self._collect_train_t(task_name)
+        centers, sigmas = _init_kernels(train_t, cfg.n_kernel)
+        return KernelRegressionTaskConfig(
+            name=task_name,
+            data_column=spec["column"],
+            t_column=spec["t_column"],
+            x_dim=[ld, 128, 64],
+            t_dim=[16, 8],
+            kernel_num_centers=cfg.n_kernel,
+            kernel_centers_init=centers or None,
+            kernel_sigmas_init=sigmas or None,
+            kernel_learnable_centers=True,
+            kernel_learnable_sigmas=True,
+            enable_mu3=False,
+            optimizer=OptimizerConfig(lr=cfg.kr_lr, weight_decay=cfg.kr_decay),
+        )
+
+    def _collect_train_t(self, task_name: str) -> np.ndarray:
+        spec = TASK_SPECS[task_name]
+        frame = self.properties
+        mask = frame[spec["column"]].notna()
+        if "split" in frame.columns:
+            mask &= frame["split"] == "train"
+        t_cells = frame.loc[mask, spec["t_column"]].dropna()
+        if t_cells.empty:
+            return np.array([])
+        return np.concatenate([_as_float_array(c) for c in t_cells])
+
+    # ------------------------------------------------------------------ run
+
+    def run(self) -> None:
+        cfg = self.config
+        seed_everything(cfg.random_seed, workers=True)
+
+        encoder_config = MLPEncoderConfig(hidden_dims=[self.x_dim, cfg.encoder_hidden, cfg.latent_dim])
+        model = FlexibleMultiTaskModel(
+            task_configs=[],
+            encoder_config=encoder_config,
+            enable_autoencoder=True,
+            shared_block_optimizer=OptimizerConfig(lr=cfg.encoder_lr, weight_decay=1e-2),
+        )
+
+        task_configs: dict[str, Any] = {}
+        # metric_history[task] = list of (step_index, metric_value)
+        metric_history: dict[str, list[tuple[int, float]]] = {name: [] for name in cfg.task_sequence}
+        records: list[dict[str, Any]] = []
+
+        for step, task_name in enumerate(cfg.task_sequence):
+            logger.info(f"=== Step {step + 1}/{len(cfg.task_sequence)}: add task '{task_name}' ===")
+            new_cfg = self._build_task_config(task_name)
+            task_configs[task_name] = new_cfg
+            model.add_task(new_cfg)
+
+            # Rehearsal: new task full, previously learned tasks keep replay_ratio of train targets.
+            active = cfg.task_sequence[: step + 1]
+            for name in active:
+                task_configs[name].task_masking_ratio = 1.0 if name == task_name else cfg.replay_ratio
+
+            datamodule = CompoundDataModule(
+                task_configs=[task_configs[name] for name in active],
+                descriptor_fn=self.descriptor_fn,
+                task_frames={name: self._task_frame(name) for name in active},
+                composition_column=self.composition_column,
+                random_seed=cfg.datamodule_random_seed,
+                batch_size=cfg.batch_size,
+                num_workers=cfg.num_workers,
+            )
+
+            callbacks: list[Any] = []
+            if cfg.early_stopping_patience > 0:
+                callbacks.append(EarlyStopping(monitor="val_final_loss", patience=cfg.early_stopping_patience))
+            trainer = Trainer(
+                max_epochs=cfg.max_epochs_per_step,
+                accelerator=cfg.accelerator,
+                devices=cfg.devices,
+                logger=False,
+                enable_checkpointing=False,
+                enable_progress_bar=False,
+                callbacks=callbacks,
+            )
+            trainer.fit(model, datamodule=datamodule)
+
+            step_dir = self.output_dir / f"step{step + 1:02d}_{task_name}"
+            step_dir.mkdir(parents=True, exist_ok=True)
+            step_metrics: dict[str, dict[str, float]] = {}
+            for name in active:
+                metric, primary = self._evaluate_task(model, name, step_dir, is_new=(name == task_name))
+                step_metrics[name] = metric
+                metric_history[name].append((step + 1, primary))
+
+            records.append(
+                {"step": step + 1, "new_task": task_name, "active_tasks": list(active), "metrics": step_metrics}
+            )
+            logger.info(f"Step {step + 1} metrics: { {k: round(v['primary'], 4) for k, v in step_metrics.items()} }")
+
+        self._plot_forgetting(metric_history)
+        summary_path = self.output_dir / "experiment_records.json"
+        summary_path.write_text(json.dumps(records, indent=2))
+        logger.info(f"Done. Summary: {summary_path}")
+
+    # ------------------------------------------------------------------ eval
+
+    def _test_rows(self, task_name: str) -> pd.Index:
+        spec = TASK_SPECS[task_name]
+        frame = self.properties
+        mask = frame[spec["column"]].notna()
+        if "split" in frame.columns:
+            mask &= frame["split"] == "test"
+        return frame.index[mask]
+
+    def _evaluate_task(
+        self, model: FlexibleMultiTaskModel, task_name: str, step_dir: Path, *, is_new: bool
+    ) -> tuple[dict[str, float], float]:
+        spec = TASK_SPECS[task_name]
+        kind = spec["kind"]
+        comps = list(self._test_rows(task_name))
+        model.eval()
+        device = next(model.parameters()).device
+        if not comps:
+            return {"primary": float("nan"), "samples": 0}, float("nan")
+
+        x = torch.tensor(self.descriptors.loc[comps].values, dtype=torch.float32, device=device)
+        head = model.task_heads[task_name]
+
+        with torch.no_grad():
+            # Evaluate the target head directly off the shared latent so other (e.g. kernel)
+            # heads — which require their own t_sequences — are not invoked.
+            h_task = torch.tanh(model.encoder(x))
+
+            if kind == "reg":
+                pred = head(h_task).squeeze(-1).cpu().numpy()
+                true = self.properties.loc[comps, spec["column"]].astype(float).to_numpy()
+                metric = {
+                    "r2": float(r2_score(true, pred)),
+                    "mae": float(mean_absolute_error(true, pred)),
+                    "samples": len(comps),
+                }
+                metric["primary"] = metric["r2"]
+                if is_new:
+                    self._plot_parity(true, pred, task_name, metric["r2"], step_dir)
+                return metric, metric["r2"]
+
+            if kind == "clf":
+                logits = head(h_task)
+                pred = logits.argmax(dim=-1).cpu().numpy()
+                true = self.properties.loc[comps, spec["column"]].astype(int).to_numpy()
+                acc = float(accuracy_score(true, pred))
+                metric = {
+                    "accuracy": acc,
+                    "macro_f1": float(f1_score(true, pred, average="macro", zero_division=0)),
+                    "samples": len(comps),
+                    "primary": acc,
+                }
+                if is_new:
+                    self._plot_confusion(true, pred, task_name, acc, step_dir, spec["num_classes"])
+                return metric, acc
+
+            # kernel regression: build per-sample t lists, evaluate concatenated points
+            t_col = spec["t_column"]
+            keep, t_list, true_parts = [], [], []
+            for comp in comps:
+                y_cell = self.properties.at[comp, spec["column"]]
+                t_cell = self.properties.at[comp, t_col]
+                if y_cell is None or t_cell is None:
+                    continue
+                y_arr, t_arr = _as_float_array(y_cell), _as_float_array(t_cell)
+                if y_arr.size == 0 or y_arr.size != t_arr.size:
+                    continue
+                keep.append(comp)
+                t_list.append(torch.tensor(t_arr, dtype=torch.float32, device=device))
+                true_parts.append(y_arr)
+            if not keep:
+                return {"primary": float("nan"), "samples": 0}, float("nan")
+            xk = torch.tensor(self.descriptors.loc[keep].values, dtype=torch.float32, device=device)
+            h_k = torch.tanh(model.encoder(xk))
+            expanded_h, expanded_t = model._expand_for_kernel_regression(h_k, t_list)
+            pred = head(expanded_h, t=expanded_t).squeeze(-1).cpu().numpy()
+            true = np.concatenate(true_parts)
+            metric = {
+                "r2": float(r2_score(true, pred)),
+                "mae": float(mean_absolute_error(true, pred)),
+                "samples": len(keep),
+                "points": int(true.size),
+                "primary": float(r2_score(true, pred)),
+            }
+            if is_new:
+                self._plot_kr_sequences(keep, t_list, true_parts, pred, task_name, metric["r2"], step_dir)
+            return metric, metric["primary"]
+
+    # ------------------------------------------------------------------ plots
+
+    def _plot_parity(self, true, pred, task_name, r2, step_dir):
+        fig, ax = plt.subplots(figsize=(5, 5), dpi=130)
+        ax.scatter(true, pred, s=8, alpha=0.4, edgecolor="none")
+        lo, hi = float(min(true.min(), pred.min())), float(max(true.max(), pred.max()))
+        ax.plot([lo, hi], [lo, hi], "r--", lw=1)
+        ax.set_xlabel("true")
+        ax.set_ylabel("pred")
+        ax.set_title(f"{task_name} (new) — R²={r2:.3f}, n={len(true)}")
+        fig.tight_layout()
+        fig.savefig(step_dir / f"{task_name}_parity.png")
+        plt.close(fig)
+
+    def _plot_confusion(self, true, pred, task_name, acc, step_dir, num_classes):
+        cm = np.zeros((num_classes, num_classes), dtype=int)
+        for t, p in zip(true, pred):
+            if 0 <= t < num_classes and 0 <= p < num_classes:
+                cm[t, p] += 1
+        fig, ax = plt.subplots(figsize=(5, 4.5), dpi=130)
+        im = ax.imshow(cm, cmap="Blues")
+        fig.colorbar(im, ax=ax)
+        ax.set_xlabel("pred")
+        ax.set_ylabel("true")
+        ax.set_title(f"{task_name} (new) — acc={acc:.3f}, n={int(cm.sum())}")
+        fig.tight_layout()
+        fig.savefig(step_dir / f"{task_name}_confusion.png")
+        plt.close(fig)
+
+    def _plot_kr_sequences(self, comps, t_list, true_parts, pred, task_name, r2, step_dir):
+        # Split the concatenated prediction back into per-sample chunks.
+        fig, ax = plt.subplots(figsize=(6, 4), dpi=130)
+        offset = 0
+        for i in range(min(3, len(comps))):
+            n = true_parts[i].size
+            t = t_list[i].cpu().numpy()
+            ax.plot(t, true_parts[i], lw=1.2, alpha=0.8, label=f"true #{i}")
+            ax.plot(t, pred[offset : offset + n], lw=1.0, ls="--", alpha=0.8, label=f"pred #{i}")
+            offset += n
+        ax.set_xlabel("t")
+        ax.set_ylabel("value (normalized)")
+        ax.set_title(f"{task_name} (new) — R²={r2:.3f} over all points")
+        ax.legend(fontsize=7, ncol=2)
+        fig.tight_layout()
+        fig.savefig(step_dir / f"{task_name}_sequences.png")
+        plt.close(fig)
+
+    def _plot_forgetting(self, metric_history: dict[str, list[tuple[int, float]]]):
+        fig, ax = plt.subplots(figsize=(7, 4.5), dpi=130)
+        for task_name, points in metric_history.items():
+            if not points:
+                continue
+            steps = [s for s, _ in points]
+            vals = [v for _, v in points]
+            ax.plot(steps, vals, marker="o", label=task_name)
+        ax.set_xlabel("finetuning step")
+        ax.set_ylabel("primary metric (R² / accuracy)")
+        ax.set_title("Per-task performance vs continual finetuning step (forgetting)")
+        ax.grid(True, alpha=0.3)
+        ax.legend(fontsize=8)
+        fig.tight_layout()
+        fig.savefig(self.output_dir / "forgetting_trajectory.png")
+        plt.close(fig)
+        logger.info(f"Saved forgetting trajectory to {self.output_dir / 'forgetting_trajectory.png'}")
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def _load_toml(path: Path) -> dict[str, Any]:
+    try:
+        import tomllib  # type: ignore[attr-defined]
+    except ModuleNotFoundError:  # pragma: no cover
+        import tomli as tomllib  # type: ignore
+    return tomllib.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _parse_args(argv: list[str] | None = None) -> ContinualRehearsalConfig:
+    parser = argparse.ArgumentParser(description="Continual multi-task rehearsal demo.")
+    parser.add_argument("--config-file", type=Path, default=None, help="TOML config path.")
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--sample", type=int, default=None)
+    parser.add_argument("--max-epochs-per-step", type=int, default=None)
+    parser.add_argument("--replay-ratio", type=float, default=None)
+    parser.add_argument("--batch-size", type=int, default=None)
+    parser.add_argument("--accelerator", type=str, default=None)
+    parser.add_argument("--task-sequence", nargs="+", default=None)
+    args = parser.parse_args(argv)
+
+    data = _load_toml(args.config_file) if args.config_file else {}
+    # CLI overrides take precedence over the config file.
+    for key in (
+        "output_dir",
+        "sample",
+        "max_epochs_per_step",
+        "replay_ratio",
+        "batch_size",
+        "accelerator",
+        "task_sequence",
+    ):
+        val = getattr(args, key)
+        if val is not None:
+            data[key] = val
+
+    field_names = {f for f in ContinualRehearsalConfig.__dataclass_fields__}
+    path_fields = {"data_path", "descriptor_path", "preprocessing_path", "output_dir"}
+    kwargs: dict[str, Any] = {}
+    for key, value in data.items():
+        if key not in field_names:
+            logger.warning(f"Ignoring unknown config key '{key}'.")
+            continue
+        kwargs[key] = Path(value) if key in path_fields and value is not None else value
+    return ContinualRehearsalConfig(**kwargs)
+
+
+def main(argv: list[str] | None = None) -> None:
+    config = _parse_args(argv)
+    ContinualRehearsalRunner(config).run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Scope

End-to-end demo exercising the composition-keyed data stack + `FlexibleMultiTaskModel` across **every inorganic dataset and task type**, with continual (dynamic) finetuning + 5% rehearsal, plus a latent-space **inverse-design** stage. Includes one small core-model upgrade.

## Task set (9 supervised + AE)
- qc_ac_te_mp: `density`, `formation_energy` (reg); `dos_density`, `power_factor` (kernel reg); `material_type` (clf).
- NEMAD superconductor: `tc`, `pressure` (reg). NEMAD magnetic: `curie`, `magnetization` (reg).
- Built-in autoencoder head, always on.

## Mechanism
- **KMD-1d descriptor** (`utils/kmd_plus`) computed on the fly as the `descriptor_fn` (cached) and **invertible** back to composition via `KMD.inverse` — the unifying, invertible featurizer across all datasets, joined by composition formula. NEMAD targets are z-scored; split = qc's `split` column + a random split for NEMAD.
- Tasks added one at a time (`model.add_task`); the AE stays on; each previously-learned task keeps only `replay_ratio` (5%) of its valid **training** targets active via per-task `task_masking_ratio` (val/test full, so forgetting is measured on the complete test set).
- **All 9 tasks** are evaluated every step; per-step plots (parity / kernel-sequence / confusion) + a per-task **forgetting trajectory**.

## Core model upgrade
`optimize_latent` gains `class_targets` — maximize the combined probability of given class indices — composable with regression `task_targets` (classification-only and the legacy single-task path also work). Tests added (input/latent space, combined, validation, classification-only).

## Inverse design
After all tasks are learned, optimize the latent toward **2 regression targets** (`density`→1.5, `formation_energy`→−1.5) **+ increased quasicrystal probability** (`material_type` classes DQC+IQC), then decode the optimized KMD descriptor back to a composition with `KMD.inverse`. Records in-latent achieved values, the decode round-trip, and decoded compositions, with plots.

## Verification — full 20-epoch run (bounded to 8000 rows/dataset, ~23.5k compositions)
- Per-task tracking, e.g. `density` R² 0.98→…→0.94 (held by rehearsal as 8 more tasks are added); `material_type` acc 0.98; NEMAD `tc` R²≈0.5→0.3; etc. — full trajectory in `forgetting_trajectory.png` / `experiment_records.json`.
- **Inverse design works**: in-latent `density` −0.20→**1.49** (target 1.5), `formation_energy` 0.30→**−1.46** (target −1.5); QC probability rises (e.g. 0.005→0.021); KMD.inverse decodes real compositions (e.g. `Zr0.321 La0.257 O0.215 …`).
- A 1500-row / 1-epoch **smoke config** runs the whole pipeline in seconds.
- `ruff` + `mypy` clean on changed files; model/data suites pass (112), optimize_latent/AE tests pass (13). Run outputs land under `artifacts/` (gitignored).

## Files
- `models/flexible_multi_task_model.py` (+ test): `optimize_latent` `class_targets`.
- `scripts/continual_rehearsal_demo.py`: the runner (KMD featurizer, NEMAD integration, incremental rehearsal, evaluation, inverse design, plots).
- `samples/continual_rehearsal_demo_config.toml` (full, 20 epochs) + `..._smoke.toml`; `run_continual_rehearsal_demo.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)