### PR TITLE
feat(model): differentiable composition-space inverse design (KMD.transform_torch + optimize_composition)

### DIFF
--- a/src/foundation_model/models/flexible_multi_task_model.py
+++ b/src/foundation_model/models/flexible_multi_task_model.py
@@ -2260,23 +2260,32 @@ class FlexibleMultiTaskModel(L.LightningModule):
         # --- Set up the optimisation variable: logits over n_components -------------------------
         was_training = self.training
         self.eval()
-        device = next(self.parameters()).device
-        kmd_kernel = kmd_kernel.to(device=device, dtype=torch.float32)
+        params = next(self.parameters())
+        device, dtype = params.device, params.dtype  # match the model's precision (fp32/fp16/bf16/fp64)
+        kmd_kernel = kmd_kernel.to(device=device, dtype=dtype)
 
         if initial_weights is None:
             if n_starts < 1:
                 raise ValueError("n_starts must be >= 1 when initial_weights is None.")
-            torch.manual_seed(torch.initial_seed())  # respect outer seeding
-            logits = torch.randn(n_starts, n_components, device=device) * 0.5
+            # Use the caller's existing global RNG state — don't reseed here (would defeat the
+            # intended diversity across repeated calls and would leak state to surrounding code).
+            logits = torch.randn(n_starts, n_components, device=device, dtype=dtype) * 0.5
         else:
             if initial_weights.ndim != 2 or initial_weights.shape[1] != n_components:
                 raise ValueError(
                     f"initial_weights must have shape (B, {n_components}); got {tuple(initial_weights.shape)}."
                 )
-            w0 = initial_weights.to(device=device, dtype=torch.float32).clamp(min=1e-9)
-            # softmax(log w0) recovers w0 (up to the simplex normalisation), so this lets the user
-            # seed from real compositions and have step-0 logits reproduce them.
-            logits = torch.log(w0).detach().clone()
+            w0 = initial_weights.to(device=device, dtype=dtype)
+            if (w0 < 0).any():
+                raise ValueError("initial_weights must be non-negative (no silent clamping).")
+            row_sums = w0.sum(dim=-1)
+            if (row_sums <= 0).any():
+                raise ValueError("initial_weights rows must have a positive sum.")
+            # Normalise to the simplex (so callers may pass un-normalised positive weights), then
+            # convert to logits via log. A tiny floor only avoids log(0) for legitimate zero
+            # entries (e.g. sparse element-presence seeds).
+            w0 = w0 / row_sums.unsqueeze(-1)
+            logits = torch.log(w0.clamp(min=1e-12)).detach().clone()
         logits = logits.requires_grad_(True)
         optimizer = optim.Adam([logits], lr=lr)
 
@@ -2284,7 +2293,7 @@ class FlexibleMultiTaskModel(L.LightningModule):
         target_tensor_map: dict[str, torch.Tensor] = {}
         if target_tasks is not None:
             target_tensor_map = {
-                name: torch.as_tensor(val, device=device, dtype=torch.float32) for name, val in target_tasks.items()
+                name: torch.as_tensor(val, device=device, dtype=dtype) for name, val in target_tasks.items()
             }
         class_index_map: dict[str, torch.Tensor] = {}
         if class_target_map is not None:
@@ -2312,8 +2321,10 @@ class FlexibleMultiTaskModel(L.LightningModule):
                 terms.append(class_target_weight * (-combined.mean()))
             return preds, terms
 
+        n_reg_tracked = len(tasks_for_optimization)
+
         def _stack(values: list[torch.Tensor], B: int) -> torch.Tensor:
-            return torch.stack(values, dim=-1) if values else torch.zeros((B, 0), device=device)
+            return torch.stack(values, dim=-1) if values else torch.zeros((B, 0), device=device, dtype=dtype)
 
         # --- Record initial scores --------------------------------------------------------------
         with torch.no_grad():
@@ -2355,7 +2366,8 @@ class FlexibleMultiTaskModel(L.LightningModule):
             optimized_descriptor=x_final.detach(),
             optimized_target=final_target,
             initial_score=initial_score,
+            # Preserve the (steps, B, T) shape contract even when steps == 0.
             trajectory=torch.stack(trajectory, dim=0)
             if trajectory
-            else torch.empty((0, logits.shape[0], 0), device=device),
+            else torch.empty((0, logits.shape[0], n_reg_tracked), device=device, dtype=dtype),
         )

--- a/src/foundation_model/models/flexible_multi_task_model.py
+++ b/src/foundation_model/models/flexible_multi_task_model.py
@@ -61,6 +61,13 @@ OptimizationResult = namedtuple(
     "OptimizationResult", ["optimized_input", "optimized_target", "initial_score", "trajectory"]
 )
 
+# Composition-space optimization (gradient descent over element weights w ∈ simplex). The optimised
+# w *is* the recipe (no AE-decode round-trip), so it is reported alongside the descriptor x = w @ K.
+CompositionOptimizationResult = namedtuple(
+    "CompositionOptimizationResult",
+    ["optimized_weights", "optimized_descriptor", "optimized_target", "initial_score", "trajectory"],
+)
+
 
 class FlexibleMultiTaskModel(L.LightningModule):
     """
@@ -2136,4 +2143,219 @@ class FlexibleMultiTaskModel(L.LightningModule):
             optimized_target=opt_target_tensor,
             initial_score=initial_score_tensor,
             trajectory=traj_tensor,
+        )
+
+    def optimize_composition(
+        self,
+        kmd_kernel: torch.Tensor,
+        *,
+        initial_weights: torch.Tensor | None = None,
+        n_starts: int = 16,
+        task_targets: Mapping[str, torch.Tensor | float] | None = None,
+        class_targets: Mapping[str, int | Sequence[int]] | None = None,
+        class_target_weight: float = 1.0,
+        sparsity_weight: float = 0.0,
+        steps: int = 300,
+        lr: float = 0.05,
+    ) -> CompositionOptimizationResult:
+        """Gradient-based inverse design in **composition space**.
+
+        Optimises a simplex-constrained element-weight vector ``w`` directly through the
+        differentiable KMD transform ``x = w @ K`` and the supervised heads:
+
+        ``logits → w = softmax(logits) → x = w @ kmd_kernel → encoder → tanh → heads → loss``
+
+        Because the optimisation variable *is* the recipe, there is **no AE-decode round-trip**:
+        the optimised ``w`` is the composition you would report. Compared to :meth:`optimize_latent`
+        in ``"latent"`` mode, this method (a) eliminates the round-trip fidelity drop, (b) keeps the
+        solution on the legitimate composition simplex by construction, and (c) makes ``w`` itself
+        the output.
+
+        Parameters
+        ----------
+        kmd_kernel : torch.Tensor
+            The precomputed KMD kernel matrix, shape ``(n_components, x_dim)`` — typically obtained
+            from :meth:`foundation_model.utils.kmd_plus.KMD.kernel_torch`. ``x_dim`` must match the
+            encoder's input dim.
+        initial_weights : torch.Tensor | None
+            Seed weights, shape ``(B, n_components)``. If ``None``, ``n_starts`` random starts are
+            sampled from a Gaussian over the logits (mildly diverse simplex starting points).
+        n_starts : int
+            Batch size when ``initial_weights is None``. Default 16.
+        task_targets, class_targets, class_target_weight :
+            Same semantics as :meth:`optimize_latent`. Regression targets are matched by MSE;
+            classification objectives add ``-log P(target classes)`` (scaled by
+            ``class_target_weight``).
+        sparsity_weight : float, optional
+            Adds a negative-entropy term ``λ · H(w)`` to the loss, pushing ``w`` toward few-element
+            mixtures. Default 0 (no sparsity pressure).
+        steps : int
+            Adam optimisation steps. Default 300.
+        lr : float
+            Adam learning rate over the logits. Default 0.05.
+
+        Returns
+        -------
+        CompositionOptimizationResult
+            with fields:
+            - ``optimized_weights``    : (B, n_components), each row a simplex point — the recipe.
+            - ``optimized_descriptor`` : (B, x_dim), equals ``optimized_weights @ kmd_kernel``.
+            - ``optimized_target``     : (B, T), final per-regression-task predicted values.
+            - ``initial_score``        : (B, T), same shape, predicted at step 0.
+            - ``trajectory``           : (steps, B, T), per-task values across optimisation.
+        """
+        # --- Validate the kernel ----------------------------------------------------------------
+        if not isinstance(kmd_kernel, torch.Tensor) or kmd_kernel.ndim != 2:
+            raise ValueError("kmd_kernel must be a 2D torch.Tensor of shape (n_components, x_dim).")
+        n_components, x_dim = kmd_kernel.shape
+        expected_dim = getattr(self.encoder, "input_dim", None)
+        if expected_dim is not None and x_dim != expected_dim:
+            raise ValueError(f"kmd_kernel.shape[1]={x_dim} does not match encoder.input_dim={expected_dim}.")
+
+        # --- Validate regression / classification objectives (mirrors optimize_latent) ----------
+        target_tasks: dict[str, torch.Tensor | float] | None = None
+        if task_targets is not None:
+            if not isinstance(task_targets, Mapping) or len(task_targets) == 0:
+                raise ValueError("task_targets must be a non-empty mapping of task_name -> target_value")
+            target_tasks = dict(task_targets)
+            for name in target_tasks:
+                if name not in self.task_heads:
+                    raise ValueError(
+                        f"Task '{name}' not found in model. Available tasks: {list(self.task_heads.keys())}"
+                    )
+                if self.task_configs_map[name].type != TaskType.REGRESSION:
+                    raise ValueError(f"Task '{name}' must be a regression task for optimization.")
+
+        class_target_map: dict[str, list[int]] | None = None
+        if class_targets is not None:
+            if not isinstance(class_targets, Mapping) or len(class_targets) == 0:
+                raise ValueError("class_targets must be a non-empty mapping of task_name -> class index/indices")
+            if class_target_weight <= 0:
+                raise ValueError(f"class_target_weight must be > 0, got {class_target_weight}")
+            class_target_map = {}
+            for name, classes in class_targets.items():
+                if name not in self.task_heads:
+                    raise ValueError(
+                        f"Task '{name}' not found in model. Available tasks: {list(self.task_heads.keys())}"
+                    )
+                cls_cfg = self.task_configs_map[name]
+                if cls_cfg.type != TaskType.CLASSIFICATION:
+                    raise ValueError(f"class_targets task '{name}' must be a classification task.")
+                idxs = [int(classes)] if isinstance(classes, int) else [int(c) for c in classes]
+                if not idxs:
+                    raise ValueError(f"class_targets['{name}'] must specify at least one class index.")
+                num_classes = getattr(cls_cfg, "num_classes", None)
+                if num_classes is not None and any(not 0 <= i < num_classes for i in idxs):
+                    raise ValueError(
+                        f"class_targets['{name}'] indices {idxs} out of range for a "
+                        f"{num_classes}-class head; valid indices are [0, {num_classes})."
+                    )
+                class_target_map[name] = idxs
+
+        if target_tasks is None and class_target_map is None:
+            raise ValueError("Provide at least one of task_targets / class_targets.")
+        if sparsity_weight < 0:
+            raise ValueError(f"sparsity_weight must be >= 0, got {sparsity_weight}")
+
+        # --- Set up the optimisation variable: logits over n_components -------------------------
+        was_training = self.training
+        self.eval()
+        device = next(self.parameters()).device
+        kmd_kernel = kmd_kernel.to(device=device, dtype=torch.float32)
+
+        if initial_weights is None:
+            if n_starts < 1:
+                raise ValueError("n_starts must be >= 1 when initial_weights is None.")
+            torch.manual_seed(torch.initial_seed())  # respect outer seeding
+            logits = torch.randn(n_starts, n_components, device=device) * 0.5
+        else:
+            if initial_weights.ndim != 2 or initial_weights.shape[1] != n_components:
+                raise ValueError(
+                    f"initial_weights must have shape (B, {n_components}); got {tuple(initial_weights.shape)}."
+                )
+            w0 = initial_weights.to(device=device, dtype=torch.float32).clamp(min=1e-9)
+            # softmax(log w0) recovers w0 (up to the simplex normalisation), so this lets the user
+            # seed from real compositions and have step-0 logits reproduce them.
+            logits = torch.log(w0).detach().clone()
+        logits = logits.requires_grad_(True)
+        optimizer = optim.Adam([logits], lr=lr)
+
+        tasks_for_optimization: list[str] = list(target_tasks.keys()) if target_tasks is not None else []
+        target_tensor_map: dict[str, torch.Tensor] = {}
+        if target_tasks is not None:
+            target_tensor_map = {
+                name: torch.as_tensor(val, device=device, dtype=torch.float32) for name, val in target_tasks.items()
+            }
+        class_index_map: dict[str, torch.Tensor] = {}
+        if class_target_map is not None:
+            class_index_map = {
+                name: torch.as_tensor(idxs, device=device, dtype=torch.long) for name, idxs in class_target_map.items()
+            }
+
+        def _heads_forward(h_task: torch.Tensor) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+            """Run regression heads, return (per-task predictions, loss terms)."""
+            preds, terms = [], []
+            for name in tasks_for_optimization:
+                pred = self.task_heads[name](h_task)
+                reduced = pred if pred.ndim == 1 else pred.mean(dim=tuple(range(1, pred.ndim)))
+                preds.append(reduced)
+                tgt = target_tensor_map[name]
+                if tgt.ndim == 0:
+                    tgt = tgt.reshape([1] * pred.ndim)
+                if tgt.shape != pred.shape:
+                    tgt = tgt.expand(pred.shape)
+                terms.append(F.mse_loss(pred, tgt))
+            for cname, cidx in class_index_map.items():
+                cls_logits = self.task_heads[cname](h_task)
+                log_probs = F.log_softmax(cls_logits, dim=-1)
+                combined = torch.logsumexp(log_probs.index_select(-1, cidx), dim=-1)
+                terms.append(class_target_weight * (-combined.mean()))
+            return preds, terms
+
+        def _stack(values: list[torch.Tensor], B: int) -> torch.Tensor:
+            return torch.stack(values, dim=-1) if values else torch.zeros((B, 0), device=device)
+
+        # --- Record initial scores --------------------------------------------------------------
+        with torch.no_grad():
+            w0 = torch.softmax(logits, dim=-1)
+            h0 = torch.tanh(self.encoder(w0 @ kmd_kernel))
+            initial_preds, _ = _heads_forward(h0)
+            initial_score = _stack([p.detach() for p in initial_preds], logits.shape[0])
+
+        # --- Optimisation loop ------------------------------------------------------------------
+        trajectory: list[torch.Tensor] = []
+        for _ in range(steps):
+            optimizer.zero_grad()
+            w = torch.softmax(logits, dim=-1)
+            x = w @ kmd_kernel
+            h_task = torch.tanh(self.encoder(x))
+            preds, terms = _heads_forward(h_task)
+            if sparsity_weight > 0:
+                # Negative entropy of w (minimise entropy → push w toward few-element mixtures).
+                entropy = -(w * w.clamp(min=1e-12).log()).sum(dim=-1).mean()
+                terms.append(sparsity_weight * entropy)
+            loss = torch.stack(terms).mean()
+            loss.backward()
+            optimizer.step()
+            trajectory.append(_stack([p.detach() for p in preds], logits.shape[0]))
+
+        # --- Final state ------------------------------------------------------------------------
+        with torch.no_grad():
+            w_final = torch.softmax(logits, dim=-1)
+            x_final = w_final @ kmd_kernel
+            h_final = torch.tanh(self.encoder(x_final))
+            final_preds, _ = _heads_forward(h_final)
+            final_target = _stack([p.detach() for p in final_preds], logits.shape[0])
+
+        if was_training:
+            self.train()
+
+        return CompositionOptimizationResult(
+            optimized_weights=w_final.detach(),
+            optimized_descriptor=x_final.detach(),
+            optimized_target=final_target,
+            initial_score=initial_score,
+            trajectory=torch.stack(trajectory, dim=0)
+            if trajectory
+            else torch.empty((0, logits.shape[0], 0), device=device),
         )

--- a/src/foundation_model/models/flexible_multi_task_model.py
+++ b/src/foundation_model/models/flexible_multi_task_model.py
@@ -2257,117 +2257,136 @@ class FlexibleMultiTaskModel(L.LightningModule):
         if sparsity_weight < 0:
             raise ValueError(f"sparsity_weight must be >= 0, got {sparsity_weight}")
 
-        # --- Set up the optimisation variable: logits over n_components -------------------------
-        was_training = self.training
-        self.eval()
-        params = next(self.parameters())
-        device, dtype = params.device, params.dtype  # match the model's precision (fp32/fp16/bf16/fp64)
-        kmd_kernel = kmd_kernel.to(device=device, dtype=dtype)
-
+        # --- Validate the seed (BEFORE touching model state, so a bad input doesn't leave the
+        #     model in eval() / with params switched off). ---------------------------------------
         if initial_weights is None:
             if n_starts < 1:
                 raise ValueError("n_starts must be >= 1 when initial_weights is None.")
-            # Use the caller's existing global RNG state — don't reseed here (would defeat the
-            # intended diversity across repeated calls and would leak state to surrounding code).
-            logits = torch.randn(n_starts, n_components, device=device, dtype=dtype) * 0.5
         else:
             if initial_weights.ndim != 2 or initial_weights.shape[1] != n_components:
                 raise ValueError(
                     f"initial_weights must have shape (B, {n_components}); got {tuple(initial_weights.shape)}."
                 )
-            w0 = initial_weights.to(device=device, dtype=dtype)
-            if (w0 < 0).any():
+            if (initial_weights < 0).any():
                 raise ValueError("initial_weights must be non-negative (no silent clamping).")
-            row_sums = w0.sum(dim=-1)
-            if (row_sums <= 0).any():
+            if (initial_weights.sum(dim=-1) <= 0).any():
                 raise ValueError("initial_weights rows must have a positive sum.")
-            # Normalise to the simplex (so callers may pass un-normalised positive weights), then
-            # convert to logits via log. A tiny floor only avoids log(0) for legitimate zero
-            # entries (e.g. sparse element-presence seeds).
-            w0 = w0 / row_sums.unsqueeze(-1)
-            logits = torch.log(w0.clamp(min=1e-12)).detach().clone()
-        logits = logits.requires_grad_(True)
-        optimizer = optim.Adam([logits], lr=lr)
 
-        tasks_for_optimization: list[str] = list(target_tasks.keys()) if target_tasks is not None else []
-        target_tensor_map: dict[str, torch.Tensor] = {}
-        if target_tasks is not None:
-            target_tensor_map = {
-                name: torch.as_tensor(val, device=device, dtype=dtype) for name, val in target_tasks.items()
-            }
-        class_index_map: dict[str, torch.Tensor] = {}
-        if class_target_map is not None:
-            class_index_map = {
-                name: torch.as_tensor(idxs, device=device, dtype=torch.long) for name, idxs in class_target_map.items()
-            }
+        # --- Save / restore model state ------------------------------------------------------------
+        # Wrap the optimisation in try/finally so a later raise (e.g. a head failure) still
+        # restores training mode and parameter requires_grad flags. During the call we also turn
+        # off requires_grad on every parameter — only ``logits`` is being optimised, so
+        # ``loss.backward()`` would otherwise populate stale ``.grad`` on every encoder/head
+        # parameter for no benefit.
+        was_training = self.training
+        saved_req_grad: list[tuple[torch.nn.Parameter, bool]] = [(p, p.requires_grad) for p in self.parameters()]
+        self.eval()
+        for p, _ in saved_req_grad:
+            p.requires_grad_(False)
+        try:
+            ref_param = next(self.parameters())
+            device, dtype = ref_param.device, ref_param.dtype  # match the model's precision
+            kmd_kernel = kmd_kernel.to(device=device, dtype=dtype)
 
-        def _heads_forward(h_task: torch.Tensor) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
-            """Run regression heads, return (per-task predictions, loss terms)."""
-            preds, terms = [], []
-            for name in tasks_for_optimization:
-                pred = self.task_heads[name](h_task)
-                reduced = pred if pred.ndim == 1 else pred.mean(dim=tuple(range(1, pred.ndim)))
-                preds.append(reduced)
-                tgt = target_tensor_map[name]
-                if tgt.ndim == 0:
-                    tgt = tgt.reshape([1] * pred.ndim)
-                if tgt.shape != pred.shape:
-                    tgt = tgt.expand(pred.shape)
-                terms.append(F.mse_loss(pred, tgt))
-            for cname, cidx in class_index_map.items():
-                cls_logits = self.task_heads[cname](h_task)
-                log_probs = F.log_softmax(cls_logits, dim=-1)
-                combined = torch.logsumexp(log_probs.index_select(-1, cidx), dim=-1)
-                terms.append(class_target_weight * (-combined.mean()))
-            return preds, terms
+            # --- Build logits over n_components ---------------------------------------------------
+            if initial_weights is None:
+                # Use the caller's existing global RNG state — don't reseed here (would defeat
+                # the intended diversity across repeated calls and would leak state outward).
+                logits = torch.randn(n_starts, n_components, device=device, dtype=dtype) * 0.5
+            else:
+                w0 = initial_weights.to(device=device, dtype=dtype)
+                # Normalise to the simplex (callers may pass un-normalised positive weights);
+                # log gives logits whose softmax recovers the row. A tiny floor only avoids
+                # log(0) for legitimate zero entries (sparse element-presence seeds).
+                w0 = w0 / w0.sum(dim=-1, keepdim=True)
+                logits = torch.log(w0.clamp(min=1e-12)).detach().clone()
+            logits = logits.requires_grad_(True)
+            optimizer = optim.Adam([logits], lr=lr)
 
-        n_reg_tracked = len(tasks_for_optimization)
+            tasks_for_optimization: list[str] = list(target_tasks.keys()) if target_tasks is not None else []
+            target_tensor_map: dict[str, torch.Tensor] = {}
+            if target_tasks is not None:
+                target_tensor_map = {
+                    name: torch.as_tensor(val, device=device, dtype=dtype) for name, val in target_tasks.items()
+                }
+            class_index_map: dict[str, torch.Tensor] = {}
+            if class_target_map is not None:
+                class_index_map = {
+                    name: torch.as_tensor(idxs, device=device, dtype=torch.long)
+                    for name, idxs in class_target_map.items()
+                }
 
-        def _stack(values: list[torch.Tensor], B: int) -> torch.Tensor:
-            return torch.stack(values, dim=-1) if values else torch.zeros((B, 0), device=device, dtype=dtype)
+            def _heads_forward(h_task: torch.Tensor) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+                """Run regression heads, return (per-task predictions, loss terms)."""
+                preds, terms = [], []
+                for name in tasks_for_optimization:
+                    pred = self.task_heads[name](h_task)
+                    reduced = pred if pred.ndim == 1 else pred.mean(dim=tuple(range(1, pred.ndim)))
+                    preds.append(reduced)
+                    tgt = target_tensor_map[name]
+                    if tgt.ndim == 0:
+                        tgt = tgt.reshape([1] * pred.ndim)
+                    if tgt.shape != pred.shape:
+                        tgt = tgt.expand(pred.shape)
+                    terms.append(F.mse_loss(pred, tgt))
+                for cname, cidx in class_index_map.items():
+                    cls_logits = self.task_heads[cname](h_task)
+                    log_probs = F.log_softmax(cls_logits, dim=-1)
+                    combined = torch.logsumexp(log_probs.index_select(-1, cidx), dim=-1)
+                    terms.append(class_target_weight * (-combined.mean()))
+                return preds, terms
 
-        # --- Record initial scores --------------------------------------------------------------
-        with torch.no_grad():
-            w0 = torch.softmax(logits, dim=-1)
-            h0 = torch.tanh(self.encoder(w0 @ kmd_kernel))
-            initial_preds, _ = _heads_forward(h0)
-            initial_score = _stack([p.detach() for p in initial_preds], logits.shape[0])
+            n_reg_tracked = len(tasks_for_optimization)
 
-        # --- Optimisation loop ------------------------------------------------------------------
-        trajectory: list[torch.Tensor] = []
-        for _ in range(steps):
-            optimizer.zero_grad()
-            w = torch.softmax(logits, dim=-1)
-            x = w @ kmd_kernel
-            h_task = torch.tanh(self.encoder(x))
-            preds, terms = _heads_forward(h_task)
-            if sparsity_weight > 0:
-                # Negative entropy of w (minimise entropy → push w toward few-element mixtures).
-                entropy = -(w * w.clamp(min=1e-12).log()).sum(dim=-1).mean()
-                terms.append(sparsity_weight * entropy)
-            loss = torch.stack(terms).mean()
-            loss.backward()
-            optimizer.step()
-            trajectory.append(_stack([p.detach() for p in preds], logits.shape[0]))
+            def _stack(values: list[torch.Tensor], B: int) -> torch.Tensor:
+                return torch.stack(values, dim=-1) if values else torch.zeros((B, 0), device=device, dtype=dtype)
 
-        # --- Final state ------------------------------------------------------------------------
-        with torch.no_grad():
-            w_final = torch.softmax(logits, dim=-1)
-            x_final = w_final @ kmd_kernel
-            h_final = torch.tanh(self.encoder(x_final))
-            final_preds, _ = _heads_forward(h_final)
-            final_target = _stack([p.detach() for p in final_preds], logits.shape[0])
+            # --- Record initial scores --------------------------------------------------------------
+            with torch.no_grad():
+                w0_tensor = torch.softmax(logits, dim=-1)
+                h0 = torch.tanh(self.encoder(w0_tensor @ kmd_kernel))
+                initial_preds, _ = _heads_forward(h0)
+                initial_score = _stack([p.detach() for p in initial_preds], logits.shape[0])
 
-        if was_training:
-            self.train()
+            # --- Optimisation loop ------------------------------------------------------------------
+            # With every model parameter at ``requires_grad=False``, ``loss.backward()`` populates
+            # gradient only on ``logits`` — no stale grads accumulate on encoder/heads.
+            trajectory: list[torch.Tensor] = []
+            for _ in range(steps):
+                optimizer.zero_grad()
+                w = torch.softmax(logits, dim=-1)
+                x = w @ kmd_kernel
+                h_task = torch.tanh(self.encoder(x))
+                preds, terms = _heads_forward(h_task)
+                if sparsity_weight > 0:
+                    # Negative entropy of w (minimise entropy → push w toward few-element mixtures).
+                    entropy = -(w * w.clamp(min=1e-12).log()).sum(dim=-1).mean()
+                    terms.append(sparsity_weight * entropy)
+                loss = torch.stack(terms).mean()
+                loss.backward()
+                optimizer.step()
+                trajectory.append(_stack([p.detach() for p in preds], logits.shape[0]))
 
-        return CompositionOptimizationResult(
-            optimized_weights=w_final.detach(),
-            optimized_descriptor=x_final.detach(),
-            optimized_target=final_target,
-            initial_score=initial_score,
-            # Preserve the (steps, B, T) shape contract even when steps == 0.
-            trajectory=torch.stack(trajectory, dim=0)
-            if trajectory
-            else torch.empty((0, logits.shape[0], n_reg_tracked), device=device, dtype=dtype),
-        )
+            # --- Final state ------------------------------------------------------------------------
+            with torch.no_grad():
+                w_final = torch.softmax(logits, dim=-1)
+                x_final = w_final @ kmd_kernel
+                h_final = torch.tanh(self.encoder(x_final))
+                final_preds, _ = _heads_forward(h_final)
+                final_target = _stack([p.detach() for p in final_preds], logits.shape[0])
+
+            return CompositionOptimizationResult(
+                optimized_weights=w_final.detach(),
+                optimized_descriptor=x_final.detach(),
+                optimized_target=final_target,
+                initial_score=initial_score,
+                # Preserve the (steps, B, T) shape contract even when steps == 0.
+                trajectory=torch.stack(trajectory, dim=0)
+                if trajectory
+                else torch.empty((0, logits.shape[0], n_reg_tracked), device=device, dtype=dtype),
+            )
+        finally:
+            if was_training:
+                self.train()
+            for p, prev in saved_req_grad:
+                p.requires_grad_(prev)

--- a/src/foundation_model/models/flexible_multi_task_model_test.py
+++ b/src/foundation_model/models/flexible_multi_task_model_test.py
@@ -1080,6 +1080,36 @@ def test_optimize_composition_trajectory_shape_when_zero_steps():
     assert res.trajectory.shape == (0, 3, 1)
 
 
+def test_optimize_composition_does_not_populate_module_grads():
+    """Encoder/head .grad must NOT be touched; only logits is optimised."""
+    torch.manual_seed(0)
+    model = _make_reg_clf_model()
+    kernel = torch.randn(6, INPUT_DIM)
+    # Ensure no pre-existing grads.
+    for p in model.parameters():
+        p.grad = None
+    model.optimize_composition(kernel, task_targets={"prop": 0.5}, n_starts=3, steps=4)
+    # After the call, no encoder/head parameter should have an accumulated .grad.
+    for name, p in model.named_parameters():
+        assert p.grad is None, f"parameter {name} unexpectedly has .grad after optimize_composition"
+
+
+def test_optimize_composition_restores_model_state_on_error():
+    """A validation raised inside the call must still leave the model in its original mode and
+    with parameter requires_grad flags untouched (try/finally invariant)."""
+    model = _make_reg_clf_model()
+    model.train()  # put model into training mode
+    before_mode = model.training
+    before_req_grad = [p.requires_grad for p in model.parameters()]
+    kernel = torch.randn(6, INPUT_DIM)
+    # Force a failure deep in the optimisation (mismatched class target index).
+    with pytest.raises(ValueError):
+        model.optimize_composition(kernel, class_targets={"cls": [99]}, n_starts=2, steps=2)
+    # Mode and requires_grad must be exactly as we left them.
+    assert model.training == before_mode
+    assert [p.requires_grad for p in model.parameters()] == before_req_grad
+
+
 def test_optimize_composition_uses_kmd_kernel_torch():
     """End-to-end: a real KMD's kernel_torch flows into optimize_composition."""
     from foundation_model.utils.kmd_plus import KMD

--- a/src/foundation_model/models/flexible_multi_task_model_test.py
+++ b/src/foundation_model/models/flexible_multi_task_model_test.py
@@ -1046,6 +1046,40 @@ def test_optimize_composition_increases_target_class_probability():
     assert _prob(res.optimized_weights) > _prob(init_w)
 
 
+def test_optimize_composition_rejects_negative_initial_weights():
+    model = _make_reg_clf_model()
+    kernel = torch.randn(6, INPUT_DIM)
+    bad = torch.tensor([[1.0, -0.1, 0.2, 0.2, 0.2, 0.5]])
+    with pytest.raises(ValueError, match="non-negative"):
+        model.optimize_composition(kernel, initial_weights=bad, task_targets={"prop": 0.0}, steps=2)
+    zero_row = torch.zeros(1, 6)
+    with pytest.raises(ValueError, match="positive sum"):
+        model.optimize_composition(kernel, initial_weights=zero_row, task_targets={"prop": 0.0}, steps=2)
+
+
+def test_optimize_composition_does_not_reset_global_rng():
+    """The method must not rewind the global RNG (would defeat n_starts diversity)."""
+    torch.manual_seed(42)
+    model = _make_reg_clf_model()
+    kernel = torch.randn(6, INPUT_DIM)
+    state_before = torch.random.get_rng_state().clone()
+    model.optimize_composition(kernel, task_targets={"prop": 0.0}, n_starts=4, steps=2)
+    state_after = torch.random.get_rng_state()
+    # The RNG must have advanced (some random was consumed), not been reset.
+    assert not torch.equal(state_before, state_after)
+
+
+def test_optimize_composition_trajectory_shape_when_zero_steps():
+    """Empty trajectory still carries the regression-task width T (not 0)."""
+    model = _make_reg_clf_model()
+    kernel = torch.randn(6, INPUT_DIM)
+    res = model.optimize_composition(
+        kernel, task_targets={"prop": 0.0}, class_targets={"cls": [1]}, n_starts=3, steps=0
+    )
+    # tasks_for_optimization = ["prop"] → T == 1
+    assert res.trajectory.shape == (0, 3, 1)
+
+
 def test_optimize_composition_uses_kmd_kernel_torch():
     """End-to-end: a real KMD's kernel_torch flows into optimize_composition."""
     from foundation_model.utils.kmd_plus import KMD

--- a/src/foundation_model/models/flexible_multi_task_model_test.py
+++ b/src/foundation_model/models/flexible_multi_task_model_test.py
@@ -981,6 +981,87 @@ def test_optimize_latent_class_targets_only_no_regression():
     assert res.optimized_target.shape == (4, 1, 0)  # no regression tasks tracked
 
 
+# --- optimize_composition (differentiable KMD) --------------------------------
+
+
+def test_optimize_composition_runs_and_returns_simplex_weights():
+    torch.manual_seed(0)
+    model = _make_reg_clf_model()  # INPUT_DIM=20
+    n_components = 6
+    kmd_kernel = torch.randn(n_components, INPUT_DIM)
+    res = model.optimize_composition(
+        kmd_kernel,
+        task_targets={"prop": 1.0},
+        class_targets={"cls": [1]},
+        class_target_weight=3.0,
+        n_starts=4,
+        steps=10,
+    )
+    assert res.optimized_weights.shape == (4, n_components)
+    # Output is a simplex: non-negative, rows sum to 1.
+    assert (res.optimized_weights >= 0).all()
+    assert torch.allclose(res.optimized_weights.sum(dim=-1), torch.ones(4), atol=1e-5)
+    assert res.optimized_descriptor.shape == (4, INPUT_DIM)
+    # Descriptor matches the matmul exactly (no round-trip).
+    assert torch.allclose(res.optimized_descriptor, res.optimized_weights @ kmd_kernel, atol=1e-5)
+    assert res.optimized_target.shape == (4, 1)
+    assert res.trajectory.shape == (10, 4, 1)
+
+
+def test_optimize_composition_validates_kernel_and_objectives():
+    model = _make_reg_clf_model()
+    # kernel must be 2D
+    with pytest.raises(ValueError, match="2D torch.Tensor"):
+        model.optimize_composition(torch.randn(6), task_targets={"prop": 1.0}, n_starts=2, steps=2)
+    # kernel's x_dim must match encoder.input_dim
+    with pytest.raises(ValueError, match="encoder.input_dim"):
+        model.optimize_composition(torch.randn(6, INPUT_DIM + 1), task_targets={"prop": 1.0}, n_starts=2, steps=2)
+    # at least one objective required
+    with pytest.raises(ValueError, match="at least one of task_targets"):
+        model.optimize_composition(torch.randn(6, INPUT_DIM), n_starts=2, steps=2)
+
+
+def test_optimize_composition_increases_target_class_probability():
+    """Optimising for a class with high class_target_weight raises P(target) from a uniform seed."""
+    torch.manual_seed(0)
+    model = _make_reg_clf_model()
+    model.eval()
+    kmd_kernel = torch.randn(6, INPUT_DIM)
+    target = [1]
+    init_w = torch.full((4, 6), 1.0 / 6)
+
+    def _prob(w):
+        with torch.no_grad():
+            logits = model.task_heads["cls"](torch.tanh(model.encoder(w @ kmd_kernel)))
+            return torch.softmax(logits, dim=-1)[:, target].sum(dim=-1).mean().item()
+
+    res = model.optimize_composition(
+        kmd_kernel,
+        initial_weights=init_w,
+        class_targets={"cls": target},
+        class_target_weight=5.0,
+        steps=200,
+        lr=0.2,
+    )
+    assert _prob(res.optimized_weights) > _prob(init_w)
+
+
+def test_optimize_composition_uses_kmd_kernel_torch():
+    """End-to-end: a real KMD's kernel_torch flows into optimize_composition."""
+    from foundation_model.utils.kmd_plus import KMD
+
+    rng = np.random.default_rng(0)
+    # 1d with n_features=5, n_grids=4 → x_dim = 20 (matches INPUT_DIM).
+    cf = rng.normal(size=(7, 5))
+    kmd = KMD(cf, method="1d", n_grids=4)
+    model = _make_reg_clf_model()
+    kernel = kmd.kernel_torch()
+    assert kernel.shape == (7, INPUT_DIM)
+    res = model.optimize_composition(kernel, task_targets={"prop": 0.5}, n_starts=3, steps=10)
+    assert res.optimized_weights.shape == (3, 7)
+    assert torch.allclose(res.optimized_weights.sum(dim=-1), torch.ones(3), atol=1e-5)
+
+
 def test_optimize_latent_space_with_ae():
     model = _make_model()
     model.eval()

--- a/src/foundation_model/utils/kmd_plus.py
+++ b/src/foundation_model/utils/kmd_plus.py
@@ -151,25 +151,24 @@ class KMD:
         return self.transform(weight)
 
     def kernel_torch(self, *, device=None, dtype=None):  # type: ignore[no-untyped-def]
-        """Return the precomputed kernel as a (cached) ``torch.Tensor``.
+        """Return the precomputed kernel as a fresh ``torch.Tensor``.
 
-        The kernel is constant after construction, so we cache the torch view once and move it
-        to the caller's device/dtype on demand.
+        Each call materialises an independently-allocated tensor (no memory sharing with the
+        numpy kernel or any previous return), so in-place mutations on the result cannot affect
+        :meth:`transform` / :meth:`inverse` — :class:`KMD` itself remains 100% numpy-only and
+        backwards-compatible.
 
         Parameters
         ----------
         device, dtype:
-            Optional torch device / dtype overrides for the returned view.
+            Optional torch device / dtype overrides for the returned tensor.
         """
         import torch
 
-        cached = getattr(self, "_kernel_torch", None)
-        if cached is None:
-            cached = torch.as_tensor(self._kernel)
-            self._kernel_torch = cached
+        out = torch.from_numpy(np.array(self._kernel, copy=True))
         if device is not None or dtype is not None:
-            return cached.to(device=device, dtype=dtype)
-        return cached
+            out = out.to(device=device, dtype=dtype)
+        return out
 
     def transform_torch(self, weight, *, device=None, dtype=None):  # type: ignore[no-untyped-def]
         """Differentiable torch counterpart of :meth:`transform`.

--- a/src/foundation_model/utils/kmd_plus.py
+++ b/src/foundation_model/utils/kmd_plus.py
@@ -150,6 +150,50 @@ class KMD:
         """Alias for :meth:`transform`."""
         return self.transform(weight)
 
+    def kernel_torch(self, *, device=None, dtype=None):  # type: ignore[no-untyped-def]
+        """Return the precomputed kernel as a (cached) ``torch.Tensor``.
+
+        The kernel is constant after construction, so we cache the torch view once and move it
+        to the caller's device/dtype on demand.
+
+        Parameters
+        ----------
+        device, dtype:
+            Optional torch device / dtype overrides for the returned view.
+        """
+        import torch
+
+        cached = getattr(self, "_kernel_torch", None)
+        if cached is None:
+            cached = torch.as_tensor(self._kernel)
+            self._kernel_torch = cached
+        if device is not None or dtype is not None:
+            return cached.to(device=device, dtype=dtype)
+        return cached
+
+    def transform_torch(self, weight, *, device=None, dtype=None):  # type: ignore[no-untyped-def]
+        """Differentiable torch counterpart of :meth:`transform`.
+
+        :meth:`transform` is a single matrix multiplication ``weight @ K`` with ``K`` constant —
+        so the only step needed for end-to-end gradient flow into composition weights (e.g. for
+        gradient-based inverse design in composition space) is doing that matmul in torch.
+
+        Parameters
+        ----------
+        weight : torch.Tensor
+            Mixing ratios, shape ``(n_samples, n_components)``. Any ``device`` / ``dtype``.
+            Gradients flow through this argument.
+        device, dtype : optional
+            Overrides for the cached kernel view; defaults to ``weight``'s device/dtype.
+
+        Returns
+        -------
+        torch.Tensor
+            Descriptors, same shape as :meth:`transform` would produce.
+        """
+        kernel = self.kernel_torch(device=device or weight.device, dtype=dtype or weight.dtype)
+        return weight @ kernel
+
     def inverse(self, kmd: npt.ArrayLike) -> npt.NDArray[np.float64]:
         """Recover mixing weights from descriptors (descriptors → materials).
 

--- a/src/foundation_model/utils/kmd_plus.py
+++ b/src/foundation_model/utils/kmd_plus.py
@@ -150,25 +150,43 @@ class KMD:
         """Alias for :meth:`transform`."""
         return self.transform(weight)
 
-    def kernel_torch(self, *, device=None, dtype=None):  # type: ignore[no-untyped-def]
-        """Return the precomputed kernel as a fresh ``torch.Tensor``.
+    def _internal_kernel_torch(self, *, device=None, dtype=None):  # type: ignore[no-untyped-def]
+        """Cached torch kernel for **internal** read-only use (no clone, no exposure).
 
-        Each call materialises an independently-allocated tensor (no memory sharing with the
-        numpy kernel or any previous return), so in-place mutations on the result cannot affect
-        :meth:`transform` / :meth:`inverse` — :class:`KMD` itself remains 100% numpy-only and
-        backwards-compatible.
+        Keyed by ``(device, dtype)`` so repeated calls in a gradient loop avoid the deep-copy
+        cost of :meth:`kernel_torch`. The cached tensor must never be returned to callers — they
+        could mutate it in place and break :meth:`transform` / :meth:`inverse`.
+        """
+        import torch
+
+        if not hasattr(self, "_kernel_torch_cache"):
+            self._kernel_torch_cache: dict[tuple[str, str], "torch.Tensor"] = {}
+        key = (str(device) if device is not None else "default", str(dtype) if dtype is not None else "default")
+        cached = self._kernel_torch_cache.get(key)
+        if cached is None:
+            # First time for this (device, dtype): build an independent copy of the numpy kernel.
+            base = torch.from_numpy(np.array(self._kernel, copy=True))
+            if device is not None or dtype is not None:
+                base = base.to(device=device, dtype=dtype)
+            self._kernel_torch_cache[key] = base
+            cached = base
+        return cached
+
+    def kernel_torch(self, *, device=None, dtype=None):  # type: ignore[no-untyped-def]
+        """Return the precomputed kernel as a fresh ``torch.Tensor`` (safe to mutate).
+
+        Each call returns an independently-allocated tensor (no memory sharing with the numpy
+        kernel, the internal cache, or any previous return), so in-place mutations on the result
+        cannot affect :meth:`transform` / :meth:`inverse` — :class:`KMD` itself stays 100%
+        numpy-only and backwards-compatible. For hot loops that just need a read-only view, use
+        :meth:`transform_torch` (which reuses an internal cache).
 
         Parameters
         ----------
         device, dtype:
             Optional torch device / dtype overrides for the returned tensor.
         """
-        import torch
-
-        out = torch.from_numpy(np.array(self._kernel, copy=True))
-        if device is not None or dtype is not None:
-            out = out.to(device=device, dtype=dtype)
-        return out
+        return self._internal_kernel_torch(device=device, dtype=dtype).clone()
 
     def transform_torch(self, weight, *, device=None, dtype=None):  # type: ignore[no-untyped-def]
         """Differentiable torch counterpart of :meth:`transform`.
@@ -177,20 +195,23 @@ class KMD:
         so the only step needed for end-to-end gradient flow into composition weights (e.g. for
         gradient-based inverse design in composition space) is doing that matmul in torch.
 
+        Uses the internal kernel cache (matmul reads, never mutates), so repeated calls inside
+        an optimisation loop are constant-time after the first.
+
         Parameters
         ----------
         weight : torch.Tensor
             Mixing ratios, shape ``(n_samples, n_components)``. Any ``device`` / ``dtype``.
             Gradients flow through this argument.
         device, dtype : optional
-            Overrides for the cached kernel view; defaults to ``weight``'s device/dtype.
+            Overrides for the kernel view; defaults to ``weight``'s device/dtype.
 
         Returns
         -------
         torch.Tensor
             Descriptors, same shape as :meth:`transform` would produce.
         """
-        kernel = self.kernel_torch(device=device or weight.device, dtype=dtype or weight.dtype)
+        kernel = self._internal_kernel_torch(device=device or weight.device, dtype=dtype or weight.dtype)
         return weight @ kernel
 
     def inverse(self, kmd: npt.ArrayLike) -> npt.NDArray[np.float64]:

--- a/src/foundation_model/utils/kmd_plus_test.py
+++ b/src/foundation_model/utils/kmd_plus_test.py
@@ -154,6 +154,18 @@ def test_kernel_torch_mutation_does_not_affect_numpy_kmd(component_features, wei
     np.testing.assert_allclose(fresh.numpy(), kmd.transform(np.eye(component_features.shape[0])))
 
 
+def test_transform_torch_reuses_internal_cache(component_features):
+    """transform_torch must not deep-copy the kernel on every call (perf-critical for loops)."""
+    import torch
+
+    kmd = KMD(component_features, method="1d", n_grids=10)
+    w = torch.rand(2, component_features.shape[0])
+    _ = kmd.transform_torch(w)  # first call seeds the internal cache
+    cached = kmd._internal_kernel_torch(device=w.device, dtype=w.dtype)
+    again = kmd._internal_kernel_torch(device=w.device, dtype=w.dtype)
+    assert cached is again  # same (device, dtype) key returns the cached tensor
+
+
 def test_transform_torch_preserves_input_dtype():
     """The torch transform should respect the caller's dtype (e.g. fp64 stays fp64)."""
     import torch

--- a/src/foundation_model/utils/kmd_plus_test.py
+++ b/src/foundation_model/utils/kmd_plus_test.py
@@ -103,6 +103,33 @@ def test_call_matches_transform(method, kwargs, weight, component_features):
     np.testing.assert_array_equal(kmd(weight), kmd.transform(weight))
 
 
+# --- differentiable torch transform -----------------------------------------
+
+
+@pytest.mark.parametrize("method,kwargs", [("1d", {"n_grids": 10}), ("md", {})])
+def test_transform_torch_matches_numpy(method, kwargs, weight, component_features):
+    import torch
+
+    kmd = KMD(component_features, method=method, **kwargs)
+    np_out = kmd.transform(weight)
+    torch_out = kmd.transform_torch(torch.as_tensor(weight, dtype=torch.float64))
+    assert torch.allclose(torch_out, torch.as_tensor(np_out), atol=1e-10)
+
+
+def test_transform_torch_is_differentiable(component_features):
+    """Gradients flow through transform_torch back to the weight tensor."""
+    import torch
+
+    kmd = KMD(component_features, method="1d", n_grids=10)
+    w = torch.rand(3, component_features.shape[0], dtype=torch.float64, requires_grad=True)
+    desc = kmd.transform_torch(w)
+    loss = desc.pow(2).sum()
+    loss.backward()
+    assert w.grad is not None
+    assert w.grad.shape == w.shape
+    assert torch.any(w.grad != 0)
+
+
 # --- roundtrip ---------------------------------------------------------------
 
 

--- a/src/foundation_model/utils/kmd_plus_test.py
+++ b/src/foundation_model/utils/kmd_plus_test.py
@@ -130,6 +130,42 @@ def test_transform_torch_is_differentiable(component_features):
     assert torch.any(w.grad != 0)
 
 
+def test_kernel_torch_mutation_does_not_affect_numpy_kmd(component_features, weight):
+    """Backwards-compatibility lock: torch additions never affect the numpy KMD path.
+
+    The legacy ``transform`` / ``inverse`` callers must keep working unchanged even after we
+    hand out torch views of the kernel — including the worst case where downstream code
+    accidentally mutates the returned tensor in place.
+    """
+    import torch
+
+    kmd = KMD(component_features, method="1d", n_grids=10)
+    before = kmd.transform(weight)
+    # Try to mutate the returned tensor in place (worst-case adversarial use).
+    t = kmd.kernel_torch()
+    t.zero_()
+    t2 = kmd.kernel_torch()
+    t2.add_(1000.0)
+    # The numpy transform must still produce the original output.
+    after = kmd.transform(weight)
+    np.testing.assert_array_equal(before, after)
+    # And a fresh kernel_torch call must still match the numpy kernel.
+    fresh = kmd.kernel_torch()
+    np.testing.assert_allclose(fresh.numpy(), kmd.transform(np.eye(component_features.shape[0])))
+
+
+def test_transform_torch_preserves_input_dtype():
+    """The torch transform should respect the caller's dtype (e.g. fp64 stays fp64)."""
+    import torch
+
+    cf = np.random.default_rng(0).normal(size=(6, 3))
+    kmd = KMD(cf, method="1d", n_grids=8)
+    w_fp64 = torch.rand(2, 6, dtype=torch.float64)
+    assert kmd.transform_torch(w_fp64).dtype == torch.float64
+    w_fp32 = w_fp64.to(torch.float32)
+    assert kmd.transform_torch(w_fp32).dtype == torch.float32
+
+
 # --- roundtrip ---------------------------------------------------------------
 
 


### PR DESCRIPTION
## Why

Latent-space inverse design (the existing ``optimize_latent`` with ``optimize_space=\"latent\"``) suffers from an **AE-decode round-trip fidelity loss**: the optimizer can find a latent that scores well on the heads, but ``AE.decode(z) → encoder → z′`` doesn't faithfully return to ``z``, so after-decode predictions drift back from the in-latent optimum.

This PR adds an alternative inverse-design path that **eliminates the round-trip by construction**: optimise the element-weight recipe ``w`` directly through the (differentiable) KMD transform and the supervised heads. The optimisation variable IS the composition you report.

## What

### 1. Differentiable KMD (utility)

``KMD.transform(weight)`` is literally ``weight @ self._kernel`` with ``K`` constant after construction. That's already differentiable; we just need a torch matmul. Adds:

- ``KMD.transform_torch(weight)``: torch counterpart of ``transform``, sharing a cached torch view of the kernel; supports any device/dtype.
- ``KMD.kernel_torch()``: exposes the cached kernel matrix as a ``torch.Tensor``.

Verified by tests to match ``transform`` to 1e-10 across both 1d/md methods, with gradients flowing back to ``weight``.

### 2. ``FlexibleMultiTaskModel.optimize_composition(...)``

```
logits → w = softmax(logits) → x = w @ kmd_kernel → encoder → tanh → heads → loss
```

- **Optimisation variable**: ``logits`` over ``n_components`` elements (softmax → simplex-constrained ``w``); seeded uniform-random or from explicit ``initial_weights``.
- **Objectives**: ``task_targets`` (regression MSE) and ``class_targets`` with ``class_target_weight`` (same semantics as ``optimize_latent``); optional ``sparsity_weight`` (negative entropy on ``w``) to push toward few-element mixtures.
- **Output**: ``CompositionOptimizationResult`` with ``optimized_weights`` (the recipe), ``optimized_descriptor`` (= ``w @ K``), ``optimized_target`` (per-task), ``initial_score``, ``trajectory``.

Because ``w`` IS the recipe:
- **No AE-decode round-trip** ⇒ no after-decode fidelity drop.
- **No ``KMD.inverse`` QP** ⇒ no quadprog edge cases at output time.
- **Simplex-constrained by construction** ⇒ output is always a legitimate composition.
- **AE optional** in training (this method doesn't touch the AE head; you can keep AE for self-supervised encoder regularisation, or disable it — orthogonal to this PR).

## Validation

- ``ruff format`` / ``ruff check`` clean.
- ``pytest src/foundation_model/models/ src/foundation_model/utils/`` → **87 passed**.
- New focused tests:
  - ``transform_torch`` matches numpy ``transform`` (1d + md) to 1e-10 and is differentiable.
  - ``optimize_composition`` returns simplex-valid weights, validates kernel shape vs ``encoder.input_dim``, raises without an objective, and **raises P(target class)** from a uniform seed under a class objective.
  - ``optimize_composition`` accepts a real ``KMD.kernel_torch()`` end-to-end.

## Compatibility

Purely additive: new utility methods on ``KMD``, a new method on ``FlexibleMultiTaskModel``, a new ``NamedTuple`` result. **No changes to model architecture, training, encoder, AE, or any nn.Module**. Existing ``state_dict`` checkpoints remain forward-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)