### PR TITLE
feat(data): system-wide composition normalization for cross-source alignment

### DIFF
--- a/src/foundation_model/data/composition_sources.py
+++ b/src/foundation_model/data/composition_sources.py
@@ -20,7 +20,7 @@ tested in isolation with in-memory frames and a fake descriptor function.
 
 from __future__ import annotations
 
-from collections.abc import Mapping  # used for runtime isinstance; safe (unlike typing.Mapping)
+from collections.abc import Mapping
 from typing import Callable, Sequence
 
 import joblib  # type: ignore[import-untyped]
@@ -70,7 +70,7 @@ def normalize_composition(value: object, *, decimals: int = _COMPOSITION_AMOUNT_
     from pymatgen.core.composition import Composition  # local import; pymatgen is heavy
 
     try:
-        if isinstance(value, Mapping):
+        if isinstance(value, dict):
             cleaned = {k: float(v) for k, v in value.items() if v is not None and float(v) > 0}
             if not cleaned:
                 return None
@@ -145,16 +145,21 @@ def lookup_descriptor_fn(
 def _reindex_by_canonical(
     frame: pd.DataFrame, normalizer: CompositionNormalizer | None, *, source: str
 ) -> pd.DataFrame:
-    """Return ``frame`` re-indexed by canonical composition key, deduped keep-first (with warning)."""
+    """Return ``frame`` re-indexed by canonical composition key, deduped keep-first (with warning).
+
+    Uses a shallow copy (the descriptor matrix is shared, only the index is replaced) to avoid
+    duplicating large descriptor frames.
+    """
     canon = pd.Index([canonical_key(c, normalizer) for c in frame.index])
+    out = frame.copy(deep=False)
+    out.index = canon
     duplicated = canon.duplicated(keep="first")
     if duplicated.any():
         logger.warning(
             f"{source}: {int(duplicated.sum())} descriptor row(s) collapsed to a duplicate "
             "composition key after normalization; keeping the first occurrence of each."
         )
-    out = frame.loc[~duplicated].copy()
-    out.index = canon[~duplicated]
+        out = out[~duplicated]
     return out
 
 

--- a/src/foundation_model/data/composition_sources.py
+++ b/src/foundation_model/data/composition_sources.py
@@ -20,7 +20,6 @@ tested in isolation with in-memory frames and a fake descriptor function.
 
 from __future__ import annotations
 
-import re
 from collections.abc import Mapping  # used for runtime isinstance; safe (unlike typing.Mapping)
 from typing import Callable, Sequence
 
@@ -39,11 +38,6 @@ VALID_SPLIT_LABELS = frozenset(_SPLIT_PRECEDENCE)
 # Decimal places used when rendering element amounts in a canonical composition key. Six is
 # enough for typical fractional stoichiometries while collapsing float-representation noise.
 _COMPOSITION_AMOUNT_DECIMALS = 6
-
-# Characters that can legitimately appear in a chemical formula. A string with anything else
-# (``-`` in ``mp-1234`` Materials Project IDs, ``*``/``=`` in SMILES, …) is obviously not a
-# formula, so we reject it without paying for a pymatgen parse + exception per row.
-_FORMULA_CHARS = re.compile(r"^[A-Za-z0-9.()\[\]\s]+$")
 
 
 def normalize_composition(value: object, *, decimals: int = _COMPOSITION_AMOUNT_DECIMALS) -> str | None:
@@ -82,10 +76,12 @@ def normalize_composition(value: object, *, decimals: int = _COMPOSITION_AMOUNT_
                 return None
             comp = Composition(cleaned)
         else:
-            text = str(value)
-            # Fast-path: skip the pymatgen parse for strings that can't be formulas (e.g. ``mp-``
-            # IDs, SMILES) so non-formula join keys don't cost an exception each.
-            if not text or not _FORMULA_CHARS.match(text):
+            text = str(value).strip()
+            # Fast-path: a real formula starts with an element symbol (uppercase) or an opening
+            # bracket. This cheaply rejects non-formula join keys (``mp-1234`` IDs, synthetic
+            # ``s0`` keys, SMILES like ``*CC*``) without a pymatgen parse, while still letting
+            # charged/bracketed formulas through for pymatgen to decide.
+            if not text or not (text[0].isupper() or text[0] in "(["):
                 return None
             comp = Composition(text)
     except Exception:
@@ -96,7 +92,7 @@ def normalize_composition(value: object, *, decimals: int = _COMPOSITION_AMOUNT_
     return " ".join(f"{el}{amounts[el]:.{decimals}f}" for el in sorted(amounts))
 
 
-CompositionNormalizer = Callable[[object], "str | None"]
+CompositionNormalizer = Callable[[object], str | None]
 
 
 def canonical_key(value: object, normalizer: CompositionNormalizer | None) -> str:
@@ -135,12 +131,13 @@ def lookup_descriptor_fn(
     """
     frame = _reindex_by_canonical(features, composition_normalizer, source="lookup_descriptor_fn")
 
+    index = frame.index
+
     def descriptor_fn(compositions: Sequence[str]) -> pd.DataFrame:
-        # Canonicalize the query keys too (idempotent when the DataModule already did) so the
-        # lookup is robust whether called with raw or canonical compositions.
-        keys = [canonical_key(c, composition_normalizer) for c in compositions]
-        present = [k for k in keys if k in frame.index]
-        return frame.loc[present]
+        # Keys are usually already canonical (the DataModule normalized them), so try a direct
+        # hit first and only pay for canonicalization on a miss.
+        present = [c if c in index else canonical_key(c, composition_normalizer) for c in compositions]
+        return frame.loc[[k for k in present if k in index]]
 
     return descriptor_fn
 
@@ -358,11 +355,11 @@ class PrecomputedDescriptorSource:
 
     def __call__(self, compositions: Sequence[str]) -> pd.DataFrame:
         frame = self._load()
-        # Canonicalize the query keys with the same rule used for the index (idempotent when the
-        # DataModule already did), so lookups work whether called with raw or canonical keys.
-        keys = (canonical_key(c, self._composition_normalizer) for c in compositions)
-        present = [k for k in keys if k in frame.index]
-        return frame.loc[present]
+        index = frame.index
+        # Keys are usually already canonical (the DataModule normalized them); try a direct hit
+        # first and only canonicalize on a miss, so we don't re-normalize every query at scale.
+        present = [c if c in index else canonical_key(c, self._composition_normalizer) for c in compositions]
+        return frame.loc[[k for k in present if k in index]]
 
 
 class DescriptorCache:

--- a/src/foundation_model/data/composition_sources.py
+++ b/src/foundation_model/data/composition_sources.py
@@ -20,7 +20,9 @@ tested in isolation with in-memory frames and a fake descriptor function.
 
 from __future__ import annotations
 
-from typing import Callable, Mapping, Sequence
+import re
+from collections.abc import Mapping  # used for runtime isinstance; safe (unlike typing.Mapping)
+from typing import Callable, Sequence
 
 import joblib  # type: ignore[import-untyped]
 import pandas as pd
@@ -37,6 +39,11 @@ VALID_SPLIT_LABELS = frozenset(_SPLIT_PRECEDENCE)
 # Decimal places used when rendering element amounts in a canonical composition key. Six is
 # enough for typical fractional stoichiometries while collapsing float-representation noise.
 _COMPOSITION_AMOUNT_DECIMALS = 6
+
+# Characters that can legitimately appear in a chemical formula. A string with anything else
+# (``-`` in ``mp-1234`` Materials Project IDs, ``*``/``=`` in SMILES, …) is obviously not a
+# formula, so we reject it without paying for a pymatgen parse + exception per row.
+_FORMULA_CHARS = re.compile(r"^[A-Za-z0-9.()\[\]\s]+$")
 
 
 def normalize_composition(value: object, *, decimals: int = _COMPOSITION_AMOUNT_DECIMALS) -> str | None:
@@ -75,7 +82,12 @@ def normalize_composition(value: object, *, decimals: int = _COMPOSITION_AMOUNT_
                 return None
             comp = Composition(cleaned)
         else:
-            comp = Composition(str(value))
+            text = str(value)
+            # Fast-path: skip the pymatgen parse for strings that can't be formulas (e.g. ``mp-``
+            # IDs, SMILES) so non-formula join keys don't cost an exception each.
+            if not text or not _FORMULA_CHARS.match(text):
+                return None
+            comp = Composition(text)
     except Exception:
         return None
     amounts = comp.get_el_amt_dict()
@@ -108,10 +120,10 @@ def lookup_descriptor_fn(
 ) -> DescriptorFn:
     """Build a ``descriptor_fn`` that looks up rows of an in-memory descriptor frame.
 
-    The frame's index is mapped through :func:`canonical_key` so lookups match the canonical
-    composition keys the DataModule passes (it normalizes task frames the same way). Only a small
-    label map is built up front — the descriptor matrix itself is not copied — and the returned
-    rows are re-indexed by the canonical key so they align with the DataModule's master index.
+    The frame is re-indexed by :func:`canonical_key` so lookups match the canonical composition
+    keys the DataModule passes (it normalizes task frames the same way). Rows whose keys collide
+    after normalization — including pre-existing duplicate index labels — are collapsed keep-first
+    (with a warning), guaranteeing a 1:1 key→row map so lookups never mismatch in length.
 
     Parameters
     ----------
@@ -121,25 +133,32 @@ def lookup_descriptor_fn(
         Normalizer applied to the frame index. Defaults to :func:`normalize_composition`;
         pass ``None`` to look up by the raw (stringified) index instead.
     """
-    label_by_key: dict[str, object] = {}
-    for idx in features.index:
-        label_by_key.setdefault(canonical_key(idx, composition_normalizer), idx)
+    frame = _reindex_by_canonical(features, composition_normalizer, source="lookup_descriptor_fn")
 
     def descriptor_fn(compositions: Sequence[str]) -> pd.DataFrame:
         # Canonicalize the query keys too (idempotent when the DataModule already did) so the
         # lookup is robust whether called with raw or canonical compositions.
-        pairs = [
-            (key, label_by_key[key])
-            for key in (canonical_key(c, composition_normalizer) for c in compositions)
-            if key in label_by_key
-        ]
-        if not pairs:
-            return features.iloc[0:0]
-        out = features.loc[[label for _, label in pairs]].copy()
-        out.index = pd.Index([key for key, _ in pairs])
-        return out
+        keys = [canonical_key(c, composition_normalizer) for c in compositions]
+        present = [k for k in keys if k in frame.index]
+        return frame.loc[present]
 
     return descriptor_fn
+
+
+def _reindex_by_canonical(
+    frame: pd.DataFrame, normalizer: CompositionNormalizer | None, *, source: str
+) -> pd.DataFrame:
+    """Return ``frame`` re-indexed by canonical composition key, deduped keep-first (with warning)."""
+    canon = pd.Index([canonical_key(c, normalizer) for c in frame.index])
+    duplicated = canon.duplicated(keep="first")
+    if duplicated.any():
+        logger.warning(
+            f"{source}: {int(duplicated.sum())} descriptor row(s) collapsed to a duplicate "
+            "composition key after normalization; keeping the first occurrence of each."
+        )
+    out = frame.loc[~duplicated].copy()
+    out.index = canon[~duplicated]
+    return out
 
 
 def read_data_file(path: str) -> pd.DataFrame:
@@ -329,10 +348,9 @@ class PrecomputedDescriptorSource:
                 frame = frame.set_index(self.composition_column)
             frame = frame.copy()
             if self._composition_normalizer is not None:
-                frame.index = pd.Index([canonical_key(c, self._composition_normalizer) for c in frame.index])
-                duplicated = frame.index.duplicated(keep="first")
-                if duplicated.any():
-                    frame = frame[~duplicated]
+                frame = _reindex_by_canonical(
+                    frame, self._composition_normalizer, source=f"PrecomputedDescriptorSource('{self.path}')"
+                )
             else:
                 frame.index = frame.index.astype(str)
             self._frame = frame

--- a/src/foundation_model/data/composition_sources.py
+++ b/src/foundation_model/data/composition_sources.py
@@ -34,6 +34,113 @@ DescriptorFn = Callable[[list[str]], pd.DataFrame]
 _SPLIT_PRECEDENCE: dict[str, int] = {"train": 1, "val": 2, "test": 3}
 VALID_SPLIT_LABELS = frozenset(_SPLIT_PRECEDENCE)
 
+# Decimal places used when rendering element amounts in a canonical composition key. Six is
+# enough for typical fractional stoichiometries while collapsing float-representation noise.
+_COMPOSITION_AMOUNT_DECIMALS = 6
+
+
+def normalize_composition(value: object, *, decimals: int = _COMPOSITION_AMOUNT_DECIMALS) -> str | None:
+    """Canonical, float-amount composition key shared across every data source.
+
+    Different files spell the same composition differently — a pymatgen ``Composition`` /
+    element-amount ``dict`` (the qc dataset) versus a formula string (NEMAD / phonix), and
+    ``"Fe3O2"`` versus ``"Fe3.0O2.0"``. This maps any of them through pymatgen to a single
+    canonical string so the composition-keyed DataModule can join them by exact match.
+
+    The amounts are **not reduced** (``Fe2O3`` ≠ ``Fe4O6``) because some descriptors aggregate
+    by sum rather than by mean, so the absolute stoichiometry must be preserved. Every amount is
+    rendered as a fixed-precision float and elements are sorted by symbol, making the key
+    invariant to integer-vs-decimal spelling and to element ordering.
+
+    Parameters
+    ----------
+    value : object
+        A formula string, a pymatgen ``Composition``, or an element→amount mapping. Mapping
+        entries that are ``None`` or non-positive are dropped (the qc ``composition`` column
+        stores every element with mostly-``None`` amounts).
+    decimals : int, optional
+        Decimal places for each amount. Defaults to six.
+
+    Returns
+    -------
+    str | None
+        e.g. ``"Fe2.000000 O3.000000"``; ``None`` if the input is empty or unparseable.
+    """
+    from pymatgen.core.composition import Composition  # local import; pymatgen is heavy
+
+    try:
+        if isinstance(value, Mapping):
+            cleaned = {k: float(v) for k, v in value.items() if v is not None and float(v) > 0}
+            if not cleaned:
+                return None
+            comp = Composition(cleaned)
+        else:
+            comp = Composition(str(value))
+    except Exception:
+        return None
+    amounts = comp.get_el_amt_dict()
+    if not amounts:
+        return None
+    return " ".join(f"{el}{amounts[el]:.{decimals}f}" for el in sorted(amounts))
+
+
+CompositionNormalizer = Callable[[object], "str | None"]
+
+
+def canonical_key(value: object, normalizer: CompositionNormalizer | None) -> str:
+    """Apply ``normalizer`` to ``value``, falling back to ``str(value)`` when it can't parse.
+
+    The fallback is what keeps normalization safe to enable by default: real formulas are
+    canonicalized while non-formula keys (synthetic IDs, material IDs) pass through unchanged,
+    and — crucially — both the task and descriptor sides use this same rule, so even unparseable
+    keys still align.
+    """
+    if normalizer is None:
+        return str(value)
+    out = normalizer(value)
+    return out if out is not None else str(value)
+
+
+def lookup_descriptor_fn(
+    features: pd.DataFrame,
+    *,
+    composition_normalizer: CompositionNormalizer | None = normalize_composition,
+) -> DescriptorFn:
+    """Build a ``descriptor_fn`` that looks up rows of an in-memory descriptor frame.
+
+    The frame's index is mapped through :func:`canonical_key` so lookups match the canonical
+    composition keys the DataModule passes (it normalizes task frames the same way). Only a small
+    label map is built up front — the descriptor matrix itself is not copied — and the returned
+    rows are re-indexed by the canonical key so they align with the DataModule's master index.
+
+    Parameters
+    ----------
+    features : pd.DataFrame
+        Descriptor matrix indexed by composition.
+    composition_normalizer : Callable | None, optional
+        Normalizer applied to the frame index. Defaults to :func:`normalize_composition`;
+        pass ``None`` to look up by the raw (stringified) index instead.
+    """
+    label_by_key: dict[str, object] = {}
+    for idx in features.index:
+        label_by_key.setdefault(canonical_key(idx, composition_normalizer), idx)
+
+    def descriptor_fn(compositions: Sequence[str]) -> pd.DataFrame:
+        # Canonicalize the query keys too (idempotent when the DataModule already did) so the
+        # lookup is robust whether called with raw or canonical compositions.
+        pairs = [
+            (key, label_by_key[key])
+            for key in (canonical_key(c, composition_normalizer) for c in compositions)
+            if key in label_by_key
+        ]
+        if not pairs:
+            return features.iloc[0:0]
+        out = features.loc[[label for _, label in pairs]].copy()
+        out.index = pd.Index([key for key, _ in pairs])
+        return out
+
+    return descriptor_fn
+
 
 def read_data_file(path: str) -> pd.DataFrame:
     """Load a single data file into a DataFrame based on its extension.
@@ -85,6 +192,7 @@ def load_task_frame(
     composition_column: str,
     *,
     task_name: str = "",
+    composition_normalizer: CompositionNormalizer | None = None,
 ) -> pd.DataFrame:
     """Load and concatenate a task's data file(s), indexed by composition.
 
@@ -100,6 +208,10 @@ def load_task_frame(
         Name of the column holding composition keys.
     task_name : str, optional
         Task name used only for log messages.
+    composition_normalizer : Callable | None, optional
+        When given, the composition index is mapped through :func:`canonical_key` (deduped after
+        normalization). The DataModule passes its normalizer here; standalone callers default to
+        ``None`` (raw string index).
 
     Returns
     -------
@@ -131,7 +243,10 @@ def load_task_frame(
         frames.append(df)
 
     combined = pd.concat(frames, axis=0) if len(frames) > 1 else frames[0]
-    combined.index = combined.index.astype(str)
+    if composition_normalizer is not None:
+        combined.index = pd.Index([canonical_key(c, composition_normalizer) for c in combined.index])
+    else:
+        combined.index = combined.index.astype(str)
     combined.index.name = composition_column
 
     duplicated = combined.index.duplicated(keep="first")
@@ -189,11 +304,22 @@ class PrecomputedDescriptorSource:
     composition_column : str | None, optional
         If given and present as a column, it is set as the index; otherwise the file's existing
         index is treated as the composition key.
+    composition_normalizer : Callable | None, optional
+        Normalizer applied to the descriptor index via :func:`canonical_key` (deduped keep-first
+        afterwards), so lookups match the canonical keys the DataModule passes. Defaults to
+        :func:`normalize_composition`; pass ``None`` to look up by the raw string index.
     """
 
-    def __init__(self, path: str, composition_column: str | None = None):
+    def __init__(
+        self,
+        path: str,
+        composition_column: str | None = None,
+        *,
+        composition_normalizer: CompositionNormalizer | None = normalize_composition,
+    ):
         self.path = path
         self.composition_column = composition_column
+        self._composition_normalizer = composition_normalizer
         self._frame: pd.DataFrame | None = None
 
     def _load(self) -> pd.DataFrame:
@@ -202,13 +328,22 @@ class PrecomputedDescriptorSource:
             if self.composition_column is not None and self.composition_column in frame.columns:
                 frame = frame.set_index(self.composition_column)
             frame = frame.copy()
-            frame.index = frame.index.astype(str)
+            if self._composition_normalizer is not None:
+                frame.index = pd.Index([canonical_key(c, self._composition_normalizer) for c in frame.index])
+                duplicated = frame.index.duplicated(keep="first")
+                if duplicated.any():
+                    frame = frame[~duplicated]
+            else:
+                frame.index = frame.index.astype(str)
             self._frame = frame
         return self._frame
 
     def __call__(self, compositions: Sequence[str]) -> pd.DataFrame:
         frame = self._load()
-        present = [str(c) for c in compositions if str(c) in frame.index]
+        # Canonicalize the query keys with the same rule used for the index (idempotent when the
+        # DataModule already did), so lookups work whether called with raw or canonical keys.
+        keys = (canonical_key(c, self._composition_normalizer) for c in compositions)
+        present = [k for k in keys if k in frame.index]
         return frame.loc[present]
 
 

--- a/src/foundation_model/data/composition_sources_test.py
+++ b/src/foundation_model/data/composition_sources_test.py
@@ -14,9 +14,34 @@ from foundation_model.data.composition_sources import (
     PrecomputedDescriptorSource,
     build_composition_universe,
     load_task_frame,
+    lookup_descriptor_fn,
+    normalize_composition,
     read_data_file,
     resolve_splits,
 )
+
+
+# --- normalize_composition --------------------------------------------------
+
+
+def test_normalize_composition_float_and_order_invariant():
+    # Integer vs decimal spelling and element ordering all collapse to one canonical key.
+    assert normalize_composition("Fe3O2") == normalize_composition("Fe3.0O2.0")
+    assert normalize_composition("Fe2O3") == normalize_composition("O3Fe2")
+    assert normalize_composition("Fe2O3") == "Fe2.000000 O3.000000"
+    # Amounts are NOT reduced: absolute stoichiometry is preserved.
+    assert normalize_composition("Fe2O3") != normalize_composition("Fe4O6")
+
+
+def test_normalize_composition_accepts_mapping_dropping_none():
+    # The qc 'composition' column stores every element, mostly None.
+    sparse = {"Fe": 2.0, "O": 3.0, "Na": None, "Cl": 0.0}
+    assert normalize_composition(sparse) == "Fe2.000000 O3.000000"
+
+
+def test_normalize_composition_invalid_returns_none():
+    assert normalize_composition({}) is None
+    assert normalize_composition("not-a-formula!!") is None
 
 
 @pytest.fixture
@@ -220,7 +245,8 @@ def test_precomputed_descriptor_source_indexed_file(tmp_path, comp_col):
     df = pd.DataFrame({"d0": [1.0, 2.0, 3.0]}, index=pd.Index(["A", "B", "C"], name="id"))
     path = tmp_path / "desc.parquet"
     df.to_parquet(path)
-    source = PrecomputedDescriptorSource(str(path), composition_column=comp_col)
+    # composition_normalizer=None: look up by the raw (stringified) index.
+    source = PrecomputedDescriptorSource(str(path), composition_column=comp_col, composition_normalizer=None)
     out = source(["C", "A", "missing"])
     assert list(out.index) == ["C", "A"]
     assert out.loc["C", "d0"] == 3.0
@@ -231,10 +257,31 @@ def test_precomputed_descriptor_source_column_file(tmp_path):
     df = pd.DataFrame({"id": ["A", "B"], "d0": [1.0, 2.0]})
     path = tmp_path / "desc.csv"
     df.to_csv(path, index=False)
-    source = PrecomputedDescriptorSource(str(path), composition_column="id")
+    source = PrecomputedDescriptorSource(str(path), composition_column="id", composition_normalizer=None)
     out = source(["A"])
     assert list(out.index) == ["A"]
     assert out.loc["A", "d0"] == 1.0
+
+
+def test_precomputed_descriptor_source_normalizes_by_default(tmp_path):
+    """By default the index is canonicalized, so heterogeneous spellings of a query still hit."""
+    df = pd.DataFrame({"d0": [1.0, 2.0]}, index=pd.Index(["Fe2O3", "H2O"], name="composition"))
+    path = tmp_path / "desc.parquet"
+    df.to_parquet(path)
+    source = PrecomputedDescriptorSource(str(path), composition_column="composition")
+    # Queried with a different spelling of Fe2O3 (decimal amounts, reversed order).
+    out = source(["O3.0Fe2.0", "missing"])
+    assert list(out.index) == [normalize_composition("Fe2O3")]
+    assert out.iloc[0]["d0"] == 1.0
+
+
+def test_lookup_descriptor_fn_aligns_heterogeneous_spellings():
+    features = pd.DataFrame({"d0": [1.0, 2.0]}, index=pd.Index(["Fe2O3", "NaCl"]))
+    fn = lookup_descriptor_fn(features)
+    # Descriptor frame spelled "Fe2O3"; query spelled with float amounts -> still matches.
+    out = fn([normalize_composition("Fe2.0O3.0"), "missing"])
+    assert list(out.index) == [normalize_composition("Fe2O3")]
+    assert out.iloc[0]["d0"] == 1.0
 
 
 # --- resolve_splits ---------------------------------------------------------

--- a/src/foundation_model/data/composition_sources_test.py
+++ b/src/foundation_model/data/composition_sources_test.py
@@ -44,6 +44,13 @@ def test_normalize_composition_invalid_returns_none():
     assert normalize_composition("not-a-formula!!") is None
 
 
+def test_normalize_composition_fast_path_rejects_non_formula_strings():
+    # Non-formula join keys (MP IDs, SMILES) are rejected without a pymatgen parse.
+    assert normalize_composition("mp-1234") is None
+    assert normalize_composition("*CC*") is None
+    assert normalize_composition("") is None
+
+
 @pytest.fixture
 def loguru_warnings():
     """Capture loguru WARNING-level messages (caplog only sees stdlib logging)."""
@@ -282,6 +289,17 @@ def test_lookup_descriptor_fn_aligns_heterogeneous_spellings():
     out = fn([normalize_composition("Fe2.0O3.0"), "missing"])
     assert list(out.index) == [normalize_composition("Fe2O3")]
     assert out.iloc[0]["d0"] == 1.0
+
+
+def test_lookup_descriptor_fn_dedupes_colliding_labels(loguru_warnings):
+    # Duplicate raw labels / spellings that canonicalize to the same key must not crash the
+    # length-matched re-index; they collapse keep-first with a warning (Codex P1 regression).
+    features = pd.DataFrame({"d0": [1.0, 9.0, 2.0]}, index=pd.Index(["Fe2O3", "Fe2.0O3.0", "NaCl"]))
+    fn = lookup_descriptor_fn(features)
+    out = fn([normalize_composition("Fe2O3"), normalize_composition("NaCl")])
+    assert list(out.index) == [normalize_composition("Fe2O3"), normalize_composition("NaCl")]
+    assert out.loc[normalize_composition("Fe2O3"), "d0"] == 1.0  # first occurrence kept
+    assert any("collapsed to a duplicate" in m for m in loguru_warnings)
 
 
 # --- resolve_splits ---------------------------------------------------------

--- a/src/foundation_model/data/datamodule.py
+++ b/src/foundation_model/data/datamodule.py
@@ -22,6 +22,7 @@ from .composition_sources import (
     CompositionNormalizer,
     DescriptorCache,
     DescriptorFn,
+    PrecomputedDescriptorSource,
     build_composition_universe,
     canonical_key,
     load_task_frame,
@@ -232,6 +233,10 @@ class CompoundDataModule(L.LightningDataModule):
             self.default_data_files = tuple(str(p) for p in default_data_files)
         self.composition_column = composition_column
         self.composition_normalizer = composition_normalizer
+        # The DataModule owns the normalization policy; keep a recognized descriptor source in
+        # sync so the opt-out (composition_normalizer=None) only has to be set in one place.
+        if isinstance(descriptor_fn, PrecomputedDescriptorSource):
+            descriptor_fn._composition_normalizer = composition_normalizer
         self.random_seed = random_seed
         self.val_split = val_split
         self.test_split = test_split
@@ -297,7 +302,10 @@ class CompoundDataModule(L.LightningDataModule):
         frame = frame.copy()
         if composition_column in frame.columns:
             frame = frame.set_index(composition_column)
-        frame.index = pd.Index([self._canon(c) for c in frame.index])
+        if self.composition_normalizer is None:
+            frame.index = frame.index.astype(str)  # vectorized fast path when normalization is off
+        else:
+            frame.index = pd.Index([self._canon(c) for c in frame.index])
         duplicated = frame.index.duplicated(keep="first")
         if duplicated.any():
             logger.warning(

--- a/src/foundation_model/data/datamodule.py
+++ b/src/foundation_model/data/datamodule.py
@@ -19,10 +19,13 @@ from foundation_model.models.model_config import (
 )
 
 from .composition_sources import (
+    CompositionNormalizer,
     DescriptorCache,
     DescriptorFn,
     build_composition_universe,
+    canonical_key,
     load_task_frame,
+    normalize_composition,
     resolve_splits,
 )
 from .dataset import CompoundDataset
@@ -157,6 +160,16 @@ class CompoundDataModule(L.LightningDataModule):
     composition_column : str, optional
         Global default composition column name; overridable per task via
         ``cfg.composition_column``. Defaults to ``"composition"``.
+    composition_normalizer : Callable[[object], str | None] | None, optional
+        Canonicalizes every composition key the DataModule ingests (task frames, ``data_files``,
+        explicit ``predict_idx`` sequences) so heterogeneously-spelled sources — a pymatgen
+        ``Composition``/dict vs a formula string, ``Fe3O2`` vs ``Fe3.0O2.0`` — join by exact
+        match. Keys that don't parse fall back to their raw string (so synthetic/non-formula IDs
+        are untouched). Defaults to :func:`~foundation_model.data.composition_sources.normalize_composition`;
+        pass ``None`` to disable. **The descriptor side must use the same rule**: the bundled
+        :class:`~foundation_model.data.composition_sources.PrecomputedDescriptorSource` and
+        :func:`~foundation_model.data.composition_sources.lookup_descriptor_fn` normalize by
+        default; a custom ``descriptor_fn`` must accept these canonical keys.
     random_seed : int | None, optional
         Base seed for all stochastic operations (split, masking, swap). Defaults to 42.
     val_split, test_split : float, optional
@@ -182,6 +195,7 @@ class CompoundDataModule(L.LightningDataModule):
         task_frames: Mapping[str, pd.DataFrame] | None = None,
         default_data_files: str | Sequence[str] | None = None,
         composition_column: str = "composition",
+        composition_normalizer: CompositionNormalizer | None = normalize_composition,
         random_seed: int | None = 42,
         val_split: float = 0.1,
         test_split: float = 0.1,
@@ -217,6 +231,7 @@ class CompoundDataModule(L.LightningDataModule):
         else:
             self.default_data_files = tuple(str(p) for p in default_data_files)
         self.composition_column = composition_column
+        self.composition_normalizer = composition_normalizer
         self.random_seed = random_seed
         self.val_split = val_split
         self.test_split = test_split
@@ -250,7 +265,9 @@ class CompoundDataModule(L.LightningDataModule):
         self._train_sampler: DistributedSampler | None = None
 
         self.save_hyperparameters(
-            ignore=["task_configs", "descriptor_fn", "task_frames"],
+            # Callables / large frames must not be pickled into checkpoints (a function reference
+            # such as composition_normalizer also trips torch's weights_only=True loader).
+            ignore=["task_configs", "descriptor_fn", "task_frames", "composition_normalizer"],
         )
 
         logger.info(f"DataModule initialized with {len(self.task_configs)} task configurations.")
@@ -271,12 +288,16 @@ class CompoundDataModule(L.LightningDataModule):
     def _composition_column_for(self, cfg: TaskConfig) -> str:
         return cfg.composition_column or self.composition_column
 
+    def _canon(self, value: object) -> str:
+        """Canonical composition key (normalizer with raw-string fallback)."""
+        return canonical_key(value, self.composition_normalizer)
+
     def _normalize_frame(self, frame: pd.DataFrame, composition_column: str, *, task_name: str = "") -> pd.DataFrame:
-        """Return a copy indexed by string composition keys, deduped keep-first."""
+        """Return a copy indexed by canonical composition keys, deduped keep-first."""
         frame = frame.copy()
         if composition_column in frame.columns:
             frame = frame.set_index(composition_column)
-        frame.index = frame.index.astype(str)
+        frame.index = pd.Index([self._canon(c) for c in frame.index])
         duplicated = frame.index.duplicated(keep="first")
         if duplicated.any():
             logger.warning(
@@ -312,10 +333,17 @@ class CompoundDataModule(L.LightningDataModule):
                 frame = self._normalize_frame(self._input_task_frames[cfg.name], comp_col, task_name=cfg.name)
                 logger.info(f"Task '{cfg.name}': using provided in-memory frame ({len(frame)} rows).")
             elif cfg.data_files:
-                frame = load_task_frame(cfg.data_files, comp_col, task_name=cfg.name)
+                frame = load_task_frame(
+                    cfg.data_files, comp_col, task_name=cfg.name, composition_normalizer=self.composition_normalizer
+                )
                 logger.info(f"Task '{cfg.name}': loaded {len(frame)} rows from {len(cfg.data_files)} file(s).")
             elif self.default_data_files:
-                frame = load_task_frame(self.default_data_files, comp_col, task_name=cfg.name)
+                frame = load_task_frame(
+                    self.default_data_files,
+                    comp_col,
+                    task_name=cfg.name,
+                    composition_normalizer=self.composition_normalizer,
+                )
                 logger.info(
                     f"Task '{cfg.name}': loaded {len(frame)} rows from shared default_data_files "
                     f"({len(self.default_data_files)} file(s))."
@@ -333,7 +361,7 @@ class CompoundDataModule(L.LightningDataModule):
         for cfg in self._supervised_tasks():
             pid = cfg.predict_idx
             if isinstance(pid, (list, tuple)):
-                extra.extend(str(c) for c in pid)
+                extra.extend(self._canon(c) for c in pid)
         universe = build_composition_universe(self._task_frames, extra_compositions=extra)
         if not universe:
             raise ValueError(
@@ -448,7 +476,7 @@ class CompoundDataModule(L.LightningDataModule):
                 else:  # "test"
                     subset = list(self.test_idx)
             else:  # explicit sequence of composition keys
-                requested = [str(c) for c in pid]
+                requested = [self._canon(c) for c in pid]
                 subset = [c for c in requested if c in master_set]
                 missing = [c for c in requested if c not in master_set]
                 if missing:

--- a/src/foundation_model/data/datamodule.py
+++ b/src/foundation_model/data/datamodule.py
@@ -378,7 +378,14 @@ class CompoundDataModule(L.LightningDataModule):
                 f"(e.g. {', '.join(dropped[:5])})."
             )
         if self.descriptors.empty:
-            raise ValueError("descriptor_fn produced no valid descriptors for any composition.")
+            hint = ""
+            if self.composition_normalizer is None:
+                hint = (
+                    " The DataModule has composition_normalizer=None but bundled descriptor sources "
+                    "(PrecomputedDescriptorSource / lookup_descriptor_fn) normalize by default — pass "
+                    "composition_normalizer=None to the descriptor source too so both sides use the same keys."
+                )
+            raise ValueError(f"descriptor_fn produced no valid descriptors for any composition.{hint}")
         self.master_index = [str(c) for c in self.descriptors.index]
         logger.info(f"Master composition index size (with valid descriptors): {len(self.master_index)}")
 

--- a/src/foundation_model/data/datamodule_test.py
+++ b/src/foundation_model/data/datamodule_test.py
@@ -181,6 +181,40 @@ def test_default_data_files_shared_across_tasks(tmp_path, descriptors_df):
 # --- splitting --------------------------------------------------------------
 
 
+def test_datamodule_normalizes_heterogeneous_compositions():
+    """Task frames and descriptors that spell the same compositions differently join by default."""
+    from foundation_model.data.composition_sources import lookup_descriptor_fn, normalize_composition
+
+    descs = pd.DataFrame({"f1": [0.1, 0.2], "f2": [0.3, 0.4]}, index=pd.Index(["Fe2O3", "H2O"]))
+    frames = {
+        "task1": pd.DataFrame({"task1": [1.0, 2.0]}, index=pd.Index(["Fe2O3", "H2O"])),  # plain
+        # Same two compositions, spelled with float amounts / reversed order.
+        "task_cls": pd.DataFrame({"task_cls": [0, 1]}, index=pd.Index(["O3.0Fe2.0", "H2.0O1.0"])),
+    }
+    configs = [
+        RegressionTaskConfig(name="task1", data_column="task1", dims=[2, 8, 1]),
+        ClassificationTaskConfig(name="task_cls", data_column="task_cls", num_classes=2, dims=[2, 8, 2]),
+    ]
+    dm = CompoundDataModule(
+        task_configs=configs, descriptor_fn=lookup_descriptor_fn(descs), task_frames=frames, test_all=True
+    )
+    dm.setup(stage="test")
+    # Both spellings collapse to the same two canonical keys (universe stays 2, nothing dropped).
+    assert set(dm.master_index) == {normalize_composition("Fe2O3"), normalize_composition("H2O")}
+
+
+def test_datamodule_disable_normalizer_keeps_raw_keys(descriptors_df, reg_cls_configs):
+    """composition_normalizer=None preserves raw string keys (synthetic 's0' fixtures unchanged)."""
+    dm = CompoundDataModule(
+        task_configs=reg_cls_configs,
+        descriptor_fn=make_descriptor_fn(descriptors_df),
+        task_frames=_reg_cls_frames(),
+        composition_normalizer=None,
+    )
+    dm.setup(stage="fit")
+    assert set(dm.master_index) == set(COMPOSITIONS)
+
+
 def test_split_column_resolution(descriptors_df, reg_cls_configs):
     split = ["train"] * 10 + ["val"] * 5 + ["test"] * 5
     dm = build_dm(descriptors_df, task_frames=_reg_cls_frames(split=split), configs=reg_cls_configs)

--- a/src/foundation_model/data/datamodule_test.py
+++ b/src/foundation_model/data/datamodule_test.py
@@ -215,6 +215,15 @@ def test_datamodule_disable_normalizer_keeps_raw_keys(descriptors_df, reg_cls_co
     assert set(dm.master_index) == set(COMPOSITIONS)
 
 
+def test_datamodule_syncs_normalizer_into_precomputed_source(reg_cls_configs):
+    """The DataModule's opt-out propagates into a PrecomputedDescriptorSource (single source of truth)."""
+    from foundation_model.data.composition_sources import PrecomputedDescriptorSource
+
+    source = PrecomputedDescriptorSource("unused.parquet")  # defaults to normalization ON
+    CompoundDataModule(task_configs=reg_cls_configs, descriptor_fn=source, composition_normalizer=None)
+    assert source._composition_normalizer is None
+
+
 def test_split_column_resolution(descriptors_df, reg_cls_configs):
     split = ["train"] * 10 + ["val"] * 5 + ["test"] * 5
     dm = build_dm(descriptors_df, task_frames=_reg_cls_frames(split=split), configs=reg_cls_configs)

--- a/src/foundation_model/scripts/continual_rehearsal_demo.py
+++ b/src/foundation_model/scripts/continual_rehearsal_demo.py
@@ -55,6 +55,7 @@ from lightning import Trainer, seed_everything
 from loguru import logger
 from sklearn.metrics import accuracy_score, f1_score, mean_absolute_error, r2_score  # type: ignore[import-untyped]
 
+from foundation_model.data.composition_sources import normalize_composition
 from foundation_model.data.datamodule import CompoundDataModule
 from foundation_model.models.flexible_multi_task_model import FlexibleMultiTaskModel
 from foundation_model.models.model_config import (
@@ -154,20 +155,12 @@ def _as_float_array(cell: Any) -> np.ndarray:
 
 
 def _composition_key(raw: Any) -> str | None:
-    """Canonical reduced-formula key for a composition dict (qc) or formula string (NEMAD)."""
-    from pymatgen.core.composition import Composition  # local import; pymatgen is heavy
+    """Canonical, float-amount composition key shared with the data stack.
 
-    try:
-        if isinstance(raw, dict):
-            cleaned = {k: v for k, v in raw.items() if v is not None and float(v) > 0}
-            if not cleaned:
-                return None
-            comp = Composition(cleaned)
-        else:
-            comp = Composition(str(raw))
-        return comp.reduced_formula
-    except Exception:
-        return None
+    Uses the system-wide :func:`normalize_composition` (non-reduced, float amounts) so the demo's
+    in-memory frames key exactly the way ``CompoundDataModule`` does — no demo-local convention.
+    """
+    return normalize_composition(raw)
 
 
 def _init_kernels(t_values: np.ndarray, n_kernel: int) -> tuple[list[float], list[float]]:

--- a/src/foundation_model/scripts/dynamic_task_suite.py
+++ b/src/foundation_model/scripts/dynamic_task_suite.py
@@ -28,6 +28,7 @@ from lightning.pytorch.callbacks import EarlyStopping, ModelCheckpoint
 from lightning.pytorch.loggers import CSVLogger, TensorBoardLogger
 from loguru import logger as fm_logger
 
+from foundation_model.data.composition_sources import lookup_descriptor_fn
 from foundation_model.data.datamodule import CompoundDataModule
 from foundation_model.models.flexible_multi_task_model import FlexibleMultiTaskModel
 from foundation_model.models.model_config import (
@@ -472,18 +473,13 @@ class DynamicTaskSuiteRunner:
 
     @staticmethod
     def _make_descriptor_fn(features: pd.DataFrame):
-        """Build a descriptor_fn that looks up precomputed descriptor rows by composition.
+        """Look up precomputed descriptor rows by canonical composition key.
 
-        Avoids copying the (potentially large) descriptor matrix: only an index label map is
-        built. The DataModule's descriptor cache stringifies the returned index.
+        Delegates to :func:`lookup_descriptor_fn`, which normalizes the descriptor index the same
+        way the DataModule normalizes task frames, so the two sides join even when the descriptor
+        file and the task data spell compositions differently.
         """
-        label_by_str = {str(idx): idx for idx in features.index}
-
-        def descriptor_fn(compositions):
-            labels = [label_by_str[c] for c in compositions if c in label_by_str]
-            return features.loc[labels]
-
-        return descriptor_fn
+        return lookup_descriptor_fn(features)
 
     def _task_masking_ratio_for(self, name: str) -> float | None:
         """Resolve the per-task keep ratio from the (float | dict | None) suite config."""

--- a/src/foundation_model/scripts/multi_task_progressive_clf.py
+++ b/src/foundation_model/scripts/multi_task_progressive_clf.py
@@ -44,6 +44,7 @@ from lightning.pytorch.loggers import CSVLogger, TensorBoardLogger
 from loguru import logger as fm_logger
 from sklearn.metrics import accuracy_score, classification_report, confusion_matrix
 
+from foundation_model.data.composition_sources import lookup_descriptor_fn
 from foundation_model.data.datamodule import CompoundDataModule
 from foundation_model.models.flexible_multi_task_model import FlexibleMultiTaskModel
 from foundation_model.models.model_config import (
@@ -332,18 +333,13 @@ class ProgressiveClfRunner:
 
     @staticmethod
     def _make_descriptor_fn(features: pd.DataFrame):
-        """Build a descriptor_fn that looks up precomputed descriptor rows by composition.
+        """Look up precomputed descriptor rows by canonical composition key.
 
-        Avoids copying the (potentially large) descriptor matrix: only an index label map is
-        built. The DataModule's descriptor cache stringifies the returned index.
+        Delegates to :func:`lookup_descriptor_fn`, which normalizes the descriptor index the same
+        way the DataModule normalizes task frames, so the two sides join even when the descriptor
+        file and the task data spell compositions differently.
         """
-        label_by_str = {str(idx): idx for idx in features.index}
-
-        def descriptor_fn(compositions):
-            labels = [label_by_str[c] for c in compositions if c in label_by_str]
-            return features.loc[labels]
-
-        return descriptor_fn
+        return lookup_descriptor_fn(features)
 
     def _build_pretrain_datamodule(self, task_cfgs: list) -> CompoundDataModule:
         columns = list(self._get_task_columns(task_cfgs))


### PR DESCRIPTION
## Why

Different data files spell the same composition differently — a pymatgen `Composition`/dict (qc DOS/material set) versus a formula string (NEMAD superconductor/magnetic, phonix-db), and `"Fe3O2"` vs `"Fe3.0O2.0"`. The composition-keyed `CompoundDataModule` joins task data and descriptors by **exact string match**, so heterogeneous sources silently failed to align (missing rows masked out, no error). This makes composition canonicalization a system-level concern with one shared rule.

## What

- **`normalize_composition()`** — canonical key: **non-reduced** (absolute stoichiometry preserved, because some descriptors aggregate by sum, not mean), **float amounts**, **element-sorted**. So `Fe3O2`, `Fe3.0O2.0`, `O3Fe2` all collapse to `Fe2.000000 O3.000000`-style keys; `Fe2O3` ≠ `Fe4O6`.
- **`canonical_key(value, normalizer)`** — applies the normalizer with a **raw-string fallback**. This is what makes default-ON safe: real formulas canonicalize, while non-formula keys (Materials Project IDs `mp-111`, polymer identifiers) and unparseable entries pass through unchanged — and because the task and descriptor sides use the *same* rule, even those still align.
- **`CompoundDataModule(composition_normalizer=normalize_composition)`** (default ON; pass `None` to disable) — normalizes in-memory frames, `data_files`, and explicit `predict_idx`. Excluded from `save_hyperparameters` so the function reference isn't pickled into checkpoints (would trip torch's `weights_only=True` loader).
- **Descriptor side kept consistent**: `PrecomputedDescriptorSource` normalizes its index + queries by default; new **`lookup_descriptor_fn()`** does the same for an in-memory descriptor frame. `dynamic_task_suite` and `multi_task_progressive_clf` now use it.
- **Demo** `_composition_key` delegates to `normalize_composition` (was `reduced_formula`, which dropped the amounts).

## Validation

- ruff clean; data-layer mypy clean.
- Unit tests: data **95 passed**, model **28 passed**, prediction-writer green. New tests cover heterogeneous-spelling alignment across task+descriptor sides and the `normalizer=None` opt-out.
- End-to-end smokes all run: continual demo (cross-dataset master index aligns), **progressive_clf** (MP-ID join preserved), **dynamic_task_suite** (polymer-id join preserved).

## Note on data files

The bundled qc / NEMAD / phonix parquet files were also normalized on disk locally (drop redundant `formula` column, `composition` → canonical key). `data/` is gitignored, so this PR is code-only; runtime normalization makes the on-disk conversion optional but keeps the data clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)