### PR TITLE
PR1 — fm CLI foundation: task_catalog + recording

### DIFF
--- a/docs/refactor_fm_cli/00_OVERVIEW.md
+++ b/docs/refactor_fm_cli/00_OVERVIEW.md
@@ -1,0 +1,222 @@
+# Refactor: Unified `fm` CLI — Master Plan
+
+> **Status**: approved plan, not yet implemented.
+> **Goal owner**: TsumiNa. Executed in stages by coding agents — each numbered doc in this
+> directory is one PR. Read this overview first, then the PR doc you are executing.
+
+## 1. Goal
+
+Consolidate all console entry points into a single `fm` command:
+
+```
+fm pretrain  --config <toml> [overrides]   # continual rehearsal pre-training (multi-run sweep)
+fm finetune  --config <toml> [overrides]   # frozen-encoder fine-tuning of selected task heads
+fm inverse   --config <toml> [overrides]   # inverse design (scenarios × algorithm paths)
+fm predict   --config <toml> [overrides]   # evaluate / predict with an arbitrary checkpoint
+```
+
+This **fully replaces and deletes**:
+
+| Legacy entry | Script | Replaced by |
+|---|---|---|
+| `fm-trainer` | `scripts/train.py` (LightningCLI) | `fm pretrain` / `fm finetune` (fit), `fm predict` (validate/test/predict) |
+| `fm-pretrain-suite` | `scripts/dynamic_task_suite.py` | `fm pretrain` (n_runs sweep) + `fm finetune` |
+| `fm-progressive-clf` | `scripts/multi_task_progressive_clf.py` | `fm pretrain` (reg+kr sequence) + `fm finetune` (clf head) |
+| — | `scripts/continual_rehearsal_demo.py` | `fm pretrain` (smoke config) |
+| — | `scripts/continual_rehearsal_full.py` | `fm pretrain` + `fm inverse` |
+| — | `scripts/finetune_inverse_heads.py` | `fm finetune` |
+| — | `scripts/paper_inverse_comparison.py` / `paper_inverse_3scenarios.py` | `fm inverse` |
+| — | `scripts/eval_inverse_methods.py` | helpers folded into `workflows/inverse.py` |
+
+## 2. Non-negotiable decisions (already confirmed with the owner)
+
+1. **Single `fm` command** built with [`click`](https://click.palletsprojects.com/) (one group +
+   four subcommands). No `fm-*` intermediates. (`click` chosen over stdlib argparse — popular,
+   ergonomic, extensible for multi-subcommand CLIs; added as a direct dep in PR2.)
+2. **`LightningCLI` is dropped entirely.** No jsonargparse / YAML configs anywhere. All configs
+   are TOML + argparse CLI overrides. Lightning is kept only as the internal training engine
+   (`Trainer`, `EarlyStopping`, etc.). `StrictFalseLightningCLI` / `LoggerSaveConfigCallback`
+   are deleted, not migrated; checkpoint loading uses `torch.load` +
+   `load_state_dict(strict=False)` directly.
+3. **Provenance log on every execution** (all four subcommands): `run_provenance.json` written
+   into the output dir at startup, containing the fully-resolved config, core package versions
+   (python / torch / lightning / numpy / pandas / scikit-learn / foundation-model), execution
+   datetime (ISO), git commit hash + dirty flag, full `sys.argv`, and random seeds. Plus a
+   human-readable `run.log` (loguru sink) in the same dir.
+4. **Task catalog is fully TOML-driven** (`[datasets]` + `[[tasks]]`). No hardcoded
+   `TASK_SPECS` / task registries in code.
+5. **Rehearsal interval semantics**: `interval = N` → old tasks join training only on every Nth
+   step (with replay subsampling); other steps train the new task + AE only. `N = 1` reproduces
+   current behaviour. Evaluation always covers **all** learned heads at every step (forgetting
+   trajectory must not be affected by the interval).
+6. **Replay amount**: float `< 1` = fraction of labels, int `>= 1` = absolute label count.
+   Global default + per-task override. This replaces the old `fixed_tail` / `replay_ratio_high`
+   two-tier design.
+7. **AE head always trains** in both pretrain and finetune; only its learning rate (`ae_lr`) is
+   configurable. (Behaviour change vs `finetune_inverse_heads`, which froze AE — intentional.)
+   `task_log_sigmas` are frozen during finetune.
+8. **`n_runs` sweep built into `fm pretrain`**: `task_order = "fixed" | "random"`, per-run
+   subdirectory + derived seed, aggregated `experiment_records.json`.
+9. **Research provenance is first-class**: per-step checkpoints, metrics json + csv, prediction
+   parquets, forgetting trajectory, inverse seeds/results/trajectory arrays + plots/animations
+   are all preserved and centralised in one recording module.
+10. **All legacy scripts, sample configs, shell wrappers and stale docs are deleted** at the end
+    (PR6). Historical `artifacts/*/README.md` files are left untouched.
+
+## 3. Target architecture
+
+```
+src/foundation_model/
+  cli/
+    __init__.py
+    main.py              # `fm` entry: argparse subparsers → dispatch. THIN — no business logic.
+  workflows/
+    __init__.py
+    task_catalog.py      # TOML → DatasetSpec/TaskSpec; data loading; descriptor sources; scalers
+    recording.py         # RunRecorder: output layout, provenance, checkpoints, metrics, parquet
+    pretrain.py          # rehearsal pretrain engine (interval replay, n_runs sweep)
+    finetune.py          # freeze policy + finetune engine
+    inverse.py           # scenario × path inverse-design engine, seed selection
+    inverse_trajectory.py# trajectory analytics/plots/animations (migrated)
+    plots.py             # parity / confusion / kr-sequences / forgetting / comparison / heatmap
+    predict.py           # arbitrary-checkpoint evaluation & prediction
+```
+
+Module boundaries:
+
+- `cli/` parses argv, loads TOML, applies overrides, builds the workflow config dataclass, calls
+  exactly one `workflows.<mod>.run(cfg)` function. Nothing else.
+- `workflows/*` never parse argv. Each `run()` takes a validated config dataclass.
+- Only `recording.py` writes artifacts (files) for training/predict flows; other modules hand it
+  dataframes/dicts/figures. `inverse.py` may delegate figure rendering to `plots.py` /
+  `inverse_trajectory.py` but file paths still come from the recorder.
+- Config dataclasses follow repo conventions: `@dataclass(kw_only=True)`, defaults via `field`,
+  validation in `__post_init__`, dict→dataclass via builder functions (mirror
+  `build_encoder_config`), `str`-based enums for closed choices.
+- Imports: single-dot relative inside `workflows/` (`from .recording import RunRecorder`),
+  absolute across packages (`from foundation_model.models.model_config import ...`).
+- Every module ships a colocated `<module>_test.py` (pytest, parametrized).
+
+## 4. Config schema (shared sections)
+
+One TOML file can hold everything; each subcommand reads the shared sections plus its own.
+See per-PR docs for the full schemas. Shared:
+
+```toml
+# ---- data & tasks (consumed by all subcommands) ----
+[data]
+composition_column = "composition"
+val_split = 0.1
+test_split = 0.1
+split_random_seed = 42
+batch_size = 256
+num_workers = 0
+
+[descriptor]
+kind = "kmd"                    # "kmd" (on-the-fly, invertible) | "precomputed"
+n_grids = 8                     # kmd only
+# path = "data/descriptors.pd.parquet"   # precomputed only (composition-indexed)
+
+[datasets.qc]
+path = "data/qc_ac_te_mp_dos_reformat_20260515.pd.parquet"
+# preprocessing_path = "..."    # optional dropped-row index cache
+# min_elements = 4              # optional composition filter
+# sample = 2000                 # optional row cap (smoke runs)
+
+[datasets.supercon]
+path = "data/NEMAD_superconductor_20260425.parquet"
+
+[[tasks]]
+name = "density"
+kind = "regression"             # regression | kernel_regression | classification
+dataset = "qc"
+column = "Density (normalized)"
+# t_column = "DOS energy"       # kernel_regression only
+# num_classes = 3               # classification only
+# lr = 5e-3                     # per-task LR override
+# replay = 0.10                 # per-task rehearsal override (fraction or count)
+# scaler = { path = "data/scalers.pkl.z", key = "density" }  # optional inverse-transform
+
+[model]
+latent_dim = 128
+encoder_hidden = 256
+head_hidden_dim = 64
+n_kernel = 15
+
+[training]
+max_epochs = 100
+early_stop_patience = 8
+early_stop_min_delta = 1e-4
+encoder_lr = 5e-3
+head_lr = 5e-3
+kr_lr = 5e-4
+kr_weight_decay = 5e-5
+ae_lr = 5e-3
+accelerator = "auto"
+devices = 1
+seed = 2025
+
+[output]
+dir = "artifacts/my_run"        # subcommand appends its own structure under this
+```
+
+CLI override convention: `--set section.key=value` (repeatable, dotted path into the TOML tree,
+values parsed as TOML), plus first-class flags for the most common knobs (`--output-dir`,
+`--checkpoint`, `--max-epochs`, `--sample`, `--accelerator`, `--seed`).
+
+## 5. PR breakdown
+
+| PR | Doc | Branch | Contents | Depends on |
+|---|---|---|---|---|
+| 1 | [01_pr1_task_catalog_and_recording.md](01_pr1_task_catalog_and_recording.md) | `feat/fm-cli-foundation` | `workflows/task_catalog.py`, `workflows/recording.py` + tests | — |
+| 2 | [02_pr2_pretrain.md](02_pr2_pretrain.md) | `feat/fm-cli-pretrain` | `workflows/pretrain.py`, `workflows/plots.py`, `cli/main.py` skeleton, register `fm` | PR1 |
+| 3 | [03_pr3_finetune.md](03_pr3_finetune.md) | `feat/fm-cli-finetune` | `workflows/finetune.py`, `fm finetune` subcommand | PR2 |
+| 4 | [04_pr4_inverse.md](04_pr4_inverse.md) | `feat/fm-cli-inverse` | `workflows/inverse.py`, `workflows/inverse_trajectory.py`, `fm inverse` | PR2 (PR3 for e2e chain) |
+| 5 | [05_pr5_predict.md](05_pr5_predict.md) | `feat/fm-cli-predict` | `workflows/predict.py`, `fm predict` | PR2 |
+| 6 | [06_pr6_cleanup.md](06_pr6_cleanup.md) | `chore/fm-cli-cleanup` | delete legacy scripts/configs/docs/wrappers, update AGENTS/README/ARCHITECTURE, remove old console scripts | PR2–5 |
+
+Rules for every PR:
+
+- Branch off `master` (rebase on the previous PR's merge). One PR per doc; do not combine.
+- Old entry points keep working until PR6 — do not break `fm-trainer` / `fm-pretrain-suite` /
+  `fm-progressive-clf` before then. It is fine for new `workflows/` code to import from legacy
+  `scripts/` modules *temporarily only if unavoidable*; prefer copying logic into the new module
+  so PR6 can delete `scripts/` files without surgery.
+- Per repo conventions: `ruff format`, `ruff check`, `mypy src`, `pytest` must pass; colocated
+  `<module>_test.py` with primary-path + failure-pattern coverage; commit style
+  `<type>: <summary>`.
+- No new markdown docs beyond what each PR doc specifies.
+
+## 6. Functional coverage checklist (must hold at PR6)
+
+- [ ] `fm-trainer` fit → `fm pretrain` / `fm finetune`; validate/test/predict → `fm predict`;
+      `strict=False` checkpoint loading preserved.
+- [ ] `fm-pretrain-suite`: n_runs sweep, random task order, frozen-encoder finetune stages,
+      precomputed descriptors, per-task scaler inverse-transform on predictions, per-task
+      masking ratios, per-stage parquet + metrics + parity plots, `experiment_records.json`.
+- [ ] `fm-progressive-clf`: reg+kr pretrain sequence + clf finetune; kernel center/sigma
+      init-from-data; confusion matrices + classification reports; `min_elements` filter.
+- [ ] `continual_rehearsal_full`: tiered replay (per-task overrides), per-step raw artifacts,
+      forgetting trajectory, final model + taskconfigs json, inverse-only mode
+      (= `fm inverse` on an existing checkpoint).
+- [ ] `finetune_inverse_heads`: `fm finetune --set finetune.tasks=[...]`; AE now trainable.
+- [ ] `paper_inverse_comparison` + `3scenarios`: scenarios × paths, seeds.json, results.json,
+      comparison.png, element-frequency heatmap, qc-vs-secondary scatter, seed→optimized maps,
+      trajectory npz + static/animated plots (incl. per-seed variants). SLIDE_PREP/ANALYSIS
+      auto-writers are dropped intentionally.
+
+## 7. End-to-end acceptance (run at PR6)
+
+```sh
+# CPU smoke chain, ~minutes
+fm pretrain --config samples/pretrain_smoke.toml            # 2-3 tasks, sample cap, interval=2, n_runs=2
+fm finetune --config samples/finetune_smoke.toml \
+    --checkpoint <run>/runs/run00/training/final_model.pt
+fm inverse  --config samples/inverse_smoke.toml \
+    --checkpoint <finetune>/final_model.pt                  # 1 scenario, latent+comp, steps=5
+fm predict  --config samples/predict_smoke.toml \
+    --checkpoint <finetune>/final_model.pt
+```
+
+Each output dir must contain `run_provenance.json` + `run.log`. Then `pytest`, `ruff check`,
+`mypy src` green.

--- a/docs/refactor_fm_cli/01_pr1_task_catalog_and_recording.md
+++ b/docs/refactor_fm_cli/01_pr1_task_catalog_and_recording.md
@@ -1,0 +1,251 @@
+# PR1 — Foundation: `workflows/task_catalog.py` + `workflows/recording.py`
+
+> Branch: `feat/fm-cli-foundation`. Depends on: nothing. Read `00_OVERVIEW.md` first.
+> This PR adds **library modules + tests only** — no CLI, no deletion of legacy code.
+>
+> **Source references verified against `master` @ 532a4aa.** Line numbers below are corrected
+> from the original draft; where the legacy behaviour differs from what this PR proposes, the
+> divergence is called out explicitly (kernel init, `min_elements`, unknown-key rejection).
+
+## A. `src/foundation_model/workflows/task_catalog.py`
+
+Replaces every hardcoded task registry in the repo:
+
+| Legacy source | What to migrate |
+|---|---|
+| `scripts/continual_rehearsal_demo.py` `TASK_SPECS` (**L93–111**) | task → (source, kind, column, t_column, num_classes) mapping becomes TOML-driven. **`t_column` is present only for `kind=="kr"`, `num_classes` only for `kind=="clf"`** (kind-conditional, matching the new `TaskSpec.__post_init__`). Legacy `kind` values are the short strings `"reg"/"kr"/"clf"` — `build_task_catalog_config` must normalize them to the `TaskKind` enum (`"regression"/"kernel_regression"/"classification"`). |
+| `scripts/continual_rehearsal_demo.py` `ContinualRehearsalRunner._load_data` (**L350**) / `descriptor_fn` (**L452**) | composition-keyed frame loading + on-the-fly KMD-1d descriptor (`utils/kmd_plus.py`: `KMD`, `element_features` — a module-level `DataFrame`, not a fn —, `formula_to_composition`, `DEFAULT_ELEMENTS`) with per-composition caching (KMD built once as `KMD(element_features.values, method="1d", n_grids=..., sigma="auto", scale=True)`; cache is a `dict[str, np.ndarray]`). |
+| `scripts/continual_rehearsal_demo.py` `_build_task_config` (**L478**) | TaskSpec → `RegressionTaskConfig` / `ClassificationTaskConfig` / `KernelRegressionTaskConfig` builder |
+| `scripts/dynamic_task_suite.py` `SuiteConfig` descriptor/scaler fields (**L91–153**) + `_load_datasets` (**L818**) | precomputed-descriptor path (`PrecomputedDescriptorSource` in `data/composition_sources.py`, L306), per-task scaler loading — `joblib.load` returns a **dict-of-scalers keyed by task name** (`_load_scalers` L914–957) — for inverse-transform (`_maybe_inverse_transform` L959–966, applied to targets and preds). |
+| `scripts/multi_task_progressive_clf.py` `_init_centers_and_sigmas` (**L79–118**) **or** `scripts/continual_rehearsal_demo.py` `_init_kernels` (**L324–331**); `n_elements` filter | kernel center/sigma init-from-data helper (**two legacy implementations exist — pick one, see §A note below**); `min_elements` dataset filter (**behaviour-change — see note**). |
+
+### Dataclasses (all `@dataclass(kw_only=True)`, `__post_init__` validation)
+
+```python
+class TaskKind(str, Enum):
+    REGRESSION = "regression"
+    KERNEL_REGRESSION = "kernel_regression"
+    CLASSIFICATION = "classification"
+
+@dataclass(kw_only=True)
+class ScalerSpec:
+    path: Path
+    key: str | None = None          # key inside a dict-of-scalers pickle; None = whole object
+
+@dataclass(kw_only=True)
+class DatasetSpec:
+    name: str
+    path: Path
+    preprocessing_path: Path | None = None   # dropped-row index cache (qc dataset)
+    min_elements: int | None = None          # composition filter (progressive-clf `>= 4`)
+    sample: int | None = None                # row cap for smoke runs
+    # __post_init__: path exists (defer to load time is OK but validate extension),
+    #                min_elements >= 1, sample >= 1
+
+@dataclass(kw_only=True)
+class TaskSpec:
+    name: str
+    kind: TaskKind                            # accepts str, normalized in __post_init__
+    dataset: str                              # key into datasets
+    column: str
+    t_column: str | None = None               # required iff kind == KERNEL_REGRESSION
+    num_classes: int | None = None            # required iff kind == CLASSIFICATION
+    lr: float | None = None                   # per-task LR override
+    replay: float | int | None = None         # per-task rehearsal override
+    scaler: ScalerSpec | None = None
+    # __post_init__: kind-conditional requirements above; replay: float in (0,1) or int >= 1
+
+@dataclass(kw_only=True)
+class DescriptorConfig:
+    kind: str = "kmd"                          # "kmd" | "precomputed"
+    n_grids: int = 8                           # kmd only
+    path: Path | None = None                   # precomputed only; required then
+
+@dataclass(kw_only=True)
+class DataConfig:
+    composition_column: str = "composition"
+    val_split: float = 0.1
+    test_split: float = 0.1
+    split_random_seed: int = 42
+    batch_size: int = 256
+    num_workers: int = 0
+
+@dataclass(kw_only=True)
+class TaskCatalogConfig:
+    data: DataConfig
+    descriptor: DescriptorConfig
+    datasets: dict[str, DatasetSpec]
+    tasks: list[TaskSpec]
+    # __post_init__: task names unique; every task.dataset in datasets; >= 1 task
+```
+
+### Builder + catalog API
+
+```python
+def build_task_catalog_config(raw: Mapping[str, Any]) -> TaskCatalogConfig:
+    """Normalize the parsed-TOML tree ([data]/[descriptor]/[datasets.*]/[[tasks]]) into the
+    dataclass. Reject unknown keys with a ValueError naming the offending key."""
+    # NOTE: build_encoder_config() does NOT actually validate unknown keys — it forwards
+    # leftover keys via **config_dict, so an unknown key surfaces as a dataclass
+    # TypeError("unexpected keyword argument ..."), not a ValueError. Do NOT rely on that
+    # behaviour: add an explicit `set(raw) - KNOWN_KEYS` check per section here so the
+    # error message names the key, per the OVERVIEW's config-hygiene requirement.
+
+class TaskCatalog:
+    """Loads frames + descriptors once; hands out task configs and datamodules."""
+    def __init__(self, config: TaskCatalogConfig) -> None: ...
+    @property
+    def task_names(self) -> list[str]: ...
+    def task_spec(self, name: str) -> TaskSpec: ...
+    def task_frames(self, names: Sequence[str]) -> dict[str, pd.DataFrame]:
+        """Composition-keyed per-task frames (lazy per-dataset load, min_elements/sample applied)."""
+    def descriptor_fn(self) -> Callable[[list[str]], pd.DataFrame]:
+        """KMD on-the-fly (cached per composition) or precomputed-file lookup."""
+    def kmd(self) -> KMD | None:
+        """The invertible KMD object (None when descriptor.kind == 'precomputed').
+        Needed by fm inverse (optimize_composition kernel + KMD.inverse decode)."""
+    def build_task_config(
+        self, name: str, *, latent_dim: int, head_hidden_dim: int, n_kernel: int, lr: float,
+        weight_decay: float = 0.0, masking_ratio: float = 1.0, init_from_data: bool = True,
+    ) -> RegressionTaskConfig | ClassificationTaskConfig | KernelRegressionTaskConfig:
+        """Kernel-regression heads get center/sigma initialized from the task's t/y distribution.
+        Field-name mapping into the real dataclasses (model_config.py) — these params are an
+        abstraction, they do NOT match the dataclass field names 1:1. NOTE the head input dim must
+        equal the model `latent_dim` (heads consume `tanh(latent)`), so:
+          - reg/clf `dims=[latent_dim, head_hidden_dim, out]` (out=1 for reg, num_classes-ish for clf)
+          - kr `x_dim=[latent_dim, ...]`, `t_dim=[...]`
+          - n_kernel     -> kr `kernel_num_centers` (default 32 in the dataclass)
+          - lr/weight_decay -> attach `optimizer=OptimizerConfig(lr=lr, weight_decay=weight_decay)`
+            (there is no bare `lr` field on task configs; per-head LR lives on `.optimizer`)
+          - masking_ratio -> `task_masking_ratio`
+          - init_from_data -> kr `kernel_centers_init`/`kernel_sigmas_init` (None => equal-spaced)
+        clf heads also carry `num_classes` (from the TaskSpec) and optional `class_weights`."""
+    def scaler(self, name: str):  # -> fitted scaler or None
+    def inverse_transform(self, name: str, values: np.ndarray) -> np.ndarray:
+        """Apply the task's scaler inverse-transform if configured, else identity."""
+    def build_datamodule(
+        self, active_tasks: Sequence[str], *, masking_ratios: Mapping[str, float] | None = None,
+        predict_idx: str | Sequence[str] | None = None,
+    ) -> CompoundDataModule: ...
+```
+
+Notes:
+- Reuse `CompoundDataModule` / `data/composition_sources.py` as-is; this module only assembles
+  their inputs.
+- **`predict_idx` is a per-task field on `BaseTaskConfig`, not a `CompoundDataModule.__init__`
+  argument.** `build_datamodule(..., predict_idx=...)` must set it onto the built task configs
+  (literal `train/val/test/all` or an explicit composition sequence), then hand the configs to
+  `CompoundDataModule`. The DataModule exposes the resolved set as `datamodule.predict_compositions`.
+- Replay **count → ratio** conversion happens where the number of valid labels is known
+  (pretrain engine, PR2) — `TaskSpec.replay` is stored raw here.
+- Keep `normalize_composition` usage identical to the rehearsal scripts so composition joins
+  behave the same.
+- **Kernel init — choose ONE canonical helper (owner decision, then delete the other's copy in
+  PR6).** Two legacy implementations exist and produce *different* centers/sigmas:
+  `multi_task_progressive_clf._init_centers_and_sigmas` (L79–118: histogram density → CDF →
+  quantile-interp centers, neighbour-gap sigmas, called with `inverse_density=True`) vs.
+  `continual_rehearsal_demo._init_kernels` (L324–331: plain quantile centers, constant span).
+  **Decision (owner-delegated):** adopt the demo's `_init_kernels` (quantile centers + constant
+  span) as canonical, because it is what the pretrain path actually exercises today
+  (`continual_rehearsal_full` builds heads via the demo runner), so the migration reproduces
+  current behaviour. The histogram-density `_init_centers_and_sigmas` variant stays available as
+  an alternative if a future finetune path needs it, but is not the default. Document the choice
+  in the module docstring.
+- **`min_elements` is a behaviour change, not a lift-and-shift.** In the legacy code the
+  `n_elements >= 4` filter is an *evaluation-time* test-subset report
+  (`multi_task_progressive_clf._run_finetune_eval` L651–654 → `clf_report_ge4.json`), NOT a
+  row-dropping load filter. This PR intentionally reinterprets it as a `DatasetSpec.min_elements`
+  load filter that drops rows before splitting. Call this out in the PR description as a
+  deliberate semantics change so reviewers don't expect identical eval numbers.
+
+## B. `src/foundation_model/workflows/recording.py`
+
+The **only** artifact writer for training/predict flows. Centralises what today is scattered
+across `continual_rehearsal_common.py` (dump helpers), `continual_rehearsal_full.py`
+(per-step checkpoint/metrics/records), `dynamic_task_suite.py` (prediction parquet + records).
+
+```python
+@dataclass(kw_only=True)
+class RunPaths:
+    root: Path                      # <output.dir>[/runs/runNN]
+    training: Path                  # root/training
+    # helpers: step_dir(step:int, task:str) -> training/stepNN_<task>
+
+class RunRecorder:
+    def __init__(self, root: Path) -> None: ...   # mkdir -p, attach loguru file sink root/run.log
+
+    def write_provenance(self, *, config: Any, argv: list[str], seeds: Mapping[str, int]) -> Path:
+        """Write root/run_provenance.json:
+        - resolved_config: dataclasses.asdict(config), JSON-sanitized. NOTE asdict recurses into
+          nested dataclasses but leaves BOTH Path AND Enum (TaskKind/TaskOrder/InverseMethod)
+          values non-serializable — dump with a coercing default (e.g.
+          `json.dumps(..., default=lambda o: o.value if isinstance(o, Enum) else str(o))`) so
+          Path→str and Enum→its `.value`.
+        - packages: {python, torch, lightning, numpy, pandas, scikit-learn, foundation-model}
+          via importlib.metadata.version (missing → "unknown")
+        - datetime_utc / datetime_local (ISO 8601)
+        - git: {commit, dirty} via subprocess `git rev-parse HEAD` / `git status --porcelain`
+          (repo not found → nulls, never raise)
+        - argv, seeds
+        Called at startup by EVERY fm subcommand."""
+
+    def save_step_checkpoint(self, step: int, task: str, model, active_tasks: list[str]) -> Path:
+        """training/stepNN_<task>/checkpoint.pt — {"model": state_dict, "task_sequence": [...],
+        "step": N, "new_task": task, "active_tasks": [...]} (exact schema from
+        continual_rehearsal_full.py L851–861 — note `step` is stored 1-based there — so old
+        checkpoints stay loadable)."""
+
+    def save_final_model(self, model, task_sequence: list[str], task_spec_dump: dict) -> Path:
+        """training/final_model.pt + training/final_model_taskconfigs.json. Legacy schema
+        (continual_rehearsal_full.py `_save_final_model` L891–908): final_model.pt =
+        {"model": state_dict, "task_sequence": [...]}; final_model_taskconfigs.json =
+        {task_name: {"kind": ..., "column": ..., "source": ...}}. Keep both so fm finetune /
+        fm inverse can consume either era of checkpoint."""
+
+    def dump_predictions(self, step_dir: Path, task: str, frame: pd.DataFrame) -> Path:
+        """<task>_pred.parquet — columns (composition, true, pred[, t]); scaler inverse already
+        applied by caller via TaskCatalog.inverse_transform."""
+
+    def dump_metrics(self, step_dir: Path, task: str, metrics: dict) -> Path:   # <task>_metrics.json
+    def save_figure(self, path_rel: str, fig) -> Path:                          # any matplotlib fig
+    def append_record(self, record: dict) -> None:                              # in-memory
+    def write_records(self) -> Path:        # training/experiment_records.json
+    def write_metrics_table(self) -> Path:  # training/metrics_table.csv (flat per-task table)
+```
+
+Checkpoint-loading helper (used by finetune/inverse/predict later, but lives here):
+
+```python
+def load_checkpoint_state(path: Path) -> dict:
+    """torch.load(map_location='cpu'); returns the raw dict. Accepts both the rehearsal schema
+    ({"model": ..., "task_sequence": ...}) and a bare state_dict (fm-trainer era) — normalize to
+    {"model": state_dict, "task_sequence": list|None, ...}."""
+```
+
+## C. Tests (colocated)
+
+`workflows/task_catalog_test.py`:
+- `build_task_catalog_config`: happy path from a TOML string (use `tomllib.loads`);
+  unknown key → ValueError; missing kind-conditional field (`t_column` for kr, `num_classes`
+  for clf) → ValueError; duplicate task names → ValueError; `task.dataset` not in `[datasets]`
+  → ValueError; replay validation (0 < float < 1 ok, int >= 1 ok, 0/negative → ValueError).
+- `TaskCatalog` with tiny synthetic parquet fixtures (tmp_path): frames are composition-keyed;
+  `min_elements` filter drops rows; `sample` caps rows; NaN targets preserved (masking is
+  downstream); `build_task_config` returns the right dataclass per kind; kernel init-from-data
+  produces finite centers/sigmas; `inverse_transform` round-trips with a fitted StandardScaler
+  and is identity when no scaler configured; precomputed descriptor path returns the stored
+  rows and `kmd()` is None; kmd descriptor is deterministic and cached (second call, same id
+  or equal frame).
+
+`workflows/recording_test.py`:
+- `write_provenance`: file exists; contains resolved config values, all package-version keys,
+  ISO datetime, argv, seeds; git fields present (null tolerated).
+- `save_step_checkpoint` / `save_final_model`: schema keys exact; reload via
+  `load_checkpoint_state` normalizes both new-schema and bare-state_dict inputs.
+- `dump_predictions` / `dump_metrics` / `write_records` / `write_metrics_table`: files appear
+  under the documented layout; parquet round-trips.
+
+## D. Acceptance
+
+- `pytest src/foundation_model/workflows/ -q` green; `ruff format` / `ruff check` / `mypy src` clean.
+- No changes to `pyproject.toml`, no legacy files touched.

--- a/docs/refactor_fm_cli/02_pr2_pretrain.md
+++ b/docs/refactor_fm_cli/02_pr2_pretrain.md
@@ -1,0 +1,199 @@
+# PR2 — `fm pretrain`: rehearsal engine + plots + CLI skeleton
+
+> Branch: `feat/fm-cli-pretrain`. Depends on: PR1. Read `00_OVERVIEW.md` first.
+>
+> **Source references verified against `master` @ 532a4aa.** Corrected line numbers and
+> migration-source divergences are folded in below.
+
+## A. Config schema (`[pretrain]` + shared sections)
+
+```toml
+[pretrain]
+task_sequence = ["density", "dos_density", "..."]   # ordered; empty/omitted → [[tasks]] order
+n_runs = 1
+task_order = "fixed"          # "fixed" | "random"  (random: reshuffle per run, seeded)
+
+[pretrain.rehearsal]
+interval = 1                  # every Nth step includes old tasks; other steps: new task + AE only
+default_replay = 0.05         # float < 1 → fraction of valid labels; int >= 1 → label count
+
+[pretrain.rehearsal.per_task]  # optional overrides (replaces fixed_tail/replay_ratio_high)
+formation_energy = 0.10
+tc = 500                      # count form
+```
+
+Dataclasses in `workflows/pretrain.py`:
+
+```python
+@dataclass(kw_only=True)
+class RehearsalConfig:
+    interval: int = 1                      # __post_init__: >= 1
+    default_replay: float | int = 0.05     # same validation as TaskSpec.replay
+    per_task: dict[str, float | int] = field(default_factory=dict)
+
+@dataclass(kw_only=True)
+class PretrainConfig:
+    catalog: TaskCatalogConfig
+    model: ModelSectionConfig              # latent_dim / encoder_hidden / head_hidden_dim / n_kernel
+    training: TrainingSectionConfig        # epochs, early-stop, lrs (incl. ae_lr), accelerator, devices, seed
+    rehearsal: RehearsalConfig
+    task_sequence: list[str] = field(default_factory=list)   # __post_init__: subset of catalog tasks
+    n_runs: int = 1
+    task_order: str = "fixed"              # enum TaskOrder(str, Enum): FIXED | RANDOM
+    output_dir: Path
+```
+
+`ModelSectionConfig` / `TrainingSectionConfig` are shared with finetune (PR3) — put them in
+`workflows/pretrain.py` for now if only used there, or a small `workflows/_sections.py` once
+PR3 needs them (do NOT create it preemptively in this PR unless finetune fields are certain).
+
+## B. Engine (`workflows/pretrain.py :: run(cfg: PretrainConfig)`)
+
+Migrate from `scripts/continual_rehearsal_full.py` `ContinualRehearsalFullRunner`
+(training `run()` **L773–889** — NOT L2065–2217, which is `_write_slide_prep_md`;
+`_build_empty_model` **L754**; `_evaluate_task` **L1001–1096**; per-step loop L789–867) with
+these changes. Note the legacy tiered replay this PR replaces: `fixed_tail` (default
+`DEFAULT_FIXED_TAIL` L202) + `replay_ratio` (0.05) + `replay_ratio_high` (0.10), selected at
+L794–803; today **every** already-learned task participates every step (`active =
+task_sequence[:step+1]`) — there is no interval gating, so the interval schedule is entirely new.
+
+1. **Multi-run sweep** (new, covers `dynamic_task_suite` / `progressive_clf` N-run design):
+   - `n_runs == 1`: outputs directly under `<output_dir>/` (`training/...`).
+   - `n_runs > 1`: `<output_dir>/runs/runNN/training/...`; run seed = `training.seed + NN`;
+     `task_order == "random"` reshuffles `task_sequence` per run with that seed
+     (log the realized order into the run's provenance + records).
+   - Cross-run aggregate: `<output_dir>/experiment_records.json` merging per-run records
+     (fields: run, step, new_task, epochs_run, per-task metrics) + a top-level provenance.
+2. **Per-step loop** (per run):
+   - `model.add_task(task_config)`; new task `masking_ratio = 1.0`.
+   - **Rehearsal interval**: on step `s` (1-based), old supervised tasks participate iff
+     `s % rehearsal.interval == 0`. Participating old tasks get their replay amount
+     (per-task override else default); **count form is converted to a ratio here** using the
+     task's number of valid (non-NaN) training labels: `ratio = min(1.0, count / n_valid)`.
+     Non-participating old tasks are **excluded from the datamodule entirely** (cheaper than
+     ratio=0). The AE head is always on.
+   - Train with `Trainer` + `EarlyStopping(monitor="val_final_loss", patience, min_delta)`
+     (verified: this is the exact legacy monitor string, `continual_rehearsal_full.py:814–820`);
+     `max_epochs` is the ceiling. **LR mechanism:** the model has no native
+     `encoder_lr/head_lr/kr_lr/ae_lr` split — `encoder_lr` maps to the model's
+     `shared_block_optimizer.lr` (which also carries `task_log_sigmas`), and every per-head LR
+     (head_lr / kr_lr / ae_lr, and any per-task `TaskSpec.lr` override) is realized by setting
+     that head config's `.optimizer = OptimizerConfig(lr=...)`. Assign these by head type when
+     building the configs. Reuse `_DropLastTrainCompoundDataModule` (`full.py:540`) if BatchNorm
+     size-1 tail batches still crash training.
+   - **Evaluate ALL learned heads every step** (regardless of interval) on the fixed test
+     split. The legacy `_evaluate_task` (L1001–1096) does **not** call `model.forward()`; it runs
+     a manual per-head path — `h = torch.tanh(model.encoder(x))`, then `model.task_heads[name](h)`
+     (reg/clf) or the KR path via the private `model._expand_for_kernel_regression`. Preserve
+     this (or switch to `model.forward()` and select the task from the returned dict) — but do
+     not silently change the numerics. Via `RunRecorder`: `<task>_pred.parquet` (scaler
+     inverse-transformed through `TaskCatalog.inverse_transform`), `<task>_metrics.json`, the
+     newest-head plot (parity / confusion / kr-sequences via `plots.py`), `checkpoint.pt`.
+     Metric definitions (keep legacy exactly): reg → `{r2, mae, samples, primary=r2}`; clf →
+     `{accuracy, macro_f1, samples, primary=accuracy}`; kr → `r2`+`mae` over flattened
+     (concatenated) sequences. **The legacy clf metrics dict does NOT include confusion counts**
+     (confusion is plot-only). If you want confusion counts in the JSON, add them as a *new*
+     field and say so in the PR — do not describe it as "legacy".
+3. **Post-run artifacts**: `forgetting_trajectory.png` (per-step × per-task primary metric),
+   `experiment_records.json`, `metrics_table.csv`, `final_model.pt` +
+   `final_model_taskconfigs.json` (schemas from PR1 recorder). The forgetting plot is currently
+   `ContinualRehearsalFullRunner._plot_forgetting` (`continual_rehearsal_full.py:1686`), a
+   **bound method that depends on `self._task_colors` and `self.training_dir`** — migrating it
+   into `plots.py` means refactoring those `self` dependencies into plain parameters (task→color
+   map + data in, figure out).
+4. Keep `_DropLastTrainCompoundDataModule` behaviour if migrating it (check whether
+   drop_last is still needed; if yes, move it into `workflows/pretrain.py` as a private class).
+
+## C. `workflows/plots.py`
+
+Migrate the pure plotters from `scripts/continual_rehearsal_common.py`: `plot_parity` (L140),
+`plot_confusion` (L173, matplotlib, row-normalized, has a `special_material_type` flag),
+`plot_kr_sequences` (L240), `plot_element_frequency_heatmap` (L305); plus constants
+`SCATTER_COLOR` (L50), `DISCOVERED_ELEMENT_COLOR`, `MATERIAL_TYPE_CLASSES`,
+`MATERIAL_TYPE_DISPLAY_ORDER`. Two corrections vs. the original draft:
+
+- **The forgetting plot is NOT in `common.py`** — it lives in `continual_rehearsal_full.py:1686`
+  as a `self`-dependent method (see §B.3); migrate it from there, not from `common.py`.
+- **`common.py` does not currently call `matplotlib.use("Agg")`** (it's set in
+  `continual_rehearsal_full.py:54`). Adding `matplotlib.use("Agg")` at the top of `plots.py` is a
+  new line, not a migration — do it anyway (headless-safe).
+
+`multi_task_progressive_clf.py` has **no reusable** confusion/report function — its rendering is
+**inline inside `_run_finetune_eval`** and uses `seaborn.heatmap`. There are therefore two
+different confusion renderers (matplotlib `common.plot_confusion` vs. seaborn inline). **Pick
+the matplotlib `plot_confusion` as canonical** (avoids adding a seaborn dependency to the
+workflows layer); fold the classification-report JSON writing (`sklearn.classification_report`,
+`output_dict=True`) into the recorder/metrics path rather than into `plots.py`.
+
+Pure functions: take data + return/write a matplotlib figure; no file-layout knowledge (paths
+come from the recorder).
+
+## D. `cli/main.py` + packaging
+
+Use [`click`](https://click.palletsprojects.com/) (add `click>=8.1` to `pyproject.toml`
+dependencies in this PR). One `fm` group + one subcommand per workflow:
+
+```python
+# src/foundation_model/cli/main.py
+import click
+
+@click.group()
+def main() -> None:
+    """Unified foundation-model CLI."""
+
+def common_options(f):
+    """Shared decorator: --config (required), --output-dir, --set (multiple), --seed,
+    --accelerator, --sample. Applied to every subcommand."""
+    for opt in reversed([
+        click.option("--config", "config_path", required=True, type=click.Path(exists=True, dir_okay=False)),
+        click.option("--output-dir", default=None),
+        click.option("--set", "overrides", multiple=True, metavar="SECTION.KEY=VALUE"),
+        click.option("--seed", type=int, default=None),
+        click.option("--accelerator", default=None),
+        click.option("--sample", type=int, default=None),
+    ]):
+        f = opt(f)
+    return f
+
+@main.command("pretrain")
+@common_options
+def pretrain_cmd(config_path, output_dir, overrides, seed, accelerator, sample):
+    ...   # PR3-5 add finetune/inverse/predict commands the same way
+```
+
+- Common options on every subcommand: `--config <path>` (required), `--output-dir`,
+  `--set section.key=value` (repeatable via `multiple=True`; value parsed with `tomllib`
+  semantics — `tomllib.loads(f"_={value}")["_"]`), `--seed`, `--accelerator`, `--sample`
+  (maps to all datasets' `sample`).
+- Flow per subcommand: `tomllib.load` → apply `--set`/flag overrides onto the raw tree →
+  `build_*_config` → `RunRecorder(root)` → `write_provenance(...)` → `workflows.<mod>.run(cfg)`.
+  Keep the command body THIN — a helper `_load_and_override(config_path, overrides, **flags)`
+  shared across subcommands is fine; no business logic in `cli/`.
+- `pyproject.toml`: add `fm = "foundation_model.cli.main:main"` (click groups are directly
+  usable as console-script entry points). **Do not remove** the legacy entries yet (PR6).
+
+## E. Tests
+
+`workflows/pretrain_test.py`:
+- Config: interval < 1 → ValueError; `task_sequence` containing unknown task → ValueError;
+  `task_order` invalid → ValueError; per_task replay referencing unknown task → ValueError.
+- Replay math: count→ratio conversion (count > n_valid clamps to 1.0; fraction passes through).
+- Interval schedule: with interval=2 and 4 tasks, the participating-task sets per step are
+  exactly {t1}, {t2,+old}, {t3}, {t4,+old} (pure function — factor the schedule computation
+  into a testable helper, e.g. `active_old_tasks(step, learned, interval)`).
+- Random order: same seed → same permutation; different runs → logged orders differ.
+- Smoke: 2 tiny synthetic tasks (20 rows, kmd n_grids=4, latent_dim=8, max_epochs=1, cpu)
+  end-to-end; assert output layout (step dirs, parquet, metrics json, checkpoints,
+  final_model.pt, experiment_records.json, forgetting png, run_provenance.json).
+
+`workflows/plots_test.py`: each plot function renders on synthetic input without error and
+writes a file (smoke-level; migrate relevant cases from `continual_rehearsal_common_test.py`).
+
+`cli/main_test.py`: `--set training.max_epochs=3` overrides the TOML value in the built config;
+unknown subcommand exits non-zero; `--config` missing file → clear error.
+
+## F. Acceptance
+
+- `fm pretrain --config samples/pretrain_smoke.toml` (add this sample: 2–3 tasks, kmd,
+  `sample=200`, `interval=2`, `n_runs=2`, `max_epochs=2`) completes on CPU.
+- Full `pytest` / `ruff` / `mypy src` green. Legacy entry points untouched and still working.

--- a/docs/refactor_fm_cli/03_pr3_finetune.md
+++ b/docs/refactor_fm_cli/03_pr3_finetune.md
@@ -1,0 +1,117 @@
+# PR3 — `fm finetune`: freeze policy + finetune engine
+
+> Branch: `feat/fm-cli-finetune`. Depends on: PR2. Read `00_OVERVIEW.md` first.
+>
+> **Source references verified against `master` @ 532a4aa.** Corrected line numbers and
+> source-attribution fixes are folded in below.
+
+## A. Config schema
+
+```toml
+[finetune]
+checkpoint = "artifacts/run/training/final_model.pt"   # or --checkpoint flag
+tasks = ["formation_energy", "klat", "material_type"]  # heads to train (must be in [[tasks]])
+epochs = 20
+# freeze_encoder = true      # default true; expose for completeness (suite always froze it)
+# add_new_tasks = true       # default true: tasks not present in the checkpoint are added via
+#                            # model.add_task() before training (downstream-finetune use case)
+```
+
+```python
+@dataclass(kw_only=True)
+class FinetuneConfig:
+    catalog: TaskCatalogConfig
+    model: ModelSectionConfig
+    training: TrainingSectionConfig
+    checkpoint: Path
+    tasks: list[str]                     # __post_init__: non-empty, all in catalog
+    epochs: int = 20
+    freeze_encoder: bool = True
+    add_new_tasks: bool = True
+    output_dir: Path
+```
+
+If PR2 kept `ModelSectionConfig`/`TrainingSectionConfig` local to `pretrain.py`, move them now
+to `workflows/_sections.py` (shared vocabulary module) and update imports.
+
+## B. Engine (`workflows/finetune.py :: run(cfg)`)
+
+Sources to migrate/replace:
+
+| Legacy | What to take |
+|---|---|
+| `scripts/finetune_inverse_heads.py` `freeze_except` (**L44–67**) + `finetune()` (**L76–164**) | freeze bookkeeping, disable/re-enable of non-target heads (`disable_task`/`enable_task`), save flow. **Caveat:** this file loads with `load_state_dict` at **strict (default `True`)** and **errors on missing heads — it does NOT `add_task`**. |
+| `scripts/dynamic_task_suite.py` `_run_finetune_stages` (**L353–427**) | frozen-encoder finetune pattern **and** the `load_from_checkpoint(strict=False, freeze_shared_encoder=...)` + `add_task` behaviour this PR wants. NOTE it `remove_tasks(*all)` then adds a *single* head (so its checkpoint holds only that head) and writes **no** metrics.json (only a `records` list + prediction plots). |
+| `scripts/multi_task_progressive_clf.py` `_run_finetune_eval` (**L576–742**) | clf finetune (`strict=False` + `add_task(deepcopy(clf_cfg))`) + confusion matrix (seaborn) / classification report (`clf_report_all.json`, `clf_report_ge4.json`, `metrics.json`). |
+
+> Source-attribution fix: the `strict=False` + `add_task` design in the flow below comes from
+> `_run_finetune_stages` / `_run_finetune_eval`, **not** from `finetune_inverse_heads` (which is
+> strict + no add_task). Take the *disable/re-enable-then-save* pattern from
+> `finetune_inverse_heads` and the *strict=False + add_task* pattern from the suite/clf scripts.
+
+Flow:
+
+1. Rebuild the full model from `TaskCatalog` (all checkpoint tasks + AE), load
+   `load_checkpoint_state(...)["model"]` with `load_state_dict(strict=False)` (log
+   missing/unexpected keys at INFO).
+2. If `add_new_tasks` and some `finetune.tasks` are absent from the checkpoint's task set:
+   `model.add_task(...)` for them (this is how progressive-clf attaches the clf head). If
+   `add_new_tasks=False` and a requested head is missing → raise, listing the missing heads.
+3. **Freeze policy** (rewrite of `freeze_except`, adapted — note the AE change). Attribute names
+   (verified): encoder is `model.encoder` (backbone `model.encoder.shared`); heads live in the
+   `nn.ModuleDict` **`model.task_heads`** (there is no `model.heads`); disabled heads move to
+   `model.disabled_task_heads`; loss-balancer weights are `model.task_log_sigmas`
+   (`nn.ParameterDict`). The AE head is keyed by the reserved literal **`"__reconstruction__"`**
+   (no `ae_head` attribute, no shared constant today — consider extracting one).
+   - `freeze_encoder=True` → `for p in model.encoder.parameters(): p.requires_grad_(False)`.
+   - Every task head in `model.task_heads` NOT in `finetune.tasks` → `requires_grad_(False)`,
+     **except `"__reconstruction__"` which always stays trainable** (LR = `training.ae_lr`).
+     ← intentional behaviour change vs `finetune_inverse_heads` (which froze AE); owner-confirmed.
+   - `model.task_log_sigmas` → freeze every scalar `requires_grad_(False)` (weights must not
+     drift). **Note:** `task_log_sigmas` are optimized by the encoder/"main" optimizer group
+     (`shared_block_optimizer`), not a per-head one — freezing `requires_grad` is sufficient (no
+     grad flows), but if `freeze_encoder=True` also skips building the main optimizer, ensure the
+     AE head still gets an optimizer (see §B.5 LR note).
+   - Return + log a `{param_name: requires_grad}` snapshot into the records for provenance.
+4. Datamodule: only `finetune.tasks` (+ AE input) active, `masking_ratio=1.0` for all; other
+   heads disabled for the fit via `model.disable_task(*others)` then restored via
+   `model.enable_task(*others)` before saving (mirror `finetune_inverse_heads` L102–105 /
+   L135–137 so the saved state_dict keeps every head). Do **not** use the suite/clf
+   `remove_tasks(*all)+add_task(one)` pattern here — that would drop heads from the checkpoint.
+5. Train `epochs` with `Trainer` (EarlyStopping optional — reuse `training.early_stop_*`;
+   `epochs` acts as the ceiling). **LR-split mechanism (verified):** the model has **no** native
+   `encoder_lr`/`head_lr`/`kr_lr`/`ae_lr` concept. `configure_optimizers` (L1318–1399) builds one
+   "main" optimizer for the encoder + learnable `task_log_sigmas` using
+   `model.shared_block_optimizer` (an `OptimizerConfig`), and one optimizer per head from that
+   head's `config.optimizer or OptimizerConfig()`. So the 4-way LR split must be realized by:
+   encoder_lr → `shared_block_optimizer.lr`; and per-head LR (head_lr / kr_lr / ae_lr, plus any
+   `TaskSpec.lr` override) → set each head config's `.optimizer = OptimizerConfig(lr=...)` by head
+   type when `TaskCatalog.build_task_config` builds it / when the AE head is created. The AE head
+   (`"__reconstruction__"`) must receive `OptimizerConfig(lr=training.ae_lr)`.
+6. Evaluate the finetuned heads (plus optionally all heads) on the test split; dump
+   parquet + metrics + parity/confusion plots via `RunRecorder`; write
+   `final_model.pt` + `finetune_summary.json` (heads, epochs run, frozen-param counts,
+   before/after metrics).
+
+## C. CLI
+
+Add an `fm finetune` click command to `cli/main.py` (reuse `common_options`): + `--checkpoint`,
+`--tasks a,b,c` (comma list overriding `finetune.tasks`), `--epochs`.
+
+## D. Tests (`workflows/finetune_test.py`)
+
+- Freeze policy on a tiny 3-task model: target head trainable; non-target heads frozen;
+  **AE head `requires_grad=True`**; `task_log_sigmas` frozen; encoder frozen;
+  `freeze_encoder=False` leaves encoder trainable.
+- `add_new_tasks`: checkpoint without the clf head + `tasks=["clf"]` → head added and trained;
+  `add_new_tasks=False` + missing head → ValueError.
+- Config validation: empty `tasks` → ValueError; task not in catalog → ValueError.
+- Smoke: pretrain-smoke checkpoint (reuse PR2 fixture helper) → finetune 1 head 1 epoch on CPU
+  → `final_model.pt` loadable, `finetune_summary.json` schema, provenance file present.
+- Regression guard: saved state_dict contains ALL heads (disable/re-enable round-trip).
+
+## E. Acceptance
+
+- `fm finetune --config samples/finetune_smoke.toml --checkpoint <pretrain-smoke ckpt>`
+  completes on CPU (add the sample config).
+- `pytest` / `ruff` / `mypy src` green. Legacy entries untouched.

--- a/docs/refactor_fm_cli/04_pr4_inverse.md
+++ b/docs/refactor_fm_cli/04_pr4_inverse.md
@@ -1,0 +1,219 @@
+# PR4 — `fm inverse`: scenario × path inverse-design engine
+
+> Branch: `feat/fm-cli-inverse`. Depends on: PR2 (PR3 only needed for the e2e chain).
+> Read `00_OVERVIEW.md` first.
+>
+> **Source references verified against `master` @ 532a4aa.** The original draft predates commit
+> `e5cca4a` (#20, cardinality cap): `DEFAULT_PATHS` is now **11**, not 8, and `PathConfig` needs
+> two extra fields to represent the newest path. Corrections folded in below.
+
+## A. Config schema
+
+```toml
+[inverse]
+checkpoint = "artifacts/run/finetune/final_model.pt"
+steps = 300
+lr = 0.05
+class_weight = 5.0            # QC/classification primary-objective weight
+record_trajectory = true
+per_seed_trajectories = false
+animation_formats = ["gif"]   # subset of {gif, html, svg}; [] = none
+
+[inverse.seeds]
+strategy = "top_qc"           # "top_qc" | "random" | "explicit"
+n = 20
+split = "test"                # which datamodule split to draw candidates from
+explicit = []                 # used when strategy == "explicit"
+explicit_append = ["Au65 Ga20 Gd15", "Au65 Ga20 Tb15", "Au65 Ga20 Ho15"]
+dedup_by_element_system = true
+
+[[inverse.scenarios]]
+name = "scenario1_fe_down_moment_up"
+reg_tasks = ["formation_energy", "magnetic_moment"]
+reg_targets = [-2.0, 2.0]
+# primary classification objective is implicit: material_type → QC class (keep legacy default,
+# but expose:)
+# class_task = "material_type"
+# class_target = 2
+
+[[inverse.paths]]             # omit the whole array → DEFAULT_PATHS (the 11 legacy paths)
+name = "latent_align1"
+method = "latent"             # "latent" | "composition"
+ae_align_scale = 1.0
+
+[[inverse.paths]]
+name = "comp_seed_5all_elemlist_k5"
+method = "composition"
+init = "seed"                 # "seed" | "random"
+seed_blend = 0.95
+allowed_elements = ["Al", "Ti", "..."]   # or "all"; default palette constant exported
+diversity_scale = 1.0
+max_elements = 5              # optional cardinality cap
+# element_step_scale = 1.0    # float or {element: float}
+# fixed_amounts = {}          # {element: fraction} pinned during optimization
+```
+
+```python
+@dataclass(kw_only=True)
+class SeedConfig: ...          # fields above; __post_init__: strategy enum, n >= 1,
+                               # strategy=="explicit" requires non-empty explicit
+
+@dataclass(kw_only=True)
+class ScenarioConfig:
+    name: str
+    reg_tasks: list[str]
+    reg_targets: list[float]   # __post_init__: same length as reg_tasks, non-empty
+    class_task: str = "material_type"
+    class_target: int | None = None   # None → legacy QC default
+
+@dataclass(kw_only=True)
+class PathConfig:
+    name: str
+    method: str                       # enum InverseMethod: LATENT | COMPOSITION
+    # latent:
+    ae_align_scale: float = 0.5
+    # composition:
+    init: str = "seed"                # "seed" | "random"
+    n_starts: int | None = None       # random init uses n_starts=len(seeds) in the legacy path;
+                                      # None → default to len(seeds) at call time
+    seed_blend: float = 0.95
+    allowed_elements: list[str] | str = "all"
+    diversity_scale: float = 1.0
+    max_elements: int | None = None
+    element_step_scale: float | dict[str, float] = 1.0
+    fixed_amounts: dict[str, float] = field(default_factory=dict)
+    # annealing (needed to represent DEFAULT_PATHS path #8 "K=5, linear"):
+    annealing_scale: float = 0.5      # optimize_composition default is 0.5
+    annealing_schedule: dict[str, Any] | None = None
+    # __post_init__: reject latent-only keys on composition paths and vice versa (explicitly
+    # set non-default values on the wrong method → ValueError; keeps configs honest)
+
+@dataclass(kw_only=True)
+class InverseConfig:
+    catalog: TaskCatalogConfig
+    model: ModelSectionConfig
+    checkpoint: Path
+    seeds: SeedConfig
+    scenarios: list[ScenarioConfig]   # __post_init__: >= 1, unique names
+    paths: list[PathConfig]           # empty → DEFAULT_PATHS
+    steps: int = 300
+    lr: float = 0.05
+    class_weight: float = 5.0
+    record_trajectory: bool = True
+    per_seed_trajectories: bool = False
+    animation_formats: list[str] = field(default_factory=lambda: ["gif"])
+    output_dir: Path
+```
+
+`DEFAULT_PATHS`: **11** legacy paths = 3 latent + 8 composition. Sources in
+`scripts/paper_inverse_comparison.py`: `LATENT_ALIGN_SCALES` (**L203** = `[0.0, 0.25, 1.0]`) and
+`COMPOSITION_CONFIGS` (**L137–202**). Export the alloy palette constant (`DEFAULT_ALLOY_PALETTE`,
+`paper_inverse_comparison.py:80–132`, asserted length **48**) from `workflows/inverse.py`.
+
+Exact kwargs (regression-test these — hardcode expected values):
+
+Latent (`ae_align_scale` = each of): `0.0`, `0.25`, `1.0`.
+
+Composition (`P` = `DEFAULT_ALLOY_PALETTE`; unlisted fields = the `optimize_composition` default):
+
+| # | label | init | seed_blend | allowed_elements | element_step_scale | diversity_scale | extra |
+|---|---|---|---|---|---|---|---|
+| 1 | seed | seed | 1.0 | all | 1.0 | 1.0 | — |
+| 2 | seed, 5% all | seed | 0.95 | all | 1.0 | 1.0 | — |
+| 3 | seed, 5% all, element list | seed | 0.95 | P | 1.0 | 1.0 | — |
+| 4 | seed, list, low diversity | seed | 0.95 | P | 1.0 | 0.0 | — |
+| 5 | random | random | 0.95 | all | 1.0 | 1.0 | `n_starts=len(seeds)` |
+| 6 | seed, list, K=3 | seed | 0.95 | P | 1.0 | 1.0 | `max_elements=3` |
+| 7 | seed, list, K=5 | seed | 0.95 | P | 1.0 | 1.0 | `max_elements=5` |
+| 8 | seed, list, K=5, linear | seed | 0.95 | P | 1.0 | 1.0 | `max_elements=5`, `annealing_scale=0.715`, `annealing_schedule={"step":[1.0],"scale":[0.0],"annealing_func":["linear"]}` |
+
+`fixed_amounts` is exposed by `optimize_composition` but **no legacy DEFAULT_PATH sets it** — it
+is new capability, keep the default empty.
+
+## B. Engine (`workflows/inverse.py :: run(cfg)`)
+
+Sources:
+
+| Legacy | What to take |
+|---|---|
+| `scripts/paper_inverse_comparison.py` `run()` (**L759–948**), `_run_composition_config` (**L1095**), figure builders | the per-path engine + comparison.png / element_frequency_heatmap.png / qc_vs_secondary_scatter.png / seed_to_optimized__*.png |
+| `scripts/eval_inverse_methods.py` `_run_latent_method` (**L105**), `_qc_prob` (**L58**), `_reg_preds` (**L65**), `_seed_weights_from_compositions`, `_format_weights`, `_decode_latent_path` | the latent path + QC-prob / regression-prediction helpers (these live **here**, not in `paper_inverse_comparison.py` — the comparison script imports them). Its own CLI (`evaluate`/`main`) is unused elsewhere → absorb the helpers, drop the CLI. |
+| `scripts/paper_inverse_3scenarios.py` (`main` **L110**, scenario.json **L149–161**) | per-scenario loop + `<output>/<scenario>/` isolation (`dataclasses.replace` per scenario, calls the comparison `run`) |
+| seed selection: `scripts/continual_rehearsal_demo.py` `_select_seeds` (**L857**, flat `list[str]` — the one the paper engine actually invokes via `ContinualRehearsalRunner`) or `scripts/continual_rehearsal_full.py` `_select_seeds` (**L1133**, dict-returning) | top-QC seed selection with element-system dedup + explicit-append budget. Pick the demo variant to match current paper behaviour; note it is NOT at ~L2375. |
+| `scripts/continual_rehearsal_full.py` `run_inverse_only` (**L910**, exact) | replaced by `fm inverse` itself (checkpoint in, results out). The demo runner also has one (`continual_rehearsal_demo.py:627`). |
+
+Flow per scenario:
+
+1. Rebuild model from `TaskCatalog` + `load_checkpoint_state` (`strict=False`); validate that
+   every `reg_task` and the `class_task` have heads in the checkpoint — fail loudly listing
+   missing heads.
+2. Select seeds once per run (not per scenario) per `SeedConfig`; write `seeds.json` at root.
+3. For each path: dispatch on method (both signatures verified —
+   `optimize_latent` @ `flexible_multi_task_model.py:1742`, `optimize_composition` @ `:2234`; all
+   plan kwarg names are correct) —
+   `model.optimize_latent(..., optimize_space="latent", ae_align_scale=..., task_targets=...,
+   class_targets=..., steps, lr, record_input_trajectory=record_trajectory)` or
+   `model.optimize_composition(kmd_kernel, initial_weights=..., n_starts=..., seed_blend=...,
+   allowed_elements=..., diversity_scale=..., max_elements=..., element_step_scale=...,
+   fixed_amounts=..., annealing_scale=..., annealing_schedule=..., steps, lr,
+   record_weights_trajectory=...)`. **`kmd_kernel` is the positional first arg** — legacy passes
+   `runner._kmd.kernel_torch(...)` built from `catalog.kmd()`. Pass `n_starts=len(seeds)` for the
+   random-init path and `annealing_scale`/`annealing_schedule` for path #8.
+   Note the model's own defaults differ between the two (`optimize_latent`: `steps=200, lr=0.1`;
+   `optimize_composition`: `steps=300, lr=0.05`) — the `InverseConfig` defaults (300 / 0.05) are
+   passed explicitly to both, so pass them, don't rely on the method defaults.
+   Composition method requires `catalog.kmd()` — `descriptor.kind == "precomputed"` + a
+   composition path → ValueError at config-build time.
+4. Outputs per scenario dir: `scenario.json`, `results.json` (raw per-seed arrays per path),
+   `summary.json` + `SUMMARY.md` (per-path mean/std table), `comparison.png`,
+   `element_frequency_heatmap.png` (discovered elements highlighted),
+   `qc_vs_secondary_scatter.png`, `seed_to_optimized__<path>.png`, `targets.json`.
+   Legacy figure builders to migrate: `_plot_comparison` (**L218** → comparison.png),
+   `plot_element_frequency_heatmap` (imported from `continual_rehearsal_common` →
+   element_frequency_heatmap.png), `_plot_qc_vs_reg_scatter` (**L573** →
+   qc_vs_secondary_scatter.png), `_plot_seed_to_optimized_mapping` (**L426** →
+   `seed_to_optimized__<slug>.png`, note the double underscore). **This is a proposed layout, not
+   a straight copy:** the legacy `run()` does NOT write `scenario.json`, `summary.json`, or
+   `targets.json` — it embeds the summary under `results.json["summary"]` and writes
+   `final_model.pt` + `SUMMARY.md`. `scenario.json` comes from `paper_inverse_3scenarios.py`
+   (L149–161). Adding the split-out JSONs is fine; flag it as new in the PR.
+5. Trajectories: keep the `.npz` raw dumps + static/animated outputs; per-seed layout behind
+   `per_seed_trajectories`.
+6. Root outputs: `seeds.json`, `inverse_design.json` (nested all-scenario dump),
+   cross-scenario `SUMMARY.md`, `run_provenance.json`, `run.log`.
+   **Do NOT migrate** SLIDE_PREP.md / ANALYSIS.md / README.md auto-writers — dropped by design.
+
+## C. `workflows/inverse_trajectory.py`
+
+Rename-move of `scripts/paper_inverse_trajectory.py` (pure helpers:
+`best_seed_by_target_distance`, `normalize_target_trajectories`, `plot_trajectory_static`,
+`plot_trajectory_animation`). Migrate its colocated test as
+`workflows/inverse_trajectory_test.py`.
+
+## D. CLI
+
+Add an `fm inverse` click command (reuse `common_options`): + `--checkpoint`, `--scenario NAME`
+(`multiple=True` filter: run only the named scenarios), `--steps`, `--no-trajectory`,
+`--animation-formats`.
+
+## E. Tests (`workflows/inverse_test.py`)
+
+- Config validation: reg_tasks/reg_targets length mismatch; empty scenarios; duplicate
+  scenario names; latent kwargs on composition path (and vice versa) → ValueError;
+  precomputed descriptor + composition path → ValueError; `animation_formats` outside
+  {gif,html,svg} → ValueError.
+- `DEFAULT_PATHS`: exactly **11** (3 latent + 8 composition), kwargs equal to the §A table
+  (regression test — hardcode expected values, including path #8's `annealing_scale=0.715` and
+  `annealing_schedule`).
+- Path→model-kwargs mapping: a `PathConfig` produces the exact `optimize_latent` /
+  `optimize_composition` call kwargs (use a stub model recording calls).
+- Seed selection: top-QC dedup keeps one composition per element system; explicit_append
+  reduces the strategy budget; strategy="explicit" uses the given list verbatim.
+- Smoke: stub/tiny model + 2 seeds + steps=2, one latent + one composition path, one scenario
+  → full per-scenario file set exists, results.json schema sane.
+
+## F. Acceptance
+
+- `fm inverse --config samples/inverse_smoke.toml --checkpoint <smoke ckpt>` completes on CPU
+  (add the sample: 1 scenario, 2 paths, steps=5, n seeds=4, animations=[]).
+- `pytest` / `ruff` / `mypy src` green. Legacy entries untouched.

--- a/docs/refactor_fm_cli/05_pr5_predict.md
+++ b/docs/refactor_fm_cli/05_pr5_predict.md
@@ -1,0 +1,81 @@
+# PR5 — `fm predict`: arbitrary-checkpoint evaluation & prediction
+
+> Branch: `feat/fm-cli-predict`. Depends on: PR2. Read `00_OVERVIEW.md` first.
+> Replaces `fm-trainer`'s `validate` / `test` / `predict` subcommands.
+>
+> **Source references verified against `master` @ 532a4aa.** `predict_idx` /
+> `predict_compositions` mechanics confirmed; metric-source and strict=False caveats folded in.
+
+## A. Config schema
+
+```toml
+[predict]
+checkpoint = "artifacts/run/training/final_model.pt"
+tasks = []                    # empty → every head present in the checkpoint
+split = "test"                # "train" | "val" | "test" | "all"
+# compositions = ["Fe2O3", "..."]   # explicit list; overrides split when given
+with_metrics = true           # compute metrics when true targets exist (validate/test use case)
+```
+
+```python
+@dataclass(kw_only=True)
+class PredictConfig:
+    catalog: TaskCatalogConfig
+    model: ModelSectionConfig
+    checkpoint: Path
+    tasks: list[str] = field(default_factory=list)
+    split: str = "test"                       # enum; ignored when compositions given
+    compositions: list[str] = field(default_factory=list)
+    with_metrics: bool = True
+    output_dir: Path
+```
+
+## B. Engine (`workflows/predict.py :: run(cfg)`)
+
+1. Rebuild model from `TaskCatalog`, `load_checkpoint_state` + `load_state_dict(strict=False)`
+   (log missing/unexpected keys at INFO). NOTE: the legacy `StrictFalseLightningCLI`
+   (`scripts/train.py:18–22`) is **dead code** — `cli_main()` wires the base `LightningCLI`
+   (L34), so the strict=False behaviour is intent, not an active legacy path. Implement it fresh
+   here rather than trying to "preserve" a code path that isn't used.
+2. Resolve the prediction set: `split` via the datamodule's split column / random-split overlay
+   (reuse `CompoundDataModule` `predict_idx` mechanics — literal split name or explicit
+   composition sequence, exposed as `datamodule.predict_compositions`).
+3. Batch-predict all requested heads; per task write `<task>_pred.parquet`
+   (composition, pred[, true][, t]) with scaler inverse-transform applied via
+   `TaskCatalog.inverse_transform`.
+4. `with_metrics` and true targets available → `<task>_metrics.json` + a flat `metrics_table.csv`.
+   **There is no single canonical "pretrain eval" metrics module to import.** Use the same metric
+   *definitions* as the PR2 `RunRecorder`/`_evaluate_task` path (reg `{r2, mae}`; clf
+   `{accuracy, macro_f1}`; kr `r2`+`mae` over flattened sequences). The closest legacy reference
+   is the inline block in `dynamic_task_suite.py:721–742` (`samples/mae/mse/rmse/r2`), but it
+   **drops None rows** — this PR instead requires NaN/missing targets **masked out, not dropped**
+   (a composition with a NaN target still appears in the parquet with `true=NaN`, just excluded
+   from the metric). Re-implement; do not import the legacy block.
+5. Provenance as everywhere: `run_provenance.json` + `run.log`.
+
+Note: single-device only for this refactor. The legacy distributed gather in
+`dynamic_task_suite` / `callbacks/prediction_writer.py` is NOT migrated (out of scope; the
+unused callback is deleted in PR6). If multi-GPU predict is needed later it is a separate task.
+
+## C. CLI
+
+Add an `fm predict` click command (reuse `common_options`): + `--checkpoint`, `--tasks a,b,c`,
+`--split`, `--compositions "Fe2O3,BaTiO3"` (comma list), `--no-metrics`.
+
+## D. Tests (`workflows/predict_test.py`)
+
+- Config: invalid split → ValueError; unknown task name → ValueError; compositions + split
+  both given → compositions wins (documented behaviour).
+- Smoke: pretrain-smoke checkpoint → predict on `split="test"`; parquet exists per head,
+  metrics json has finite values; explicit `compositions=[...]` returns exactly those rows in
+  order; head absent from checkpoint but requested → clear error listing available heads.
+- Scaler round-trip: task with a configured scaler produces inverse-transformed predictions
+  (compare against manual `scaler.inverse_transform`).
+- Masked targets: composition with NaN target appears in parquet with `true=NaN` and is
+  excluded from metrics.
+
+## E. Acceptance
+
+- `fm predict --config samples/predict_smoke.toml --checkpoint <smoke ckpt>` completes on CPU
+  (add the sample).
+- `pytest` / `ruff` / `mypy src` green. Legacy entries untouched.

--- a/docs/refactor_fm_cli/06_pr6_cleanup.md
+++ b/docs/refactor_fm_cli/06_pr6_cleanup.md
@@ -1,0 +1,119 @@
+# PR6 — Cleanup: delete legacy code, configs, docs; update project docs
+
+> Branch: `chore/fm-cli-cleanup`. Depends on: PR2–PR5 merged.
+>
+> **Delete list verified against `master` @ 532a4aa.** All named files exist. Two orphans the
+> original draft missed (`samples/cli_examples/`, `samples/configs/`) and the omegaconf/jsonargparse
+> dep reality are folded in below.
+> Before starting, run the full functional-coverage checklist in `00_OVERVIEW.md` §6 and the
+> end-to-end acceptance chain in §7 — this PR must not land if any item fails.
+
+## A. Delete — `src/foundation_model/scripts/`
+
+| File | Also delete |
+|---|---|
+| `train.py` | — |
+| `dynamic_task_suite.py` | `dynamic_task_suite_test.py` |
+| `multi_task_progressive_clf.py` | — |
+| `continual_rehearsal_demo.py` | `continual_rehearsal_demo_test.py` |
+| `continual_rehearsal_full.py` | `continual_rehearsal_full_test.py` |
+| `continual_rehearsal_common.py` | `continual_rehearsal_common_test.py` (cases already migrated to `workflows/plots_test.py` in PR2 — verify before deleting) |
+| `finetune_inverse_heads.py` | `finetune_inverse_heads_test.py` |
+| `paper_inverse_comparison.py` | `paper_inverse_comparison_test.py` |
+| `paper_inverse_3scenarios.py` | — |
+| `paper_inverse_trajectory.py` | `paper_inverse_trajectory_test.py` (migrated in PR4 — verify) |
+| `eval_inverse_methods.py` | — |
+| `callbacks/prediction_writer.py` | delete `callbacks/` entirely if nothing else remains |
+
+If `scripts/` ends up empty (check `__init__.py`), remove the package and any references.
+Before each deletion, grep the repo for imports of the module (`grep -r "scripts.<name>"`) —
+notebooks may import them; notebook references get a one-line note in the PR description, not
+a code fix (notebooks are non-critical per AGENTS.md).
+
+## B. Delete — repo root & samples & docs
+
+Root shell wrappers (all 6 exist):
+- `run_dynamic_task_suite.sh`, `run_dynamic_task_suite_radonpy.sh`,
+  `run_dynamic_task_suite_retrain_source.sh`, `run_progressive_clf.sh`,
+  `run_continual_rehearsal_demo.sh`, `run_continual_rehearsal_full.sh`
+- `REFACTOR_composition_datamodule_PLAN.md` (stale plan). **`compare_input_vs_latent.py` — KEEP**
+  (verified: it imports only `foundation_model.models.flexible_multi_task_model` +
+  `foundation_model.models.model_config`, none of the deleted script modules, so it is standalone).
+
+`samples/` — delete all legacy configs:
+- `dynamic_task_suite_config*.toml` (4: base, `_free`, `_radonpy`, `_smoke`),
+  `progressive_clf_config*.toml` (2), `continual_rehearsal_demo_config*.toml` (3: base, `_smoke`,
+  `_inverse_baseline`), `continual_rehearsal_full_config.toml`, `example_config.yaml`
+
+`samples/` — **two orphaned subdirectories the original draft missed** (both reference the deleted
+`fm-trainer` / LightningCLI YAML and must be deleted or rewritten):
+- `samples/cli_examples/` — `01_basic_run.sh` (calls `fm-trainer fit/test/predict` 5×),
+  `02_config_override.sh`, `03_scaling_law_xargs.sh`. Delete, or rewrite against `fm` if the
+  worked examples are still wanted (owner's call — default: delete, README covers usage).
+- `samples/configs/test_t_depends_on_mac_pro/` — `fit_config.yaml`, `predict_config.yaml`,
+  `test_config.yaml` (LightningCLI YAML configs). Delete the whole directory.
+
+`samples/` — final set (created across PR2–5; verify all exist and run):
+- `pretrain.toml` (full 24-task formal run — port values from `continual_rehearsal_full_config.toml`)
+- `pretrain_smoke.toml`, `finetune.toml`, `finetune_smoke.toml`,
+  `inverse.toml` (3 scenarios, default paths), `inverse_smoke.toml`,
+  `predict.toml`, `predict_smoke.toml`
+
+`docs/` — delete stale (content superseded by the new workflows or PR history):
+- `continual_rehearsal_full_PLAN.md`, `trajectory_integration.md`,
+  `inverse_design_extension_notes.md`
+- Review individually and keep if still accurate as *results/method* docs (not script docs):
+  `inverse_design_algorithms.md`, `qc_inverse_design_summary.md` — update command references
+  to `fm inverse` if kept.
+- `docs/refactor_fm_cli/` (this plan) — keep until the refactor is fully merged, then the
+  owner decides; do not delete in this PR.
+
+## C. `pyproject.toml`
+
+```toml
+[project.scripts]
+fm = "foundation_model.cli.main:main"      # added in PR2 — now the ONLY entry
+# DELETE: fm-trainer, fm-pretrain-suite, fm-progressive-clf
+```
+
+Dependency cleanup — the original draft's "remove omegaconf / jsonargparse" is only half right
+(verified):
+- **`omegaconf`** is a *direct* dep (`pyproject.toml:14`, `omegaconf>=2.3.0`). Its only real code
+  use after this refactor is `scripts/train.py:39` (`parser_mode="omegaconf"`, deleted here) —
+  BUT `notebooks/interactive_model_test.ipynb` still does a real `from omegaconf import OmegaConf`.
+  Notebooks are non-critical per `AGENTS.md`, so either (a) drop the dep and note the notebook
+  breakage in the PR, or (b) keep the dep. Recommend (a) + a one-line PR note. Do **not** claim a
+  clean removal.
+- **`jsonargparse`** is **not** a declared dependency — it is transitive via
+  `lightning[pytorch-extra]` (`pyproject.toml:10`) and imported nowhere in `src/`. There is
+  nothing to remove; "remove jsonargparse from deps" is a no-op. If you want it gone from the
+  lockfile, drop the `[pytorch-extra]` extra (`lightning[pytorch-extra]` → `lightning`) and
+  re-run `uv sync` — but verify nothing else in the extra is needed first.
+
+## D. Update project docs
+
+- `AGENTS.md`: rewrite the **Entry Points** section (three scripts → one `fm` command with
+  four subcommands + config conventions); update Project Structure (add `cli/`, `workflows/`);
+  update any test-layout references.
+- `README.md`: user-facing usage — replace `fm-trainer`/suite examples with `fm pretrain` /
+  `fm finetune` / `fm inverse` / `fm predict` quick-start snippets pointing at `samples/`.
+  Keep README user-focused per repository-doc-boundaries rules.
+- `ARCHITECTURE.md`: add a short "Workflows & CLI" section describing the module boundaries
+  (`cli` thin dispatch / `task_catalog` / `recording` provenance / engines).
+- `.github/instructions/`: grep for references to deleted commands (e.g. rikyu doc mentions
+  `fm-trainer`, `fm-pretrain-suite`, `fm-progressive-clf` symlinks) and update the symlink
+  recipe to `fm`.
+
+Do NOT touch `artifacts/*/README.md` — they are historical run records; their stale commands
+stay as-is.
+
+## E. Acceptance
+
+1. `grep -rn "fm-trainer\|fm-pretrain-suite\|fm-progressive-clf\|continual_rehearsal\|paper_inverse\|finetune_inverse_heads\|dynamic_task_suite\|eval_inverse_methods"`
+   over `src/ samples/ docs/ README.md AGENTS.md ARCHITECTURE.md pyproject.toml *.sh` returns
+   only: historical `artifacts/` files, `docs/refactor_fm_cli/`, and git history.
+2. `uv sync --frozen --all-groups` then full `pytest`, `ruff format --check`, `ruff check`,
+   `mypy src` green.
+3. The §7 end-to-end smoke chain from `00_OVERVIEW.md` passes with the final sample configs.
+4. `fm --help` lists exactly four subcommands; the three legacy commands are gone from a fresh
+   `uv sync` environment.

--- a/src/foundation_model/workflows/__init__.py
+++ b/src/foundation_model/workflows/__init__.py
@@ -1,0 +1,9 @@
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Workflow engines behind the unified ``fm`` CLI.
+
+Each ``workflows.<name>.run(cfg)`` takes a validated config dataclass and executes one
+subcommand's flow. Only :mod:`foundation_model.workflows.recording` writes artifacts for the
+training/predict flows; the other modules hand it dataframes/dicts/figures.
+"""

--- a/src/foundation_model/workflows/recording.py
+++ b/src/foundation_model/workflows/recording.py
@@ -211,17 +211,21 @@ class RunRecorder:
 def load_checkpoint_state(path: Path) -> dict[str, Any]:
     """Load a checkpoint and normalize to ``{"model": state_dict, "task_sequence": list|None, ...}``.
 
-    Accepts both the rehearsal schema (``{"model": ..., "task_sequence": ...}``) and a bare
-    ``state_dict`` (fm-trainer era).
+    Accepts three shapes, in priority order:
+    1. the rehearsal schema — ``{"model": state_dict, "task_sequence": ...}``;
+    2. a Lightning checkpoint — ``{"state_dict": ..., "epoch": ..., ...}`` (fm-trainer era,
+       ``ModelCheckpoint`` output): the parameters live under ``state_dict``, so unwrap it;
+    3. a bare ``state_dict`` (an ``OrderedDict`` of parameter tensors).
     """
 
-    # weights_only=True hardens against arbitrary-code execution from untrusted checkpoints;
-    # both accepted formats (rehearsal dict of state_dict + primitives, and a bare state_dict)
-    # contain only safe types.
+    # weights_only=True hardens against arbitrary-code execution from untrusted checkpoints.
     obj = torch.load(Path(path), map_location="cpu", weights_only=True)
     if isinstance(obj, Mapping) and "model" in obj and isinstance(obj["model"], Mapping):
         normalized = dict(obj)
         normalized.setdefault("task_sequence", None)
         return normalized
+    if isinstance(obj, Mapping) and "state_dict" in obj and isinstance(obj["state_dict"], Mapping):
+        # Lightning checkpoint: parameters are nested under "state_dict".
+        return {"model": obj["state_dict"], "task_sequence": obj.get("task_sequence")}
     # Bare state_dict (OrderedDict of param tensors).
     return {"model": obj, "task_sequence": None}

--- a/src/foundation_model/workflows/recording.py
+++ b/src/foundation_model/workflows/recording.py
@@ -215,7 +215,10 @@ def load_checkpoint_state(path: Path) -> dict[str, Any]:
     ``state_dict`` (fm-trainer era).
     """
 
-    obj = torch.load(Path(path), map_location="cpu", weights_only=False)
+    # weights_only=True hardens against arbitrary-code execution from untrusted checkpoints;
+    # both accepted formats (rehearsal dict of state_dict + primitives, and a bare state_dict)
+    # contain only safe types.
+    obj = torch.load(Path(path), map_location="cpu", weights_only=True)
     if isinstance(obj, Mapping) and "model" in obj and isinstance(obj["model"], Mapping):
         normalized = dict(obj)
         normalized.setdefault("task_sequence", None)

--- a/src/foundation_model/workflows/recording.py
+++ b/src/foundation_model/workflows/recording.py
@@ -1,0 +1,224 @@
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The single artifact writer for the training / predict workflows.
+
+:class:`RunRecorder` centralises the output layout, provenance, per-step checkpoints, metrics,
+prediction parquets and figures that used to be scattered across the legacy rehearsal scripts.
+Every ``fm`` subcommand instantiates one recorder at startup and calls :meth:`write_provenance`
+before doing any work. :func:`load_checkpoint_state` normalizes both the rehearsal checkpoint
+schema and a bare ``state_dict`` (fm-trainer era) so downstream flows can consume either.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import subprocess
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from importlib import metadata
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import torch
+from loguru import logger
+
+# Package names whose versions we record in provenance (distribution name → key label).
+_PROVENANCE_PACKAGES = {
+    "torch": "torch",
+    "lightning": "lightning",
+    "numpy": "numpy",
+    "pandas": "pandas",
+    "scikit-learn": "scikit-learn",
+    "foundation-model": "foundation-model",
+}
+
+
+def _json_default(obj: Any) -> Any:
+    """Coerce values ``json`` cannot serialize: Enum → .value, Path/other → str."""
+    if isinstance(obj, Enum):
+        return obj.value
+    return str(obj)
+
+
+def _git_info() -> dict[str, Any]:
+    """``{commit, dirty}`` from git, or nulls when unavailable (never raises)."""
+    try:
+        commit = subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True).stdout.strip()
+        status = subprocess.run(["git", "status", "--porcelain"], capture_output=True, text=True, check=True).stdout
+        return {"commit": commit, "dirty": bool(status.strip())}
+    except Exception:
+        return {"commit": None, "dirty": None}
+
+
+@dataclass(kw_only=True)
+class RunPaths:
+    """Resolved output layout for one run."""
+
+    root: Path
+    training: Path
+
+    def step_dir(self, step: int, task: str) -> Path:
+        return self.training / f"step{step:02d}_{task}"
+
+
+class RunRecorder:
+    """The only artifact writer for training / predict flows."""
+
+    def __init__(self, root: Path) -> None:
+        self.paths = RunPaths(root=Path(root), training=Path(root) / "training")
+        self.paths.root.mkdir(parents=True, exist_ok=True)
+        self.paths.training.mkdir(parents=True, exist_ok=True)
+        self._records: list[dict[str, Any]] = []
+        self._log_sink_id: int | None = logger.add(self.paths.root / "run.log", level="INFO", enqueue=False)
+
+    # -- provenance
+
+    def write_provenance(self, *, config: Any, argv: list[str], seeds: Mapping[str, int]) -> Path:
+        """Write ``<root>/run_provenance.json`` (see module docstring)."""
+
+        resolved = (
+            dataclasses.asdict(config) if dataclasses.is_dataclass(config) and not isinstance(config, type) else config
+        )
+        packages: dict[str, str] = {"python": sys.version.split()[0]}
+        for dist, label in _PROVENANCE_PACKAGES.items():
+            try:
+                packages[label] = metadata.version(dist)
+            except metadata.PackageNotFoundError:
+                packages[label] = "unknown"
+        now_utc = datetime.now(timezone.utc)
+        provenance = {
+            "resolved_config": resolved,
+            "packages": packages,
+            "datetime_utc": now_utc.isoformat(),
+            "datetime_local": now_utc.astimezone().isoformat(),
+            "git": _git_info(),
+            "argv": list(argv),
+            "seeds": dict(seeds),
+        }
+        path = self.paths.root / "run_provenance.json"
+        path.write_text(json.dumps(provenance, indent=2, default=_json_default), encoding="utf-8")
+        logger.info(f"Wrote provenance to {path}")
+        return path
+
+    # -- checkpoints
+
+    def save_step_checkpoint(self, step: int, task: str, model: Any, active_tasks: list[str]) -> Path:
+        """``training/stepNN_<task>/checkpoint.pt`` with the rehearsal schema."""
+
+        step_dir = self.paths.step_dir(step, task)
+        step_dir.mkdir(parents=True, exist_ok=True)
+        path = step_dir / "checkpoint.pt"
+        torch.save(
+            {
+                "model": model.state_dict(),
+                "task_sequence": list(active_tasks),
+                "step": step,
+                "new_task": task,
+                "active_tasks": list(active_tasks),
+            },
+            path,
+        )
+        return path
+
+    def save_final_model(self, model: Any, task_sequence: list[str], task_spec_dump: dict[str, Any]) -> Path:
+        """``training/final_model.pt`` + ``training/final_model_taskconfigs.json`` (legacy schema)."""
+
+        path = self.paths.training / "final_model.pt"
+        torch.save({"model": model.state_dict(), "task_sequence": list(task_sequence)}, path)
+        (self.paths.training / "final_model_taskconfigs.json").write_text(
+            json.dumps(task_spec_dump, indent=2, default=_json_default), encoding="utf-8"
+        )
+        return path
+
+    # -- per-task artifacts
+
+    @staticmethod
+    def dump_predictions(step_dir: Path, task: str, frame: pd.DataFrame) -> Path:
+        """``<task>_pred.parquet`` — caller supplies the (composition, true, pred[, t]) frame."""
+
+        step_dir.mkdir(parents=True, exist_ok=True)
+        path = step_dir / f"{task}_pred.parquet"
+        frame.to_parquet(path)
+        return path
+
+    @staticmethod
+    def dump_metrics(step_dir: Path, task: str, metrics: dict[str, Any]) -> Path:
+        """``<task>_metrics.json``."""
+
+        step_dir.mkdir(parents=True, exist_ok=True)
+        path = step_dir / f"{task}_metrics.json"
+        path.write_text(json.dumps(metrics, indent=2, default=_json_default), encoding="utf-8")
+        return path
+
+    def save_figure(self, path_rel: str, fig: Any) -> Path:
+        """Save any matplotlib figure at ``<root>/<path_rel>``."""
+
+        path = self.paths.root / path_rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(path, bbox_inches="tight")
+        return path
+
+    # -- records
+
+    def append_record(self, record: dict[str, Any]) -> None:
+        self._records.append(dict(record))
+
+    def write_records(self) -> Path:
+        """``training/experiment_records.json``."""
+
+        path = self.paths.training / "experiment_records.json"
+        path.write_text(json.dumps(self._records, indent=2, default=_json_default), encoding="utf-8")
+        return path
+
+    def write_metrics_table(self) -> Path:
+        """``training/metrics_table.csv`` — a flat per-task row for every recorded metric dict."""
+
+        rows: list[dict[str, Any]] = []
+        for record in self._records:
+            context = {k: v for k, v in record.items() if k != "metrics" and not isinstance(v, (dict, list))}
+            metrics = record.get("metrics", {})
+            if isinstance(metrics, Mapping) and metrics:
+                for task, metric in metrics.items():
+                    row = dict(context)
+                    row["task"] = task
+                    if isinstance(metric, Mapping):
+                        row.update(metric)
+                    else:
+                        row["value"] = metric
+                    rows.append(row)
+            else:
+                rows.append(dict(context))
+        path = self.paths.training / "metrics_table.csv"
+        pd.DataFrame(rows).to_csv(path, index=False)
+        return path
+
+    def close(self) -> None:
+        """Detach the loguru file sink (safe to call more than once)."""
+        if self._log_sink_id is not None:
+            try:
+                logger.remove(self._log_sink_id)
+            except ValueError:
+                pass
+            self._log_sink_id = None
+
+
+def load_checkpoint_state(path: Path) -> dict[str, Any]:
+    """Load a checkpoint and normalize to ``{"model": state_dict, "task_sequence": list|None, ...}``.
+
+    Accepts both the rehearsal schema (``{"model": ..., "task_sequence": ...}``) and a bare
+    ``state_dict`` (fm-trainer era).
+    """
+
+    obj = torch.load(Path(path), map_location="cpu", weights_only=False)
+    if isinstance(obj, Mapping) and "model" in obj and isinstance(obj["model"], Mapping):
+        normalized = dict(obj)
+        normalized.setdefault("task_sequence", None)
+        return normalized
+    # Bare state_dict (OrderedDict of param tensors).
+    return {"model": obj, "task_sequence": None}

--- a/src/foundation_model/workflows/recording_test.py
+++ b/src/foundation_model/workflows/recording_test.py
@@ -91,6 +91,16 @@ def test_load_checkpoint_state_normalizes_bare_state_dict(tmp_path) -> None:
     assert "linear.weight" in state["model"]
 
 
+def test_load_checkpoint_state_unwraps_lightning_checkpoint(tmp_path) -> None:
+    model = _TinyModel()
+    ckpt = tmp_path / "epoch=2.ckpt"
+    # Mimic a Lightning ModelCheckpoint payload: params nested under "state_dict".
+    torch.save({"state_dict": model.state_dict(), "epoch": 2, "global_step": 10}, ckpt)
+    state = load_checkpoint_state(ckpt)
+    assert "linear.weight" in state["model"]  # unwrapped, not the whole checkpoint dict
+    assert state["task_sequence"] is None
+
+
 def test_dump_predictions_and_metrics_roundtrip(tmp_path) -> None:
     rec = RunRecorder(tmp_path)
     step_dir = rec.paths.step_dir(1, "density")

--- a/src/foundation_model/workflows/recording_test.py
+++ b/src/foundation_model/workflows/recording_test.py
@@ -1,0 +1,131 @@
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for :mod:`foundation_model.workflows.recording`."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+import torch
+from torch import nn
+
+from foundation_model.workflows.recording import RunRecorder, load_checkpoint_state
+
+
+@dataclass
+class _Cfg:
+    output_dir: Path
+    max_epochs: int
+
+
+class _TinyModel(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = nn.Linear(3, 2)
+
+
+def test_write_provenance(tmp_path) -> None:
+    rec = RunRecorder(tmp_path)
+    cfg = _Cfg(output_dir=tmp_path / "run", max_epochs=5)
+    path = rec.write_provenance(config=cfg, argv=["fm", "pretrain"], seeds={"seed": 2025})
+    rec.close()
+
+    assert path.exists()
+    data = json.loads(path.read_text())
+    # resolved config values (Path coerced to str by _json_default)
+    assert data["resolved_config"]["max_epochs"] == 5
+    assert str(tmp_path / "run") in data["resolved_config"]["output_dir"]
+    # every package-version key present
+    for key in ("python", "torch", "lightning", "numpy", "pandas", "scikit-learn", "foundation-model"):
+        assert key in data["packages"]
+    # ISO datetime parseable
+    datetime.fromisoformat(data["datetime_utc"])
+    datetime.fromisoformat(data["datetime_local"])
+    assert data["argv"] == ["fm", "pretrain"]
+    assert data["seeds"] == {"seed": 2025}
+    assert set(data["git"]) == {"commit", "dirty"}  # present (values may be null)
+    assert (tmp_path / "run.log").exists()
+
+
+def test_save_step_checkpoint_schema_and_reload(tmp_path) -> None:
+    rec = RunRecorder(tmp_path)
+    model = _TinyModel()
+    path = rec.save_step_checkpoint(1, "density", model, ["density"])
+    rec.close()
+
+    assert path == tmp_path / "training" / "step01_density" / "checkpoint.pt"
+    raw = torch.load(path, weights_only=False)
+    assert set(raw) == {"model", "task_sequence", "step", "new_task", "active_tasks"}
+    assert raw["step"] == 1 and raw["new_task"] == "density" and raw["active_tasks"] == ["density"]
+
+    state = load_checkpoint_state(path)
+    assert state["task_sequence"] == ["density"]
+    assert "linear.weight" in state["model"]
+
+
+def test_save_final_model(tmp_path) -> None:
+    rec = RunRecorder(tmp_path)
+    model = _TinyModel()
+    spec_dump = {"density": {"kind": "regression", "column": "d", "source": "qc"}}
+    path = rec.save_final_model(model, ["density"], spec_dump)
+    rec.close()
+
+    assert path == tmp_path / "training" / "final_model.pt"
+    raw = torch.load(path, weights_only=False)
+    assert set(raw) == {"model", "task_sequence"}
+    dumped = json.loads((tmp_path / "training" / "final_model_taskconfigs.json").read_text())
+    assert dumped == spec_dump
+
+
+def test_load_checkpoint_state_normalizes_bare_state_dict(tmp_path) -> None:
+    model = _TinyModel()
+    bare = tmp_path / "bare.pt"
+    torch.save(model.state_dict(), bare)
+    state = load_checkpoint_state(bare)
+    assert state["task_sequence"] is None
+    assert "linear.weight" in state["model"]
+
+
+def test_dump_predictions_and_metrics_roundtrip(tmp_path) -> None:
+    rec = RunRecorder(tmp_path)
+    step_dir = rec.paths.step_dir(1, "density")
+    frame = pd.DataFrame({"composition": ["Fe2 O3", "Al2 O3"], "true": [1.0, 2.0], "pred": [1.1, 1.9]})
+    pred_path = rec.dump_predictions(step_dir, "density", frame)
+    metric_path = rec.dump_metrics(step_dir, "density", {"r2": 0.95, "mae": 0.1, "primary": 0.95})
+    rec.close()
+
+    assert pred_path.exists() and metric_path.exists()
+    roundtrip = pd.read_parquet(pred_path)
+    pd.testing.assert_frame_equal(roundtrip, frame)
+    assert json.loads(metric_path.read_text())["r2"] == 0.95
+
+
+def test_write_records_and_metrics_table(tmp_path) -> None:
+    rec = RunRecorder(tmp_path)
+    rec.append_record(
+        {"step": 1, "new_task": "density", "epochs_run": 3, "metrics": {"density": {"r2": 0.9, "mae": 0.2}}}
+    )
+    rec.append_record(
+        {
+            "step": 2,
+            "new_task": "mat",
+            "epochs_run": 4,
+            "metrics": {"density": {"r2": 0.85, "mae": 0.3}, "mat": {"accuracy": 0.7}},
+        }
+    )
+    records_path = rec.write_records()
+    table_path = rec.write_metrics_table()
+    rec.close()
+
+    records = json.loads(records_path.read_text())
+    assert len(records) == 2 and records[0]["new_task"] == "density"
+    table = pd.read_csv(table_path)
+    # one row per (record, task): 1 + 2 = 3 rows
+    assert len(table) == 3
+    assert set(table["task"]) == {"density", "mat"}
+    assert "r2" in table.columns and "accuracy" in table.columns

--- a/src/foundation_model/workflows/task_catalog.py
+++ b/src/foundation_model/workflows/task_catalog.py
@@ -1,0 +1,643 @@
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TOML-driven task catalog: datasets, tasks, descriptors, scalers and datamodules.
+
+This module replaces every hardcoded task registry in the repository (the old
+``TASK_SPECS`` dicts and ``SuiteConfig`` descriptor/scaler fields). A parsed-TOML tree with
+``[data]`` / ``[descriptor]`` / ``[datasets.*]`` / ``[[tasks]]`` sections is normalized into a
+:class:`TaskCatalogConfig` by :func:`build_task_catalog_config`; :class:`TaskCatalog` then loads
+the composition-keyed frames and descriptors once and hands out task configs and datamodules.
+
+Scope boundary (intentional): the catalog loads **model-ready** target columns. Dataset-specific
+*forward* preprocessing that used to be inlined in the legacy scripts — ``log1p`` + z-scoring of
+raw NEMAD regression columns, and the 5-to-3 material-type label merge — is **not** reproduced
+here; data files are expected to carry the target column already in the form the model trains on.
+A per-task ``scaler`` provides *inverse*-transform for human-readable reporting only.
+
+Kernel-regression heads are initialized from data with :func:`init_kernel_centers_sigmas`
+(quantile centers + constant span), which is the initializer the pre-training path exercises
+today. A histogram-density variant existed in ``multi_task_progressive_clf`` but is intentionally
+not the default.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import joblib  # type: ignore[import-untyped]
+import numpy as np
+import pandas as pd
+from loguru import logger
+
+from foundation_model.data.composition_sources import (
+    PrecomputedDescriptorSource,
+    normalize_composition,
+    read_data_file,
+)
+from foundation_model.data.datamodule import CompoundDataModule
+from foundation_model.models.model_config import (
+    ClassificationTaskConfig,
+    KernelRegressionTaskConfig,
+    OptimizerConfig,
+    RegressionTaskConfig,
+)
+from foundation_model.utils.kmd_plus import DEFAULT_ELEMENTS, KMD, element_features, formula_to_composition
+
+TaskConfig = RegressionTaskConfig | ClassificationTaskConfig | KernelRegressionTaskConfig
+
+# A composition key element token, e.g. "Fe" / "Cu" in "Fe0.5 Cu0.5".
+_ELEMENT_TOKEN = re.compile(r"[A-Z][a-z]?")
+
+
+class TaskKind(str, Enum):
+    """Supported task kinds (TOML-facing spellings)."""
+
+    REGRESSION = "regression"
+    KERNEL_REGRESSION = "kernel_regression"
+    CLASSIFICATION = "classification"
+
+
+# Legacy short spellings (``TASK_SPECS`` used "reg"/"kr"/"clf") mapped to the enum.
+_KIND_ALIASES = {
+    "reg": TaskKind.REGRESSION,
+    "regression": TaskKind.REGRESSION,
+    "kr": TaskKind.KERNEL_REGRESSION,
+    "kernel_regression": TaskKind.KERNEL_REGRESSION,
+    "clf": TaskKind.CLASSIFICATION,
+    "classification": TaskKind.CLASSIFICATION,
+}
+
+_SUPPORTED_SUFFIXES = (".csv", ".parquet", ".pkl", ".pickle", ".z", ".xz")
+
+
+def _coerce_task_kind(value: Any) -> TaskKind:
+    if isinstance(value, TaskKind):
+        return value
+    try:
+        return _KIND_ALIASES[str(value).lower()]
+    except KeyError as exc:
+        raise ValueError(
+            f"Unknown task kind {value!r}; expected one of {sorted({k.value for k in TaskKind})}."
+        ) from exc
+
+
+def _validate_replay(value: float | int | None, *, where: str) -> None:
+    if value is None:
+        return
+    if isinstance(value, bool):  # bool is an int subclass — reject it explicitly
+        raise ValueError(f"{where}: replay must be a number, got bool {value!r}.")
+    if isinstance(value, float):
+        if not 0.0 < value < 1.0:
+            raise ValueError(f"{where}: replay float must be in (0, 1) (fraction of labels), got {value}.")
+    elif isinstance(value, int):
+        if value < 1:
+            raise ValueError(f"{where}: replay int must be >= 1 (label count), got {value}.")
+    else:
+        raise ValueError(f"{where}: replay must be a float in (0, 1) or an int >= 1, got {value!r}.")
+
+
+@dataclass(kw_only=True)
+class ScalerSpec:
+    """Points at a fitted scaler used to inverse-transform a task's predictions for reporting."""
+
+    path: Path
+    key: str | None = None  # key inside a dict-of-scalers pickle; None = the whole object
+
+    def __post_init__(self) -> None:
+        self.path = Path(self.path)
+
+
+@dataclass(kw_only=True)
+class DatasetSpec:
+    """One composition-keyed data file plus optional filters."""
+
+    name: str
+    path: Path
+    preprocessing_path: Path | None = None  # joblib dict with "dropped_idx" (qc dataset)
+    min_elements: int | None = None  # keep only compositions with >= this many elements
+    sample: int | None = None  # row cap for smoke runs
+
+    def __post_init__(self) -> None:
+        self.path = Path(self.path)
+        if self.path.suffix.lower() not in _SUPPORTED_SUFFIXES:
+            raise ValueError(
+                f"Dataset '{self.name}': unsupported file extension '{self.path.suffix}'; "
+                f"expected one of {_SUPPORTED_SUFFIXES}."
+            )
+        if self.preprocessing_path is not None:
+            self.preprocessing_path = Path(self.preprocessing_path)
+        if self.min_elements is not None and self.min_elements < 1:
+            raise ValueError(f"Dataset '{self.name}': min_elements must be >= 1, got {self.min_elements}.")
+        if self.sample is not None and self.sample < 1:
+            raise ValueError(f"Dataset '{self.name}': sample must be >= 1, got {self.sample}.")
+
+
+@dataclass(kw_only=True)
+class TaskSpec:
+    """One supervised task: a column in a dataset, plus kind-conditional metadata."""
+
+    name: str
+    kind: TaskKind  # accepts str/legacy alias; normalized in __post_init__
+    dataset: str  # key into TaskCatalogConfig.datasets
+    column: str
+    t_column: str | None = None  # required iff kind == KERNEL_REGRESSION
+    num_classes: int | None = None  # required iff kind == CLASSIFICATION
+    lr: float | None = None  # per-task LR override
+    replay: float | int | None = None  # per-task rehearsal override (fraction or count)
+    scaler: ScalerSpec | None = None
+
+    def __post_init__(self) -> None:
+        self.kind = _coerce_task_kind(self.kind)
+        if self.kind is TaskKind.KERNEL_REGRESSION and not self.t_column:
+            raise ValueError(f"Task '{self.name}': kernel_regression requires 't_column'.")
+        if self.kind is not TaskKind.KERNEL_REGRESSION and self.t_column:
+            raise ValueError(f"Task '{self.name}': 't_column' is only valid for kernel_regression.")
+        if self.kind is TaskKind.CLASSIFICATION:
+            if self.num_classes is None:
+                raise ValueError(f"Task '{self.name}': classification requires 'num_classes'.")
+            if self.num_classes < 2:
+                raise ValueError(f"Task '{self.name}': num_classes must be >= 2, got {self.num_classes}.")
+        elif self.num_classes is not None:
+            raise ValueError(f"Task '{self.name}': 'num_classes' is only valid for classification.")
+        _validate_replay(self.replay, where=f"Task '{self.name}'")
+
+
+@dataclass(kw_only=True)
+class DescriptorConfig:
+    """How composition descriptors are produced."""
+
+    kind: str = "kmd"  # "kmd" (on-the-fly, invertible) | "precomputed"
+    n_grids: int = 8  # kmd only
+    path: Path | None = None  # precomputed only; required then
+
+    def __post_init__(self) -> None:
+        if self.kind not in {"kmd", "precomputed"}:
+            raise ValueError(f"descriptor.kind must be 'kmd' or 'precomputed', got {self.kind!r}.")
+        if self.kind == "kmd" and self.n_grids < 1:
+            raise ValueError(f"descriptor.n_grids must be >= 1, got {self.n_grids}.")
+        if self.kind == "precomputed":
+            if self.path is None:
+                raise ValueError("descriptor.kind == 'precomputed' requires 'path'.")
+            self.path = Path(self.path)
+
+
+@dataclass(kw_only=True)
+class DataConfig:
+    """Shared data-loading knobs (consumed by every subcommand)."""
+
+    composition_column: str = "composition"
+    val_split: float = 0.1
+    test_split: float = 0.1
+    split_random_seed: int = 42
+    batch_size: int = 256
+    num_workers: int = 0
+
+    def __post_init__(self) -> None:
+        for name in ("val_split", "test_split"):
+            value = getattr(self, name)
+            if not 0.0 <= value < 1.0:
+                raise ValueError(f"data.{name} must be in [0, 1), got {value}.")
+        if self.val_split + self.test_split >= 1.0:
+            raise ValueError("data.val_split + data.test_split must be < 1.0.")
+        if self.batch_size < 1:
+            raise ValueError(f"data.batch_size must be >= 1, got {self.batch_size}.")
+        if self.num_workers < 0:
+            raise ValueError(f"data.num_workers must be >= 0, got {self.num_workers}.")
+
+
+@dataclass(kw_only=True)
+class TaskCatalogConfig:
+    """The fully-resolved catalog: data knobs, descriptor, datasets and tasks."""
+
+    data: DataConfig
+    descriptor: DescriptorConfig
+    datasets: dict[str, DatasetSpec]
+    tasks: list[TaskSpec]
+
+    def __post_init__(self) -> None:
+        if not self.tasks:
+            raise ValueError("At least one task is required ([[tasks]]).")
+        names = [t.name for t in self.tasks]
+        dupes = sorted({n for n in names if names.count(n) > 1})
+        if dupes:
+            raise ValueError(f"Duplicate task names: {dupes}.")
+        for task in self.tasks:
+            if task.dataset not in self.datasets:
+                raise ValueError(
+                    f"Task '{task.name}': dataset '{task.dataset}' is not defined in [datasets] "
+                    f"(available: {sorted(self.datasets)})."
+                )
+
+
+# --- TOML → dataclass builder -------------------------------------------------------------
+
+
+def _reject_unknown(section: str, raw: Mapping[str, Any], known: set[str]) -> None:
+    unknown = sorted(set(raw) - known)
+    if unknown:
+        raise ValueError(f"[{section}]: unknown key(s) {unknown}; allowed keys are {sorted(known)}.")
+
+
+def _build_scaler_spec(raw: Mapping[str, Any], *, task_name: str) -> ScalerSpec:
+    _reject_unknown(f"tasks.{task_name}.scaler", raw, {"path", "key"})
+    if "path" not in raw:
+        raise ValueError(f"Task '{task_name}': scaler requires 'path'.")
+    return ScalerSpec(path=Path(raw["path"]), key=raw.get("key"))
+
+
+def build_task_catalog_config(raw: Mapping[str, Any]) -> TaskCatalogConfig:
+    """Normalize the parsed-TOML tree into a :class:`TaskCatalogConfig`.
+
+    Unknown keys raise ``ValueError`` naming the offending key (an explicit per-section check —
+    the dataclasses alone would surface a less friendly ``TypeError``).
+    """
+
+    _reject_unknown("<root>", raw, {"data", "descriptor", "datasets", "tasks"})
+
+    data_raw = dict(raw.get("data", {}))
+    _reject_unknown("data", data_raw, set(DataConfig.__dataclass_fields__))
+    data = DataConfig(**data_raw)
+
+    descriptor_raw = dict(raw.get("descriptor", {}))
+    _reject_unknown("descriptor", descriptor_raw, set(DescriptorConfig.__dataclass_fields__))
+    descriptor = DescriptorConfig(**descriptor_raw)
+
+    datasets_raw = raw.get("datasets", {})
+    if not isinstance(datasets_raw, Mapping) or not datasets_raw:
+        raise ValueError("At least one [datasets.<name>] table is required.")
+    datasets: dict[str, DatasetSpec] = {}
+    for name, spec_raw in datasets_raw.items():
+        spec_map = dict(spec_raw)
+        _reject_unknown(f"datasets.{name}", spec_map, set(DatasetSpec.__dataclass_fields__) - {"name"})
+        datasets[name] = DatasetSpec(name=name, **spec_map)
+
+    tasks_raw = raw.get("tasks", [])
+    if not tasks_raw:
+        raise ValueError("At least one [[tasks]] entry is required.")
+    tasks: list[TaskSpec] = []
+    for task_raw in tasks_raw:
+        task_map = dict(task_raw)
+        _reject_unknown(
+            f"tasks.{task_map.get('name', '?')}",
+            task_map,
+            set(TaskSpec.__dataclass_fields__),
+        )
+        scaler_raw = task_map.pop("scaler", None)
+        scaler = _build_scaler_spec(scaler_raw, task_name=task_map.get("name", "?")) if scaler_raw is not None else None
+        tasks.append(TaskSpec(scaler=scaler, **task_map))
+
+    return TaskCatalogConfig(data=data, descriptor=descriptor, datasets=datasets, tasks=tasks)
+
+
+# --- kernel init-from-data ----------------------------------------------------------------
+
+
+def init_kernel_centers_sigmas(t_values: np.ndarray, n_kernel: int) -> tuple[list[float], list[float]]:
+    """Quantile kernel centers + constant span from a task's observed ``t`` distribution.
+
+    Migrated from ``continual_rehearsal_demo._init_kernels`` — the initializer the pre-training
+    path exercises today. Returns empty lists when no finite ``t`` values are available (callers
+    fall back to the head's equal-spaced default).
+    """
+
+    t = np.asarray(t_values, dtype=float)
+    t = t[np.isfinite(t)]
+    if t.size == 0:
+        return [], []
+    centers = np.quantile(t, np.linspace(0.0, 1.0, n_kernel))
+    span = max((float(t.max()) - float(t.min())) / max(n_kernel - 1, 1), 1e-3)
+    return centers.tolist(), np.full(n_kernel, span).tolist()
+
+
+def _count_elements(composition_key: str) -> int:
+    return len(_ELEMENT_TOKEN.findall(composition_key))
+
+
+def _as_float_array(cell: Any) -> np.ndarray:
+    import ast
+
+    if isinstance(cell, str):
+        cell = ast.literal_eval(cell)
+    return np.asarray(cell, dtype=float).ravel()
+
+
+# --- catalog ------------------------------------------------------------------------------
+
+
+class TaskCatalog:
+    """Loads composition-keyed frames + descriptors once; hands out task configs and datamodules."""
+
+    def __init__(self, config: TaskCatalogConfig) -> None:
+        self.config = config
+        self._task_specs = {t.name: t for t in config.tasks}
+
+        self._kmd: KMD | None = None
+        self._descriptor_source: PrecomputedDescriptorSource | None = None
+        self._desc_cache: dict[str, np.ndarray] = {}
+        if config.descriptor.kind == "kmd":
+            self._kmd = KMD(
+                element_features.values,
+                method="1d",
+                n_grids=config.descriptor.n_grids,
+                sigma="auto",
+                scale=True,
+            )
+            self._descriptor_dim = int(self._kmd.transform(np.eye(1, len(DEFAULT_ELEMENTS))).shape[1])
+        else:
+            assert config.descriptor.path is not None  # guaranteed by DescriptorConfig.__post_init__
+            self._descriptor_source = PrecomputedDescriptorSource(
+                str(config.descriptor.path), composition_column=config.data.composition_column
+            )
+            self._descriptor_dim = 0  # resolved lazily on first descriptor_fn call
+
+        self._dataset_frames: dict[str, pd.DataFrame] = {}  # keyed, filtered source frames (cached)
+        self._task_frames: dict[str, pd.DataFrame] = {}  # per-task composition-indexed frames (cached)
+        self._scalers: dict[str, Any] = {}  # loaded lazily per task
+
+    # -- introspection
+
+    @property
+    def task_names(self) -> list[str]:
+        return list(self._task_specs)
+
+    @property
+    def descriptor_dim(self) -> int:
+        """Descriptor feature dimension (encoder input dim)."""
+        if self._descriptor_dim == 0 and self._descriptor_source is not None:
+            # Force one lookup to learn the precomputed width. Use any task's first composition.
+            frame = self._descriptor_source._load()  # noqa: SLF001 — read-only width probe
+            self._descriptor_dim = int(frame.shape[1])
+        return self._descriptor_dim
+
+    def task_spec(self, name: str) -> TaskSpec:
+        try:
+            return self._task_specs[name]
+        except KeyError as exc:
+            raise KeyError(f"Unknown task '{name}'; known tasks: {self.task_names}.") from exc
+
+    def kmd(self) -> KMD | None:
+        """The invertible KMD object, or ``None`` when descriptors are precomputed."""
+        return self._kmd
+
+    # -- data loading
+
+    def _load_dataset(self, name: str) -> pd.DataFrame:
+        """Load one dataset file, apply preprocessing/min_elements/sample, key by composition."""
+
+        if name in self._dataset_frames:
+            return self._dataset_frames[name]
+        spec = self.config.datasets[name]
+        df = read_data_file(str(spec.path)).copy()
+
+        # Drop rows recorded in a preprocessing cache (e.g. qc dropped_idx).
+        if spec.preprocessing_path is not None and spec.preprocessing_path.exists():
+            dropped = joblib.load(spec.preprocessing_path).get("dropped_idx", [])
+            df = df.loc[~df.index.isin(dropped)]
+
+        # Composition key (canonical) → index; drop unparseable, keep first duplicate.
+        comp_col = self.config.data.composition_column
+        if comp_col in df.columns:
+            keys = [normalize_composition(v) for v in df[comp_col]]
+        else:
+            keys = [normalize_composition(v) for v in df.index]
+        df["__key__"] = np.asarray(keys, dtype=object)
+        df = df.dropna(subset=["__key__"]).drop_duplicates(subset="__key__", keep="first").set_index("__key__")
+
+        if spec.min_elements is not None:
+            df = df.loc[[_count_elements(str(k)) >= spec.min_elements for k in df.index]]
+
+        if spec.sample is not None and spec.sample < len(df):
+            rng = np.random.default_rng(self.config.data.split_random_seed)
+            df = df.iloc[np.sort(rng.choice(len(df), size=spec.sample, replace=False))]
+
+        self._dataset_frames[name] = df
+        logger.info(f"Loaded dataset '{name}': {len(df)} rows keyed by composition.")
+        return df
+
+    def task_frames(self, names: Sequence[str]) -> dict[str, pd.DataFrame]:
+        """Composition-keyed per-task frames with ``[column(+t_column)[, split]]``."""
+
+        out: dict[str, pd.DataFrame] = {}
+        for name in names:
+            if name not in self._task_frames:
+                spec = self.task_spec(name)
+                source = self._load_dataset(spec.dataset)
+                if spec.column not in source.columns:
+                    raise KeyError(f"Task '{name}': column '{spec.column}' missing in dataset '{spec.dataset}'.")
+                frame = pd.DataFrame(index=source.index)
+                frame[spec.column] = source[spec.column]
+                if spec.kind is TaskKind.KERNEL_REGRESSION:
+                    assert spec.t_column is not None
+                    if spec.t_column not in source.columns:
+                        raise KeyError(
+                            f"Task '{name}': t_column '{spec.t_column}' missing in dataset '{spec.dataset}'."
+                        )
+                    frame[spec.t_column] = source[spec.t_column]
+                if "split" in source.columns:
+                    frame["split"] = source["split"]
+                self._task_frames[name] = frame
+            out[name] = self._task_frames[name]
+        return out
+
+    def descriptor_fn(self) -> Callable[[list[str]], pd.DataFrame]:
+        """Return a ``Callable[[list[str]], pd.DataFrame]`` producing composition descriptors."""
+
+        if self._descriptor_source is not None:
+            source = self._descriptor_source
+            return lambda compositions: source(list(compositions))
+
+        def _kmd_descriptor(compositions: list[str]) -> pd.DataFrame:
+            uncached = [c for c in dict.fromkeys(compositions) if c not in self._desc_cache]
+            if uncached:
+                weights = np.zeros((len(uncached), len(DEFAULT_ELEMENTS)), dtype=float)
+                valid: list[str] = []
+                for key in uncached:
+                    try:
+                        w = formula_to_composition(key)
+                    except Exception:
+                        w = None
+                    if w is None or float(np.asarray(w).sum()) <= 0:
+                        continue
+                    weights[len(valid)] = w
+                    valid.append(key)
+                if valid:
+                    assert self._kmd is not None
+                    desc = self._kmd.transform(weights[: len(valid)])
+                    for j, key in enumerate(valid):
+                        self._desc_cache[key] = desc[j]
+            present = [c for c in compositions if c in self._desc_cache]
+            if not present:
+                return pd.DataFrame()
+            return pd.DataFrame(np.stack([self._desc_cache[c] for c in present]), index=present)
+
+        return _kmd_descriptor
+
+    # -- task configs
+
+    def _train_t_values(self, name: str) -> np.ndarray:
+        spec = self.task_spec(name)
+        assert spec.t_column is not None
+        frame = self.task_frames([name])[name]
+        mask = frame[spec.column].notna()
+        if "split" in frame.columns:
+            mask &= frame["split"] == "train"
+        cells = frame.loc[mask, spec.t_column].dropna()
+        if cells.empty:
+            return np.array([])
+        return np.concatenate([_as_float_array(c) for c in cells])
+
+    def _class_weights(self, name: str) -> list[float]:
+        spec = self.task_spec(name)
+        assert spec.num_classes is not None
+        frame = self.task_frames([name])[name]
+        mask = frame[spec.column].notna()
+        if "split" in frame.columns:
+            mask &= frame["split"] == "train"
+        labels = frame.loc[mask, spec.column].dropna().astype(int)
+        counts = np.bincount(labels, minlength=spec.num_classes).astype(float)
+        counts[counts == 0] = 1.0
+        weights = counts.sum() / (spec.num_classes * counts)  # sklearn "balanced" scheme
+        return weights.tolist()
+
+    def build_task_config(
+        self,
+        name: str,
+        *,
+        latent_dim: int,
+        head_hidden_dim: int,
+        n_kernel: int,
+        lr: float,
+        weight_decay: float = 0.0,
+        masking_ratio: float = 1.0,
+        init_from_data: bool = True,
+    ) -> TaskConfig:
+        """Build the model-side task config for ``name`` (see module docstring for field mapping)."""
+
+        spec = self.task_spec(name)
+        head_lr = spec.lr if spec.lr is not None else lr
+        optimizer = OptimizerConfig(lr=head_lr, weight_decay=weight_decay)
+
+        if spec.kind is TaskKind.REGRESSION:
+            return RegressionTaskConfig(
+                name=name,
+                data_column=spec.column,
+                dims=[latent_dim, head_hidden_dim, 1],
+                optimizer=optimizer,
+                task_masking_ratio=masking_ratio,
+            )
+        if spec.kind is TaskKind.CLASSIFICATION:
+            assert spec.num_classes is not None
+            return ClassificationTaskConfig(
+                name=name,
+                data_column=spec.column,
+                dims=[latent_dim, head_hidden_dim, 32],
+                num_classes=spec.num_classes,
+                class_weights=self._class_weights(name),
+                optimizer=optimizer,
+                task_masking_ratio=masking_ratio,
+            )
+
+        assert spec.t_column is not None
+        centers: list[float] = []
+        sigmas: list[float] = []
+        if init_from_data:
+            centers, sigmas = init_kernel_centers_sigmas(self._train_t_values(name), n_kernel)
+        return KernelRegressionTaskConfig(
+            name=name,
+            data_column=spec.column,
+            t_column=spec.t_column,
+            x_dim=[latent_dim, 128, 64],
+            t_dim=[16, 8],
+            kernel_num_centers=n_kernel,
+            kernel_centers_init=centers or None,
+            kernel_sigmas_init=sigmas or None,
+            kernel_learnable_centers=True,
+            kernel_learnable_sigmas=True,
+            enable_mu3=False,
+            optimizer=optimizer,
+            task_masking_ratio=masking_ratio,
+        )
+
+    # -- scalers / inverse-transform
+
+    def scaler(self, name: str) -> Any | None:
+        """The fitted scaler for ``name`` (loaded lazily), or ``None`` if not configured."""
+
+        spec = self.task_spec(name)
+        if spec.scaler is None:
+            return None
+        if name not in self._scalers:
+            obj = joblib.load(spec.scaler.path)
+            if spec.scaler.key is not None:
+                if spec.scaler.key not in obj:
+                    raise KeyError(f"Task '{name}': scaler key '{spec.scaler.key}' not found in {spec.scaler.path}.")
+                obj = obj[spec.scaler.key]
+            self._scalers[name] = obj
+        return self._scalers[name]
+
+    def inverse_transform(self, name: str, values: np.ndarray) -> np.ndarray:
+        """Apply the task's scaler inverse-transform if configured, else identity."""
+
+        scaler = self.scaler(name)
+        if scaler is None:
+            return np.asarray(values)
+        restored = scaler.inverse_transform(np.asarray(values, dtype=float).reshape(-1, 1))
+        return np.asarray(restored).reshape(-1)
+
+    # -- datamodule
+
+    def _data_task_config(self, name: str, *, masking_ratio: float | None, predict_idx: Any) -> TaskConfig:
+        """A lightweight task config carrying only the fields the datamodule reads."""
+
+        spec = self.task_spec(name)
+        kwargs: dict[str, Any] = {
+            "name": name,
+            "data_column": spec.column,
+            "task_masking_ratio": masking_ratio,
+            "predict_idx": predict_idx,
+        }
+        if spec.kind is TaskKind.REGRESSION:
+            return RegressionTaskConfig(**kwargs)
+        if spec.kind is TaskKind.CLASSIFICATION:
+            assert spec.num_classes is not None
+            return ClassificationTaskConfig(num_classes=spec.num_classes, **kwargs)
+        assert spec.t_column is not None
+        return KernelRegressionTaskConfig(t_column=spec.t_column, **kwargs)
+
+    def build_datamodule(
+        self,
+        active_tasks: Sequence[str],
+        *,
+        masking_ratios: Mapping[str, float] | None = None,
+        predict_idx: str | Sequence[str] | None = None,
+    ) -> CompoundDataModule:
+        """Assemble a :class:`CompoundDataModule` over ``active_tasks``.
+
+        ``masking_ratios`` overrides each task's keep-ratio (default 1.0); ``predict_idx`` is set
+        on every active task config (literal split name or explicit composition sequence).
+        """
+
+        masking_ratios = masking_ratios or {}
+        frames = self.task_frames(active_tasks)
+        task_configs = [
+            self._data_task_config(name, masking_ratio=masking_ratios.get(name, 1.0), predict_idx=predict_idx)
+            for name in active_tasks
+        ]
+        data = self.config.data
+        return CompoundDataModule(
+            task_configs=task_configs,
+            descriptor_fn=self.descriptor_fn(),
+            task_frames={name: frames[name] for name in active_tasks},
+            composition_column=data.composition_column,
+            random_seed=data.split_random_seed,
+            val_split=data.val_split,
+            test_split=data.test_split,
+            batch_size=data.batch_size,
+            num_workers=data.num_workers,
+        )

--- a/src/foundation_model/workflows/task_catalog.py
+++ b/src/foundation_model/workflows/task_catalog.py
@@ -37,6 +37,7 @@ from loguru import logger
 
 from foundation_model.data.composition_sources import (
     PrecomputedDescriptorSource,
+    canonical_key,
     normalize_composition,
     read_data_file,
 )
@@ -404,12 +405,13 @@ class TaskCatalog:
             dropped = joblib.load(spec.preprocessing_path).get("dropped_idx", [])
             df = df.loc[~df.index.isin(dropped)]
 
-        # Composition key (canonical) → index; drop unparseable, keep first duplicate.
+        # Composition key → index, keeping first duplicate. Use canonical_key (the same rule the
+        # DataModule / descriptor sources use): real formulas are canonicalized while non-formula
+        # IDs (e.g. precomputed-descriptor material IDs) pass through unchanged instead of being
+        # dropped. Only genuinely-missing (NaN/None) compositions are dropped.
         comp_col = self.config.data.composition_column
-        if comp_col in df.columns:
-            keys = [normalize_composition(v) for v in df[comp_col]]
-        else:
-            keys = [normalize_composition(v) for v in df.index]
+        raw = df[comp_col] if comp_col in df.columns else df.index.to_series()
+        keys = [canonical_key(v, normalize_composition) if pd.notna(v) else None for v in raw]
         df["__key__"] = np.asarray(keys, dtype=object)
         df = df.dropna(subset=["__key__"]).drop_duplicates(subset="__key__", keep="first").set_index("__key__")
 

--- a/src/foundation_model/workflows/task_catalog.py
+++ b/src/foundation_model/workflows/task_catalog.py
@@ -73,7 +73,10 @@ _KIND_ALIASES = {
     "classification": TaskKind.CLASSIFICATION,
 }
 
-_SUPPORTED_SUFFIXES = (".csv", ".parquet", ".pkl", ".pickle", ".z", ".xz")
+# Full-name suffix patterns accepted by ``data.composition_sources.read_data_file`` (kept in
+# sync with it). ``.parquet`` also covers ``.pd.parquet``; multi-suffix pickle forms need the
+# full ending, so we match on ``path.name`` rather than ``Path.suffix`` (which sees only ".z").
+_SUPPORTED_DATA_PATTERNS = (".csv", ".parquet", ".pd", ".pd.z", ".pd.xz", ".pkl")
 
 
 def _coerce_task_kind(value: Any) -> TaskKind:
@@ -125,10 +128,10 @@ class DatasetSpec:
 
     def __post_init__(self) -> None:
         self.path = Path(self.path)
-        if self.path.suffix.lower() not in _SUPPORTED_SUFFIXES:
+        if not self.path.name.lower().endswith(_SUPPORTED_DATA_PATTERNS):
             raise ValueError(
-                f"Dataset '{self.name}': unsupported file extension '{self.path.suffix}'; "
-                f"expected one of {_SUPPORTED_SUFFIXES}."
+                f"Dataset '{self.name}': unsupported data file '{self.path.name}'; "
+                f"expected a name ending in one of {_SUPPORTED_DATA_PATTERNS} (see read_data_file)."
             )
         if self.preprocessing_path is not None:
             self.preprocessing_path = Path(self.preprocessing_path)
@@ -179,8 +182,9 @@ class DescriptorConfig:
     def __post_init__(self) -> None:
         if self.kind not in {"kmd", "precomputed"}:
             raise ValueError(f"descriptor.kind must be 'kmd' or 'precomputed', got {self.kind!r}.")
-        if self.kind == "kmd" and self.n_grids < 1:
-            raise ValueError(f"descriptor.n_grids must be >= 1, got {self.n_grids}.")
+        if self.kind == "kmd" and self.n_grids < 2:
+            # KMD(method="1d") requires n_grids >= 2; surface it at config time, not at load.
+            raise ValueError(f'descriptor.n_grids must be >= 2 when kind="kmd", got {self.n_grids}.')
         if self.kind == "precomputed":
             if self.path is None:
                 raise ValueError("descriptor.kind == 'precomputed' requires 'path'.")

--- a/src/foundation_model/workflows/task_catalog_test.py
+++ b/src/foundation_model/workflows/task_catalog_test.py
@@ -414,6 +414,36 @@ def test_kmd_descriptor_deterministic_and_cached(catalog_dir) -> None:
     assert cat.descriptor_dim == first.shape[1]
 
 
+def test_precomputed_non_formula_keys_preserved(tmp_path) -> None:
+    # Non-formula IDs (e.g. Materials Project IDs) that normalize_composition can't parse must be
+    # preserved via canonical_key, not dropped — otherwise a precomputed catalog is emptied.
+    ids = ["mp-149", "mp-2534", "mp-66"]
+    qc = pd.DataFrame({"composition": ids, "density": [1.0, 2.0, 3.0]})
+    qc.to_parquet(tmp_path / "qc.parquet")
+    desc = pd.DataFrame(np.arange(6, dtype=float).reshape(3, 2), columns=["f0", "f1"])
+    desc["composition"] = ids
+    desc.to_parquet(tmp_path / "desc.parquet")
+    toml = f"""
+[descriptor]
+kind = "precomputed"
+path = "{tmp_path / "desc.parquet"}"
+
+[datasets.qc]
+path = "{tmp_path / "qc.parquet"}"
+
+[[tasks]]
+name = "density"
+kind = "regression"
+dataset = "qc"
+column = "density"
+"""
+    cat = TaskCatalog(_build(toml))
+    frame = cat.task_frames(["density"])["density"]
+    assert list(frame.index) == ids  # rows kept, not dropped
+    out = cat.descriptor_fn()(ids)
+    assert list(out.index) == ids
+
+
 def test_precomputed_descriptor_source(tmp_path) -> None:
     qc = pd.DataFrame({"composition": _COMPS, "density": [1.0, 2, 3, 4, 5, 6]})
     qc.to_parquet(tmp_path / "qc.parquet")

--- a/src/foundation_model/workflows/task_catalog_test.py
+++ b/src/foundation_model/workflows/task_catalog_test.py
@@ -1,0 +1,406 @@
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for :mod:`foundation_model.workflows.task_catalog`."""
+
+from __future__ import annotations
+
+import tomllib
+
+import joblib  # type: ignore[import-untyped]
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.preprocessing import StandardScaler  # type: ignore[import-untyped]
+
+from foundation_model.data.datamodule import CompoundDataModule
+from foundation_model.models.model_config import (
+    ClassificationTaskConfig,
+    KernelRegressionTaskConfig,
+    RegressionTaskConfig,
+)
+from foundation_model.workflows.task_catalog import (
+    ScalerSpec,
+    TaskCatalog,
+    TaskKind,
+    build_task_catalog_config,
+    init_kernel_centers_sigmas,
+)
+
+# Element counts: Fe2 O3=2, Al2 O3=2, Na1 Cl1=2, Ca1 Ti1 O3=3, Li2 O1=2, Fe1=1
+_COMPS = ["Fe2O3", "Al2O3", "NaCl", "Ca Ti O3", "Li2 O", "Fe"]
+
+
+def _base_toml(qc_path: str) -> str:
+    return f"""
+[data]
+composition_column = "composition"
+batch_size = 8
+
+[descriptor]
+kind = "kmd"
+n_grids = 4
+
+[datasets.qc]
+path = "{qc_path}"
+
+[[tasks]]
+name = "density"
+kind = "regression"
+dataset = "qc"
+column = "density"
+
+[[tasks]]
+name = "mat"
+kind = "classification"
+dataset = "qc"
+column = "mtype"
+num_classes = 3
+"""
+
+
+def _build(toml_str: str):
+    return build_task_catalog_config(tomllib.loads(toml_str))
+
+
+# --- build_task_catalog_config -----------------------------------------------------------
+
+
+def test_build_happy_path() -> None:
+    cfg = _build(_base_toml("data/qc.parquet"))
+    assert [t.name for t in cfg.tasks] == ["density", "mat"]
+    assert cfg.tasks[0].kind is TaskKind.REGRESSION
+    assert cfg.tasks[1].kind is TaskKind.CLASSIFICATION
+    assert cfg.descriptor.kind == "kmd" and cfg.descriptor.n_grids == 4
+    assert "qc" in cfg.datasets
+
+
+def test_legacy_kind_aliases_normalize() -> None:
+    toml = """
+[descriptor]
+kind = "kmd"
+
+[datasets.qc]
+path = "data/qc.parquet"
+
+[[tasks]]
+name = "dos"
+kind = "kr"
+dataset = "qc"
+column = "dos"
+t_column = "energy"
+"""
+    cfg = _build(toml)
+    assert cfg.tasks[0].kind is TaskKind.KERNEL_REGRESSION
+
+
+def test_unknown_key_raises() -> None:
+    toml = """
+[data]
+composition_column = "composition"
+not_a_field = 1
+
+[datasets.qc]
+path = "data/qc.parquet"
+
+[[tasks]]
+name = "density"
+kind = "regression"
+dataset = "qc"
+column = "density"
+"""
+    with pytest.raises(ValueError, match="not_a_field"):
+        _build(toml)
+
+
+def test_unknown_task_key_raises() -> None:
+    toml = (
+        _base_toml("data/qc.parquet")
+        + """
+[[tasks]]
+name = "bogus"
+kind = "regression"
+dataset = "qc"
+column = "x"
+not_a_field = 1
+"""
+    )
+    with pytest.raises(ValueError, match="not_a_field"):
+        _build(toml)
+
+
+def test_kr_without_t_column_raises() -> None:
+    toml = """
+[datasets.qc]
+path = "data/qc.parquet"
+
+[[tasks]]
+name = "dos"
+kind = "kernel_regression"
+dataset = "qc"
+column = "dos"
+"""
+    with pytest.raises(ValueError, match="t_column"):
+        _build(toml)
+
+
+def test_clf_without_num_classes_raises() -> None:
+    toml = """
+[datasets.qc]
+path = "data/qc.parquet"
+
+[[tasks]]
+name = "mat"
+kind = "classification"
+dataset = "qc"
+column = "mtype"
+"""
+    with pytest.raises(ValueError, match="num_classes"):
+        _build(toml)
+
+
+def test_duplicate_task_names_raise() -> None:
+    toml = (
+        _base_toml("data/qc.parquet")
+        + """
+[[tasks]]
+name = "density"
+kind = "regression"
+dataset = "qc"
+column = "density"
+"""
+    )
+    with pytest.raises(ValueError, match="Duplicate task names"):
+        _build(toml)
+
+
+def test_task_dataset_not_defined_raises() -> None:
+    toml = """
+[datasets.qc]
+path = "data/qc.parquet"
+
+[[tasks]]
+name = "density"
+kind = "regression"
+dataset = "missing"
+column = "density"
+"""
+    with pytest.raises(ValueError, match="dataset 'missing'"):
+        _build(toml)
+
+
+@pytest.mark.parametrize(
+    ("replay", "ok"),
+    [(0.1, True), (500, True), (0.0, False), (-1, False), (1.0, False)],
+)
+def test_replay_validation(replay: float, ok: bool) -> None:
+    toml = f"""
+[datasets.qc]
+path = "data/qc.parquet"
+
+[[tasks]]
+name = "density"
+kind = "regression"
+dataset = "qc"
+column = "density"
+replay = {replay!r}
+"""
+    if ok:
+        assert _build(toml).tasks[0].replay == replay
+    else:
+        with pytest.raises(ValueError, match="replay"):
+            _build(toml)
+
+
+# --- TaskCatalog with synthetic fixtures -------------------------------------------------
+
+
+@pytest.fixture
+def catalog_dir(tmp_path):
+    qc = pd.DataFrame(
+        {
+            "composition": _COMPS,
+            "density": [1.0, 2.0, np.nan, 4.0, 5.0, 6.0],
+            "mtype": [0, 1, 2, 0, 1, 2],
+            "split": ["train", "train", "test", "val", "train", "test"],
+        }
+    )
+    qc.to_parquet(tmp_path / "qc.parquet")
+    kr = pd.DataFrame(
+        {
+            "composition": _COMPS,
+            "dos": ["[0.1, 0.2, 0.3]"] * 6,
+            "energy": ["[1.0, 2.0, 3.0]"] * 6,
+            "split": ["train"] * 4 + ["test"] * 2,
+        }
+    )
+    kr.to_parquet(tmp_path / "kr.parquet")
+    return tmp_path
+
+
+def _catalog(catalog_dir, *, extra_tasks: str = "", data_extra: str = "") -> TaskCatalog:
+    toml = f"""
+[data]
+composition_column = "composition"
+batch_size = 4
+
+[descriptor]
+kind = "kmd"
+n_grids = 4
+
+[datasets.qc]
+path = "{catalog_dir / "qc.parquet"}"
+{data_extra}
+
+[datasets.kr]
+path = "{catalog_dir / "kr.parquet"}"
+
+[[tasks]]
+name = "density"
+kind = "regression"
+dataset = "qc"
+column = "density"
+
+[[tasks]]
+name = "mat"
+kind = "classification"
+dataset = "qc"
+column = "mtype"
+num_classes = 3
+
+[[tasks]]
+name = "dos"
+kind = "kernel_regression"
+dataset = "kr"
+column = "dos"
+t_column = "energy"
+{extra_tasks}
+"""
+    return TaskCatalog(_build(toml))
+
+
+def test_task_frames_composition_keyed(catalog_dir) -> None:
+    cat = _catalog(catalog_dir)
+    frames = cat.task_frames(["density"])
+    frame = frames["density"]
+    assert list(frame.index) == ["Fe2 O3", "Al2 O3", "Na1 Cl1", "Ca1 Ti1 O3", "Li2 O1", "Fe1"]
+    assert "density" in frame.columns and "split" in frame.columns
+
+
+def test_task_frames_nan_preserved(catalog_dir) -> None:
+    frame = _catalog(catalog_dir).task_frames(["density"])["density"]
+    assert frame["density"].isna().sum() == 1  # NaCl row NaN kept, not dropped
+
+
+def test_min_elements_drops_rows(catalog_dir) -> None:
+    cat = _catalog(catalog_dir, data_extra="min_elements = 2")
+    frame = cat.task_frames(["density"])["density"]
+    assert "Fe1" not in frame.index  # single-element composition dropped
+    assert len(frame) == 5
+
+
+def test_sample_caps_rows(catalog_dir) -> None:
+    cat = _catalog(catalog_dir, data_extra="sample = 3")
+    frame = cat.task_frames(["density"])["density"]
+    assert len(frame) == 3
+
+
+def test_build_task_config_per_kind(catalog_dir) -> None:
+    cat = _catalog(catalog_dir)
+    reg = cat.build_task_config("density", latent_dim=8, head_hidden_dim=4, n_kernel=5, lr=1e-3)
+    clf = cat.build_task_config("mat", latent_dim=8, head_hidden_dim=4, n_kernel=5, lr=1e-3)
+    kr = cat.build_task_config("dos", latent_dim=8, head_hidden_dim=4, n_kernel=5, lr=1e-3)
+    assert isinstance(reg, RegressionTaskConfig) and reg.dims == [8, 4, 1]
+    assert isinstance(clf, ClassificationTaskConfig) and clf.num_classes == 3
+    assert clf.class_weights is not None and len(clf.class_weights) == 3
+    assert isinstance(kr, KernelRegressionTaskConfig) and kr.kernel_num_centers == 5
+    assert reg.optimizer is not None and reg.optimizer.lr == 1e-3
+
+
+def test_build_task_config_per_task_lr_override(catalog_dir) -> None:
+    cat = _catalog(catalog_dir, extra_tasks="lr = 0.02")  # per-task override on the dos task
+    kr = cat.build_task_config("dos", latent_dim=8, head_hidden_dim=4, n_kernel=5, lr=1e-3)
+    assert kr.optimizer is not None and kr.optimizer.lr == 0.02
+
+
+def test_kernel_init_finite(catalog_dir) -> None:
+    kr = _catalog(catalog_dir).build_task_config("dos", latent_dim=8, head_hidden_dim=4, n_kernel=5, lr=1e-3)
+    assert isinstance(kr, KernelRegressionTaskConfig)
+    assert kr.kernel_centers_init is not None and len(kr.kernel_centers_init) == 5
+    assert kr.kernel_sigmas_init is not None
+    assert np.all(np.isfinite(kr.kernel_centers_init)) and np.all(np.isfinite(kr.kernel_sigmas_init))
+
+
+def test_init_kernel_centers_sigmas_empty() -> None:
+    centers, sigmas = init_kernel_centers_sigmas(np.array([]), 5)
+    assert centers == [] and sigmas == []
+
+
+def test_inverse_transform_identity_without_scaler(catalog_dir) -> None:
+    cat = _catalog(catalog_dir)
+    values = np.array([1.0, 2.0, 3.0])
+    assert np.allclose(cat.inverse_transform("density", values), values)
+
+
+def test_inverse_transform_roundtrip_with_scaler(catalog_dir) -> None:
+    raw = np.array([[10.0], [20.0], [30.0], [40.0]])
+    scaler = StandardScaler().fit(raw)
+    scaler_path = catalog_dir / "scalers.z"
+    joblib.dump({"density": scaler}, scaler_path)
+    cat = _catalog(catalog_dir)
+    cat.task_spec("density").scaler = ScalerSpec(path=scaler_path, key="density")
+    normalized = scaler.transform(raw).reshape(-1)
+    restored = cat.inverse_transform("density", normalized)
+    assert np.allclose(restored, raw.reshape(-1))
+
+
+def test_kmd_descriptor_deterministic_and_cached(catalog_dir) -> None:
+    cat = _catalog(catalog_dir)
+    fn = cat.descriptor_fn()
+    keys = ["Fe2 O3", "Al2 O3"]
+    first = fn(keys)
+    second = fn(keys)
+    assert list(first.index) == keys
+    assert np.allclose(first.values, second.values)
+    assert cat.kmd() is not None
+    assert cat.descriptor_dim == first.shape[1]
+
+
+def test_precomputed_descriptor_source(tmp_path) -> None:
+    qc = pd.DataFrame({"composition": _COMPS, "density": [1.0, 2, 3, 4, 5, 6]})
+    qc.to_parquet(tmp_path / "qc.parquet")
+    desc = pd.DataFrame(
+        np.arange(12, dtype=float).reshape(6, 2),
+        columns=["f0", "f1"],
+    )
+    desc["composition"] = _COMPS
+    desc.to_parquet(tmp_path / "desc.parquet")
+    toml = f"""
+[descriptor]
+kind = "precomputed"
+path = "{tmp_path / "desc.parquet"}"
+
+[datasets.qc]
+path = "{tmp_path / "qc.parquet"}"
+
+[[tasks]]
+name = "density"
+kind = "regression"
+dataset = "qc"
+column = "density"
+"""
+    cat = TaskCatalog(_build(toml))
+    assert cat.kmd() is None
+    fn = cat.descriptor_fn()
+    out = fn(["Fe2 O3", "Al2 O3"])
+    assert list(out.index) == ["Fe2 O3", "Al2 O3"]
+    assert cat.descriptor_dim == 2
+
+
+def test_build_datamodule(catalog_dir) -> None:
+    cat = _catalog(catalog_dir)
+    dm = cat.build_datamodule(["density", "mat"], masking_ratios={"density": 0.5}, predict_idx="test")
+    assert isinstance(dm, CompoundDataModule)
+    cfgs = {c.name: c for c in dm.task_configs}
+    assert cfgs["density"].task_masking_ratio == 0.5
+    assert cfgs["density"].predict_idx == "test"

--- a/src/foundation_model/workflows/task_catalog_test.py
+++ b/src/foundation_model/workflows/task_catalog_test.py
@@ -212,6 +212,54 @@ replay = {replay!r}
             _build(toml)
 
 
+def test_unsupported_extension_raises() -> None:
+    toml = """
+[datasets.qc]
+path = "data/qc.pickle"
+
+[[tasks]]
+name = "density"
+kind = "regression"
+dataset = "qc"
+column = "density"
+"""
+    with pytest.raises(ValueError, match="unsupported data file"):
+        _build(toml)
+
+
+def test_multi_suffix_extension_accepted() -> None:
+    toml = """
+[datasets.qc]
+path = "data/qc.pd.parquet"
+
+[[tasks]]
+name = "density"
+kind = "regression"
+dataset = "qc"
+column = "density"
+"""
+    assert "qc" in _build(toml).datasets
+
+
+def test_kmd_n_grids_below_two_raises() -> None:
+    toml = """
+[descriptor]
+kind = "kmd"
+n_grids = 1
+
+[datasets.qc]
+path = "data/qc.parquet"
+
+[[tasks]]
+name = "density"
+kind = "regression"
+dataset = "qc"
+column = "density"
+"""
+    with pytest.raises(ValueError, match="n_grids must be >= 2"):
+        _build(toml)
+
+
 # --- TaskCatalog with synthetic fixtures -------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

First PR of the unified `fm` CLI refactor (plan in `docs/refactor_fm_cli/`). Adds two
library-only modules — no CLI, no legacy code touched.

- **`workflows/task_catalog.py`** — TOML-driven task catalog. `build_task_catalog_config`
  normalizes the parsed-TOML tree (`[data]`/`[descriptor]`/`[datasets.*]`/`[[tasks]]`) into
  validated dataclasses (unknown keys rejected by name). `TaskCatalog` loads composition-keyed
  frames once, produces on-the-fly invertible KMD-1d descriptors (or precomputed lookups),
  builds per-task model configs (with kernel init-from-data), applies per-task scaler
  inverse-transform, and assembles `CompoundDataModule`s.
- **`workflows/recording.py`** — the single artifact writer for training/predict flows:
  `run_provenance.json` (resolved config + package versions + git + argv + seeds), per-step
  checkpoints, final model + taskconfigs, prediction parquets, metrics json/csv, figures, and
  `load_checkpoint_state` (normalizes rehearsal-schema and bare-state_dict checkpoints).

Also lands the refined 6-PR plan under `docs/refactor_fm_cli/` (source refs verified against
`master`).

## Design notes

- Config stack is dataclasses + stdlib `tomllib` + stdlib `json` (no pydantic/omegaconf); the
  CLI in PR2 will use `click`.
- Intentional scope boundary: the catalog loads **model-ready** target columns — legacy inline
  forward preprocessing (log1p/z-score, 5→3 label merge) is not reproduced; per-task `scaler`
  provides inverse-transform for reporting only.
- Kernel init uses the quantile+span initializer the pretrain path exercises today.

## Validation

- `pytest src/foundation_model/workflows/` → 32 passed.
- Full suite → 380 passed, 1 skipped.
- `ruff format`/`ruff check`/`mypy` clean on all new files. (Pre-existing legacy `scripts/`
  mypy/ruff debt is untouched and out of scope.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCoVwB3pntFi25YnpoHYwY