### PR TITLE
PR2 — fm pretrain: rehearsal engine + plots + click CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 authors = [{ name = "TsumiNa", email = "liu.chang.1865@gmail.com" }]
 requires-python = ">=3.11, <3.14"
 dependencies = [
+    "click>=8.1",
     "joblib>=1.5.0",
     "lightning[pytorch-extra]>=2.5.5",
     "loguru>=0.7.3",
@@ -38,6 +39,7 @@ classifiers = [
 
 
 [project.scripts]
+fm = "foundation_model.cli.main:main"
 fm-trainer = "foundation_model.scripts.train:cli_main"
 fm-pretrain-suite = "foundation_model.scripts.dynamic_task_suite:main"
 fm-progressive-clf = "foundation_model.scripts.multi_task_progressive_clf:main"

--- a/samples/pretrain_smoke.toml
+++ b/samples/pretrain_smoke.toml
@@ -1,0 +1,74 @@
+# Smoke-test config for `fm pretrain` — a fast CPU end-to-end run.
+#
+# 3 regression tasks over 2 NEMAD datasets, KMD-1d descriptors, sample=200 rows/dataset,
+# rehearsal interval=2, a 2-run sweep, 2 epochs/step.
+#
+#   fm pretrain --config samples/pretrain_smoke.toml
+
+[data]
+composition_column = "composition"
+val_split = 0.1
+test_split = 0.1
+split_random_seed = 42
+batch_size = 64
+num_workers = 0
+
+[descriptor]
+kind = "kmd"
+n_grids = 8
+
+[datasets.supercon]
+path = "data/NEMAD_superconductor_20260425.parquet"
+sample = 200
+
+[datasets.magnetic]
+path = "data/NEMAD_magnetic_20260419.parquet"
+sample = 200
+
+[[tasks]]
+name = "tc"
+kind = "regression"
+dataset = "supercon"
+column = "Transition temperature[K]"
+
+[[tasks]]
+name = "pressure"
+kind = "regression"
+dataset = "supercon"
+column = "Pressure[GPa]"
+
+[[tasks]]
+name = "moment"
+kind = "regression"
+dataset = "magnetic"
+column = "Magnetic moment[μB/f.u.]"
+
+[model]
+latent_dim = 32
+encoder_hidden = 64
+head_hidden_dim = 32
+n_kernel = 8
+
+[training]
+max_epochs = 2
+early_stop_patience = 3
+early_stop_min_delta = 1e-4
+encoder_lr = 5e-3
+head_lr = 5e-3
+kr_lr = 5e-4
+ae_lr = 5e-3
+accelerator = "cpu"
+devices = 1
+seed = 2025
+
+[pretrain]
+task_sequence = ["tc", "pressure", "moment"]
+n_runs = 2
+task_order = "fixed"
+
+[pretrain.rehearsal]
+interval = 2
+default_replay = 0.1
+
+[output]
+dir = "artifacts/pretrain_smoke"

--- a/src/foundation_model/cli/__init__.py
+++ b/src/foundation_model/cli/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The unified ``fm`` command-line interface (thin click dispatch → workflow engines)."""

--- a/src/foundation_model/cli/main.py
+++ b/src/foundation_model/cli/main.py
@@ -1,0 +1,132 @@
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``fm`` — the unified foundation-model CLI.
+
+This layer is intentionally THIN: each subcommand loads a TOML file, applies ``--set`` /
+first-class-flag overrides onto the raw tree, builds the workflow config dataclass, writes
+provenance, and calls exactly one ``workflows.<mod>.run(cfg)``. No business logic lives here.
+"""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+import click
+
+from foundation_model.workflows.pretrain import PretrainConfig, build_pretrain_config
+from foundation_model.workflows.pretrain import run as pretrain_run
+from foundation_model.workflows.recording import RunRecorder
+
+
+def _parse_toml_value(value: str) -> Any:
+    """Parse a ``--set`` value with TOML semantics (strings must be quoted, e.g. ``'"foo"'``)."""
+    try:
+        return tomllib.loads(f"_v_ = {value}")["_v_"]
+    except tomllib.TOMLDecodeError as exc:
+        raise click.BadParameter(f"could not parse override value {value!r} as TOML: {exc}") from exc
+
+
+def _set_dotted(tree: dict[str, Any], dotted_key: str, value: Any) -> None:
+    parts = dotted_key.split(".")
+    node = tree
+    for part in parts[:-1]:
+        child = node.get(part)
+        if not isinstance(child, dict):
+            child = {}
+            node[part] = child
+        node = child
+    node[parts[-1]] = value
+
+
+def load_raw_config(
+    config_path: str | Path,
+    overrides: Sequence[str] = (),
+    *,
+    seed: int | None = None,
+    accelerator: str | None = None,
+    sample: int | None = None,
+) -> dict[str, Any]:
+    """Load a TOML file and apply ``--set`` overrides plus common first-class flags."""
+
+    with open(config_path, "rb") as fh:
+        raw: dict[str, Any] = tomllib.load(fh)
+
+    for override in overrides:
+        if "=" not in override:
+            raise click.BadParameter(f"--set expects SECTION.KEY=VALUE, got {override!r}")
+        key, _, value = override.partition("=")
+        _set_dotted(raw, key.strip(), _parse_toml_value(value.strip()))
+
+    if seed is not None:
+        _set_dotted(raw, "training.seed", seed)
+    if accelerator is not None:
+        _set_dotted(raw, "training.accelerator", accelerator)
+    if sample is not None:
+        for name in raw.get("datasets", {}):
+            _set_dotted(raw, f"datasets.{name}.sample", sample)
+    return raw
+
+
+def common_options(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Attach the options shared by every subcommand."""
+    options = [
+        click.option("--config", "config_path", required=True, type=click.Path(exists=True, dir_okay=False)),
+        click.option("--output-dir", "output_dir", default=None, help="Override the run output directory."),
+        click.option("--set", "overrides", multiple=True, metavar="SECTION.KEY=VALUE", help="Override a TOML value."),
+        click.option("--seed", type=int, default=None, help="Override training.seed."),
+        click.option("--accelerator", default=None, help="Override training.accelerator."),
+        click.option("--sample", type=int, default=None, help="Cap rows for every dataset (smoke runs)."),
+    ]
+    for option in reversed(options):
+        func = option(func)
+    return func
+
+
+@click.group()
+@click.version_option(package_name="foundation-model", prog_name="fm")
+def main() -> None:
+    """Unified foundation-model CLI (pretrain / finetune / inverse / predict)."""
+
+
+def _pretrain_config(
+    config_path: str,
+    overrides: Sequence[str],
+    output_dir: str | None,
+    seed: int | None,
+    accelerator: str | None,
+    sample: int | None,
+    max_epochs: int | None,
+) -> PretrainConfig:
+    raw = load_raw_config(config_path, overrides, seed=seed, accelerator=accelerator, sample=sample)
+    if max_epochs is not None:
+        _set_dotted(raw, "training.max_epochs", max_epochs)
+    return build_pretrain_config(raw, output_dir=output_dir)
+
+
+@main.command("pretrain")
+@common_options
+@click.option("--max-epochs", type=int, default=None, help="Override training.max_epochs.")
+def pretrain_cmd(
+    config_path: str,
+    output_dir: str | None,
+    overrides: tuple[str, ...],
+    seed: int | None,
+    accelerator: str | None,
+    sample: int | None,
+    max_epochs: int | None,
+) -> None:
+    """Continual-rehearsal pre-training (multi-run sweep)."""
+    cfg = _pretrain_config(config_path, overrides, output_dir, seed, accelerator, sample, max_epochs)
+    recorder = RunRecorder(cfg.output_dir)
+    recorder.write_provenance(config=cfg, argv=list(sys.argv), seeds={"seed": cfg.training.seed})
+    pretrain_run(cfg, recorder)
+    recorder.close()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/foundation_model/cli/main_test.py
+++ b/src/foundation_model/cli/main_test.py
@@ -1,0 +1,89 @@
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for :mod:`foundation_model.cli.main`."""
+
+from __future__ import annotations
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from foundation_model.cli.main import _parse_toml_value, _pretrain_config, load_raw_config, main
+
+_CONFIG = """
+[descriptor]
+kind = "kmd"
+
+[datasets.d1]
+path = "data/x.parquet"
+
+[[tasks]]
+name = "a"
+kind = "regression"
+dataset = "d1"
+column = "a"
+
+[training]
+max_epochs = 10
+
+[output]
+dir = "out"
+"""
+
+
+def _write_config(tmp_path):
+    path = tmp_path / "c.toml"
+    path.write_text(_CONFIG)
+    return str(path)
+
+
+def test_set_override_applies_to_built_config(tmp_path) -> None:
+    cfg = _pretrain_config(_write_config(tmp_path), ("training.max_epochs=3",), None, None, None, None, None)
+    assert cfg.training.max_epochs == 3
+
+
+def test_max_epochs_flag_overrides(tmp_path) -> None:
+    cfg = _pretrain_config(_write_config(tmp_path), (), None, None, None, None, 5)
+    assert cfg.training.max_epochs == 5
+
+
+def test_seed_and_sample_flags_map_into_tree(tmp_path) -> None:
+    raw = load_raw_config(_write_config(tmp_path), seed=99, sample=50)
+    assert raw["training"]["seed"] == 99
+    assert raw["datasets"]["d1"]["sample"] == 50
+
+
+def test_output_dir_flag_overrides(tmp_path) -> None:
+    cfg = _pretrain_config(_write_config(tmp_path), (), "/tmp/custom", None, None, None, None)
+    assert str(cfg.output_dir) == "/tmp/custom"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("3", 3), ("1.5", 1.5), ('"foo"', "foo"), ("true", True), ("[1, 2]", [1, 2])],
+)
+def test_parse_toml_value(value: str, expected: object) -> None:
+    assert _parse_toml_value(value) == expected
+
+
+def test_set_without_equals_errors(tmp_path) -> None:
+    with pytest.raises(click.BadParameter):
+        load_raw_config(_write_config(tmp_path), ("training.max_epochs",))
+
+
+def test_unknown_subcommand_exits_nonzero() -> None:
+    result = CliRunner().invoke(main, ["frobnicate"])
+    assert result.exit_code != 0
+
+
+def test_missing_config_file_errors() -> None:
+    result = CliRunner().invoke(main, ["pretrain", "--config", "/no/such/file.toml"])
+    assert result.exit_code != 0
+    assert "does not exist" in result.output.lower()
+
+
+def test_help_lists_pretrain() -> None:
+    result = CliRunner().invoke(main, ["--help"])
+    assert result.exit_code == 0
+    assert "pretrain" in result.output

--- a/src/foundation_model/workflows/plots.py
+++ b/src/foundation_model/workflows/plots.py
@@ -1,0 +1,218 @@
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure plotting helpers for the training workflows.
+
+Each function takes plain data and **returns a matplotlib ``Figure``** — it has no knowledge of
+the output layout; the caller hands the figure to :meth:`RunRecorder.save_figure`. Migrated from
+``scripts/continual_rehearsal_common.py`` (parity / confusion / kr-sequences) and
+``continual_rehearsal_full._plot_forgetting`` (refactored to take a task→color map and the set of
+classification tasks instead of runner ``self`` state).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless-safe: no display backend needed for file output
+
+import matplotlib.pyplot as plt  # noqa: E402  (must follow matplotlib.use)
+import numpy as np  # noqa: E402
+from matplotlib.figure import Figure  # noqa: E402
+from sklearn.metrics import r2_score  # type: ignore[import-untyped]  # noqa: E402
+
+# --- Shared constants (migrated from continual_rehearsal_common) --------------------------
+
+#: Single blue for every regression parity scatter and KR-prediction line.
+SCATTER_COLOR = "#2563EB"
+#: Orange highlight for inverse-design "discovered" elements.
+DISCOVERED_ELEMENT_COLOR = "#E67E22"
+#: Merged material_type label set (canonical index order: class 0 == "AC").
+MATERIAL_TYPE_CLASSES: tuple[str, ...] = ("AC", "QC", "others")
+#: Confusion-matrix axis order (bottom-left → top-right, minority QC upper-right).
+MATERIAL_TYPE_DISPLAY_ORDER: tuple[str, ...] = ("others", "AC", "QC")
+
+
+def plot_parity(true: np.ndarray, pred: np.ndarray, *, r2: float, title: str) -> Figure:
+    """Regression parity scatter (true vs predicted) with ideal line and an R² annotation."""
+    fig, ax = plt.subplots(figsize=(5, 5))
+    ax.scatter(true, pred, s=14, alpha=0.55, color=SCATTER_COLOR, edgecolor="none")
+    lo, hi = float(min(true.min(), pred.min())), float(max(true.max(), pred.max()))
+    ax.plot([lo, hi], [lo, hi], color="#444444", ls="--", lw=1.2, label="ideal")
+    ax.set_xlabel("True")
+    ax.set_ylabel("Predicted")
+    ax.set_title(title)
+    ax.text(
+        0.04,
+        0.96,
+        f"R² = {r2:.3f}\nn = {len(true)}",
+        transform=ax.transAxes,
+        ha="left",
+        va="top",
+        fontsize=10,
+        bbox=dict(boxstyle="round,pad=0.4", facecolor="white", edgecolor="#d0d0d0", alpha=0.9),
+    )
+    ax.legend(loc="lower right")
+    return fig
+
+
+def plot_confusion(
+    true: np.ndarray,
+    pred: np.ndarray,
+    *,
+    num_classes: int,
+    acc: float,
+    title: str,
+    special_material_type: bool = False,
+) -> Figure:
+    """Row-normalised confusion matrix (recall diagonal), annotated with fraction + raw count.
+
+    When ``special_material_type`` is set (the merged 3-class material_type task) axes are
+    reordered to ``MATERIAL_TYPE_DISPLAY_ORDER``.
+    """
+    counts = np.zeros((num_classes, num_classes), dtype=int)
+    for t, p in zip(true, pred):
+        if 0 <= t < num_classes and 0 <= p < num_classes:
+            counts[t, p] += 1
+    if special_material_type:
+        labels = list(MATERIAL_TYPE_DISPLAY_ORDER[:num_classes])
+        perm = [MATERIAL_TYPE_CLASSES.index(lbl) for lbl in labels]
+    else:
+        labels = [str(i) for i in range(num_classes)]
+        perm = list(range(num_classes))
+    counts = counts[np.ix_(perm, perm)]
+    row_sums = counts.sum(axis=1, keepdims=True)
+    row_frac = np.divide(counts, row_sums, out=np.zeros(counts.shape, dtype=float), where=row_sums > 0)
+    fig, ax = plt.subplots(figsize=(5.6, 5.2))
+    im = ax.imshow(row_frac, cmap="Blues", vmin=0.0, vmax=1.0, origin="lower")
+    fig.colorbar(im, ax=ax, label="row-normalized fraction (recall)", fraction=0.046, pad=0.04)
+    ax.set_xticks(range(num_classes), labels, rotation=45, ha="right")
+    ax.set_yticks(range(num_classes), labels)
+    for i in range(num_classes):
+        for j in range(num_classes):
+            if counts[i, j]:
+                ax.text(
+                    j,
+                    i,
+                    f"{row_frac[i, j] * 100:.0f}%\n{counts[i, j]}",
+                    ha="center",
+                    va="center",
+                    fontsize=8,
+                    color="white" if row_frac[i, j] > 0.5 else "#333333",
+                )
+    ax.grid(False)
+    ax.set_xlabel("Predicted")
+    ax.set_ylabel("True")
+    ax.set_title(title)
+    ax.text(
+        0.5,
+        -0.22,
+        f"accuracy = {acc:.3f}  ·  n = {int(counts.sum())}",
+        transform=ax.transAxes,
+        ha="center",
+        va="top",
+        fontsize=10,
+    )
+    return fig
+
+
+def plot_kr_sequences(
+    comps: Sequence[str],
+    t_list: Sequence[np.ndarray],
+    true_parts: Sequence[np.ndarray],
+    pred: np.ndarray,
+    *,
+    title: str,
+) -> Figure | None:
+    """Per-composition KR sequence panels (up to 3), each with its own R² annotation.
+
+    Returns ``None`` when there are no compositions to plot (small KR datasets can produce an
+    empty test set at a given step).
+    """
+    k = min(3, len(comps))
+    if k == 0:
+        return None
+    fig, axes = plt.subplots(1, k, figsize=(4.2 * k, 3.7), squeeze=False)
+    offset = 0
+    line_true = line_pred = None
+    for i in range(k):
+        ax = axes[0][i]
+        n = int(true_parts[i].size)
+        t = np.asarray(t_list[i])
+        true_i = np.asarray(true_parts[i])
+        pred_i = pred[offset : offset + n]
+        order = np.argsort(t)
+        (line_true,) = ax.plot(t[order], true_i[order], color="#444444", lw=1.8, label="True")
+        (line_pred,) = ax.plot(t[order], pred_i[order], color=SCATTER_COLOR, lw=1.6, ls="--", label="Predicted")
+        ax.set_xlabel("t")
+        if i == 0:
+            ax.set_ylabel("Value")
+        r2_i = float(r2_score(true_i, pred_i)) if n >= 2 and float(np.var(true_i)) > 0 else float("nan")
+        ax.text(
+            0.96,
+            0.96,
+            f"R² = {r2_i:.3f}",
+            transform=ax.transAxes,
+            ha="right",
+            va="top",
+            fontsize=9,
+            bbox=dict(boxstyle="round,pad=0.4", facecolor="white", edgecolor="#d0d0d0", alpha=0.9),
+        )
+        ax.set_title(str(comps[i]), fontsize=9)
+        offset += n
+    if line_true is not None and line_pred is not None:
+        fig.legend(
+            [line_true, line_pred],
+            ["True", "Predicted"],
+            loc="lower left",
+            ncol=2,
+            bbox_to_anchor=(0.0, 1.10),
+            bbox_transform=axes[0][0].transAxes,
+        )
+    fig.suptitle(title, y=1.24)
+    return fig
+
+
+def plot_forgetting(
+    metric_history: Mapping[str, Sequence[tuple[int, float]]],
+    *,
+    task_colors: Mapping[str, str],
+    clf_tasks: frozenset[str] = frozenset(),
+    task_display: Mapping[str, str] | None = None,
+) -> Figure:
+    """Per-task primary metric across continual finetuning steps.
+
+    ``metric_history`` maps task → ``[(step, primary_metric), ...]``. ``clf_tasks`` selects the
+    classification marker/linestyle; ``task_display`` optionally maps task → pretty label.
+    """
+    task_display = task_display or {}
+    n_tasks = sum(1 for pts in metric_history.values() if pts)
+    fig, ax = plt.subplots(figsize=(14, max(5.5, 0.32 * n_tasks + 3)))
+    all_steps: set[int] = set()
+    for task_name, points in metric_history.items():
+        if not points:
+            continue
+        steps = [s for s, _ in points]
+        vals = [v for _, v in points]
+        all_steps.update(steps)
+        is_clf = task_name in clf_tasks
+        label = task_display.get(task_name, task_name) + (" · accuracy" if is_clf else "")
+        ax.plot(
+            steps,
+            vals,
+            marker="s" if is_clf else "o",
+            ms=5,
+            ls="--" if is_clf else "-",
+            color=task_colors.get(task_name, "#888888"),
+            label=label,
+        )
+    if all_steps:
+        ax.set_xticks(sorted(all_steps))
+    ax.set_xlabel("Continual finetuning step (a new task is added at each step)")
+    ax.set_ylabel("Primary metric  ·  R² (regression) / accuracy (classification)")
+    ax.set_title("Per-task performance across continual finetuning")
+    ncol = 1 if n_tasks <= 20 else 2
+    ax.legend(fontsize=8, ncol=ncol, loc="upper left", bbox_to_anchor=(1.01, 1.0), borderaxespad=0.0)
+    return fig

--- a/src/foundation_model/workflows/plots_test.py
+++ b/src/foundation_model/workflows/plots_test.py
@@ -1,0 +1,60 @@
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Smoke tests for :mod:`foundation_model.workflows.plots` (render without error)."""
+
+from __future__ import annotations
+
+import numpy as np
+from matplotlib.figure import Figure
+
+from foundation_model.workflows import plots
+
+
+def test_plot_parity_returns_figure() -> None:
+    fig = plots.plot_parity(np.array([1.0, 2.0, 3.0]), np.array([1.1, 1.9, 3.2]), r2=0.9, title="t")
+    assert isinstance(fig, Figure)
+    plots.plt.close(fig)
+
+
+def test_plot_confusion_returns_figure() -> None:
+    fig = plots.plot_confusion(np.array([0, 1, 2, 1]), np.array([0, 1, 1, 2]), num_classes=3, acc=0.5, title="t")
+    assert isinstance(fig, Figure)
+    plots.plt.close(fig)
+
+
+def test_plot_confusion_special_material_type() -> None:
+    fig = plots.plot_confusion(
+        np.array([0, 1, 2]), np.array([0, 1, 2]), num_classes=3, acc=1.0, title="t", special_material_type=True
+    )
+    assert isinstance(fig, Figure)
+    plots.plt.close(fig)
+
+
+def test_plot_kr_sequences_returns_figure() -> None:
+    comps = ["Fe2 O3", "Al2 O3"]
+    t_list = [np.array([1.0, 2.0, 3.0]), np.array([1.0, 2.0])]
+    true_parts = [np.array([0.1, 0.2, 0.3]), np.array([0.4, 0.5])]
+    pred = np.array([0.1, 0.2, 0.3, 0.4, 0.5])
+    fig = plots.plot_kr_sequences(comps, t_list, true_parts, pred, title="t")
+    assert isinstance(fig, Figure)
+    plots.plt.close(fig)
+
+
+def test_plot_kr_sequences_empty_returns_none() -> None:
+    assert plots.plot_kr_sequences([], [], [], np.array([]), title="t") is None
+
+
+def test_plot_forgetting_returns_figure() -> None:
+    history = {"a": [(1, 0.5), (2, 0.6)], "b": [(2, 0.7)]}
+    fig = plots.plot_forgetting(history, task_colors={"a": "#111111", "b": "#222222"}, clf_tasks=frozenset({"b"}))
+    assert isinstance(fig, Figure)
+    plots.plt.close(fig)
+
+
+def test_plot_saves_to_file(tmp_path) -> None:
+    fig = plots.plot_parity(np.array([1.0, 2.0]), np.array([1.0, 2.0]), r2=1.0, title="t")
+    out = tmp_path / "parity.png"
+    fig.savefig(out)
+    plots.plt.close(fig)
+    assert out.exists()

--- a/src/foundation_model/workflows/pretrain.py
+++ b/src/foundation_model/workflows/pretrain.py
@@ -1,0 +1,591 @@
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``fm pretrain`` — continual-rehearsal pre-training engine with an n-runs sweep.
+
+Migrated from ``scripts/continual_rehearsal_full.py`` (``ContinualRehearsalFullRunner.run`` /
+``_build_empty_model`` / ``_evaluate_task``) with three deliberate changes vs. the legacy runner:
+
+1. **Rehearsal interval** (new): on step ``s`` (1-based) already-learned tasks join training only
+   when ``s % interval == 0``; other steps train the new task + AE alone. ``interval == 1``
+   reproduces the legacy "every step replays every old task" behaviour. Evaluation still covers
+   **all** learned heads at every step (the forgetting trajectory is interval-independent).
+2. **Replay amount** replaces the legacy ``fixed_tail`` / ``replay_ratio_high`` two-tier design:
+   a global ``default_replay`` plus per-task overrides, each a fraction (< 1) or an absolute
+   label count (>= 1, converted to a ratio against the task's valid-label count).
+3. **n-runs sweep**: ``n_runs > 1`` writes ``runs/runNN/`` subdirectories with a per-run seed and
+   (optionally) a reshuffled task order, aggregated into a top-level ``experiment_records.json``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import torch
+from lightning import Trainer, seed_everything
+from lightning.pytorch.callbacks import Callback, EarlyStopping
+from loguru import logger
+from sklearn.metrics import accuracy_score, f1_score, mean_absolute_error, r2_score  # type: ignore[import-untyped]
+from torch.utils.data import DataLoader
+
+from foundation_model.data.datamodule import CompoundDataModule
+from foundation_model.models.flexible_multi_task_model import FlexibleMultiTaskModel
+from foundation_model.models.model_config import MLPEncoderConfig, OptimizerConfig
+
+from . import plots
+from .recording import RunRecorder
+from .task_catalog import TaskCatalog, TaskCatalogConfig, TaskKind, build_task_catalog_config
+
+# Reserved built-in autoencoder head name (see FlexibleMultiTaskModel).
+_AE_NAME = "__reconstruction__"
+# Legacy head weight decay for regression / classification heads (kernel heads use kr_weight_decay).
+_HEAD_WEIGHT_DECAY = 1e-5
+# Stable qualitative palette so each task keeps one colour across the forgetting figure.
+_TASK_PALETTE = (
+    "#4C72B0", "#DD8452", "#55A868", "#C44E52", "#8172B3", "#937860",
+    "#DA8BC3", "#8C8C8C", "#CCB974", "#64B5CD", "#E377C2", "#17BECF",
+)  # fmt: skip
+
+# Root TOML sections a pretrain config may contain.
+_PRETRAIN_ROOT_KEYS = {"data", "descriptor", "datasets", "tasks", "model", "training", "pretrain", "output"}
+_CATALOG_KEYS = {"data", "descriptor", "datasets", "tasks"}
+
+
+class TaskOrder(str, Enum):
+    FIXED = "fixed"
+    RANDOM = "random"
+
+
+# --- config dataclasses -------------------------------------------------------------------
+
+
+@dataclass(kw_only=True)
+class ModelSectionConfig:
+    """[model] — architecture dims shared with finetune."""
+
+    latent_dim: int = 128
+    encoder_hidden: int = 256
+    head_hidden_dim: int = 64
+    n_kernel: int = 15
+
+    def __post_init__(self) -> None:
+        for name in ("latent_dim", "encoder_hidden", "head_hidden_dim", "n_kernel"):
+            if getattr(self, name) < 1:
+                raise ValueError(f"model.{name} must be >= 1, got {getattr(self, name)}.")
+
+
+@dataclass(kw_only=True)
+class TrainingSectionConfig:
+    """[training] — epochs, early-stop, learning rates, accelerator (shared with finetune)."""
+
+    max_epochs: int = 100
+    early_stop_patience: int = 8
+    early_stop_min_delta: float = 1e-4
+    encoder_lr: float = 5e-3
+    head_lr: float = 5e-3
+    kr_lr: float = 5e-4
+    kr_weight_decay: float = 5e-5
+    ae_lr: float = 5e-3
+    accelerator: str = "auto"
+    devices: int = 1
+    seed: int = 2025
+
+    def __post_init__(self) -> None:
+        if self.max_epochs < 1:
+            raise ValueError(f"training.max_epochs must be >= 1, got {self.max_epochs}.")
+        if self.early_stop_patience < 1:
+            raise ValueError(f"training.early_stop_patience must be >= 1, got {self.early_stop_patience}.")
+
+
+def _validate_replay_amount(value: float | int, *, where: str) -> None:
+    if isinstance(value, bool):
+        raise ValueError(f"{where}: replay must be a number, got bool {value!r}.")
+    if isinstance(value, float):
+        if not 0.0 < value < 1.0:
+            raise ValueError(f"{where}: replay float must be in (0, 1), got {value}.")
+    elif isinstance(value, int):
+        if value < 1:
+            raise ValueError(f"{where}: replay int must be >= 1, got {value}.")
+    else:
+        raise ValueError(f"{where}: replay must be a float in (0, 1) or int >= 1, got {value!r}.")
+
+
+@dataclass(kw_only=True)
+class RehearsalConfig:
+    """[pretrain.rehearsal] — interval schedule + replay amounts."""
+
+    interval: int = 1
+    default_replay: float | int = 0.05
+    per_task: dict[str, float | int] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.interval < 1:
+            raise ValueError(f"rehearsal.interval must be >= 1, got {self.interval}.")
+        _validate_replay_amount(self.default_replay, where="rehearsal.default_replay")
+        for task, value in self.per_task.items():
+            _validate_replay_amount(value, where=f"rehearsal.per_task.{task}")
+
+
+@dataclass(kw_only=True)
+class PretrainConfig:
+    catalog: TaskCatalogConfig
+    model: ModelSectionConfig
+    training: TrainingSectionConfig
+    rehearsal: RehearsalConfig
+    output_dir: Path
+    task_sequence: list[str] = field(default_factory=list)
+    n_runs: int = 1
+    task_order: TaskOrder = TaskOrder.FIXED
+
+    def __post_init__(self) -> None:
+        self.output_dir = Path(self.output_dir)
+        if not isinstance(self.task_order, TaskOrder):
+            self.task_order = TaskOrder(str(self.task_order))
+        if self.n_runs < 1:
+            raise ValueError(f"pretrain.n_runs must be >= 1, got {self.n_runs}.")
+        catalog_tasks = {t.name for t in self.catalog.tasks}
+        if not self.task_sequence:
+            self.task_sequence = [t.name for t in self.catalog.tasks]
+        unknown = [t for t in self.task_sequence if t not in catalog_tasks]
+        if unknown:
+            raise ValueError(f"pretrain.task_sequence references unknown task(s): {unknown}.")
+        bad_replay = [t for t in self.rehearsal.per_task if t not in catalog_tasks]
+        if bad_replay:
+            raise ValueError(f"rehearsal.per_task references unknown task(s): {bad_replay}.")
+
+
+# --- builder ------------------------------------------------------------------------------
+
+
+def _reject_unknown(section: str, raw: Mapping[str, Any], known: set[str]) -> None:
+    unknown = sorted(set(raw) - known)
+    if unknown:
+        raise ValueError(f"[{section}]: unknown key(s) {unknown}; allowed keys are {sorted(known)}.")
+
+
+def build_pretrain_config(raw: Mapping[str, Any], *, output_dir: str | Path | None = None) -> PretrainConfig:
+    """Normalize a parsed-TOML tree into a :class:`PretrainConfig`."""
+
+    _reject_unknown("<root>", raw, _PRETRAIN_ROOT_KEYS)
+    catalog = build_task_catalog_config({k: raw[k] for k in _CATALOG_KEYS if k in raw})
+
+    model_raw = dict(raw.get("model", {}))
+    _reject_unknown("model", model_raw, set(ModelSectionConfig.__dataclass_fields__))
+    model = ModelSectionConfig(**model_raw)
+
+    training_raw = dict(raw.get("training", {}))
+    _reject_unknown("training", training_raw, set(TrainingSectionConfig.__dataclass_fields__))
+    training = TrainingSectionConfig(**training_raw)
+
+    pretrain_raw = dict(raw.get("pretrain", {}))
+    _reject_unknown("pretrain", pretrain_raw, {"task_sequence", "n_runs", "task_order", "rehearsal"})
+    rehearsal_raw = dict(pretrain_raw.get("rehearsal", {}))
+    _reject_unknown("pretrain.rehearsal", rehearsal_raw, {"interval", "default_replay", "per_task"})
+    rehearsal = RehearsalConfig(
+        interval=rehearsal_raw.get("interval", 1),
+        default_replay=rehearsal_raw.get("default_replay", 0.05),
+        per_task=dict(rehearsal_raw.get("per_task", {})),
+    )
+
+    resolved_output = output_dir if output_dir is not None else raw.get("output", {}).get("dir")
+    if resolved_output is None:
+        raise ValueError("output directory must be given via --output-dir or [output].dir.")
+
+    return PretrainConfig(
+        catalog=catalog,
+        model=model,
+        training=training,
+        rehearsal=rehearsal,
+        output_dir=Path(resolved_output),
+        task_sequence=list(pretrain_raw.get("task_sequence", [])),
+        n_runs=int(pretrain_raw.get("n_runs", 1)),
+        task_order=TaskOrder(str(pretrain_raw.get("task_order", "fixed"))),
+    )
+
+
+# --- pure helpers -------------------------------------------------------------------------
+
+
+def active_old_tasks(step: int, learned: Sequence[str], interval: int) -> list[str]:
+    """Old tasks that participate in training at 1-based ``step`` (empty on non-interval steps)."""
+    if interval <= 1 or step % interval == 0:
+        return list(learned)
+    return []
+
+
+def replay_to_ratio(replay: float | int, n_valid: int) -> float:
+    """Convert a replay amount (fraction or absolute count) to a keep-ratio in [0, 1]."""
+    if isinstance(replay, float):
+        return replay
+    if n_valid <= 0:
+        return 1.0
+    return min(1.0, replay / n_valid)
+
+
+class _DropLastTrainCompoundDataModule(CompoundDataModule):
+    """``CompoundDataModule`` whose train loader drops the final partial batch.
+
+    Guards against BatchNorm1d crashing on a size-1 tail batch (``Expected more than 1 value per
+    channel``). Only the train loader is affected; val/test/predict keep every held-out row.
+    """
+
+    def train_dataloader(self) -> DataLoader | None:  # type: ignore[override]
+        base = super().train_dataloader()
+        if base is None:
+            return None
+        return DataLoader(
+            base.dataset,
+            batch_size=base.batch_size,
+            shuffle=True,
+            num_workers=base.num_workers,
+            pin_memory=base.pin_memory,
+            collate_fn=base.collate_fn,
+            drop_last=True,
+        )
+
+
+def _as_float_array(cell: Any) -> np.ndarray:
+    import ast
+
+    if isinstance(cell, str):
+        cell = ast.literal_eval(cell)
+    return np.asarray(cell, dtype=float).ravel()
+
+
+# --- engine -------------------------------------------------------------------------------
+
+
+def run(cfg: PretrainConfig, recorder: RunRecorder | None = None) -> dict[str, Any]:
+    """Execute the pretraining sweep. Returns the aggregated cross-run records dict.
+
+    ``recorder`` is the root recorder (already carrying provenance); per-run recorders are created
+    under it. When ``n_runs == 1`` the single run writes directly under ``output_dir``.
+    """
+
+    catalog = TaskCatalog(cfg.catalog)
+    root_recorder = recorder or RunRecorder(cfg.output_dir)
+    aggregate: list[dict[str, Any]] = []
+
+    for run_idx in range(cfg.n_runs):
+        run_seed = cfg.training.seed + run_idx
+        order = _run_task_order(cfg, run_seed)
+        if cfg.n_runs == 1:
+            run_recorder = root_recorder
+        else:
+            run_recorder = RunRecorder(cfg.output_dir / "runs" / f"run{run_idx:02d}")
+        logger.info(f"=== pretrain run {run_idx + 1}/{cfg.n_runs} (seed={run_seed}) order={order} ===")
+        records = _run_single(cfg, catalog, run_recorder, task_order=order, seed=run_seed)
+        for rec in records:
+            aggregate.append({"run": run_idx, **rec})
+        if run_recorder is not root_recorder:
+            run_recorder.close()
+
+    cfg.output_dir.mkdir(parents=True, exist_ok=True)
+    (cfg.output_dir / "experiment_records.json").write_text(json.dumps(aggregate, indent=2), encoding="utf-8")
+    return {"records": aggregate}
+
+
+def _run_task_order(cfg: PretrainConfig, seed: int) -> list[str]:
+    if cfg.task_order is TaskOrder.RANDOM:
+        rng = np.random.default_rng(seed)
+        order = list(cfg.task_sequence)
+        rng.shuffle(order)
+        return order
+    return list(cfg.task_sequence)
+
+
+def _run_single(
+    cfg: PretrainConfig,
+    catalog: TaskCatalog,
+    recorder: RunRecorder,
+    *,
+    task_order: Sequence[str],
+    seed: int,
+) -> list[dict[str, Any]]:
+    seed_everything(seed, workers=True)
+    model = _build_empty_model(cfg, catalog)
+
+    task_colors = {name: _TASK_PALETTE[i % len(_TASK_PALETTE)] for i, name in enumerate(task_order)}
+    clf_tasks = frozenset(n for n in task_order if catalog.task_spec(n).kind is TaskKind.CLASSIFICATION)
+    metric_history: dict[str, list[tuple[int, float]]] = {name: [] for name in task_order}
+    records: list[dict[str, Any]] = []
+    built: dict[str, Any] = {}
+
+    for step, task_name in enumerate(task_order, start=1):
+        logger.info(f"--- step {step}/{len(task_order)}: add '{task_name}' ---")
+        built[task_name] = _build_task_config(cfg, catalog, task_name, masking_ratio=1.0)
+        model.add_task(built[task_name])
+
+        learned = list(task_order[: step - 1])
+        participating = active_old_tasks(step, learned, cfg.rehearsal.interval)
+        active = [task_name, *participating]
+        for name in participating:
+            ratio = _replay_ratio_for(cfg, catalog, name)
+            built[name].task_masking_ratio = ratio
+        built[task_name].task_masking_ratio = 1.0
+
+        datamodule = _DropLastTrainCompoundDataModule(
+            task_configs=[built[name] for name in active],
+            descriptor_fn=catalog.descriptor_fn(),
+            task_frames={name: catalog.task_frames([name])[name] for name in active},
+            composition_column=cfg.catalog.data.composition_column,
+            random_seed=cfg.catalog.data.split_random_seed,
+            val_split=cfg.catalog.data.val_split,
+            test_split=cfg.catalog.data.test_split,
+            batch_size=cfg.catalog.data.batch_size,
+            num_workers=cfg.catalog.data.num_workers,
+        )
+        callbacks: list[Callback] = [
+            EarlyStopping(
+                monitor="val_final_loss",
+                mode="min",
+                patience=cfg.training.early_stop_patience,
+                min_delta=cfg.training.early_stop_min_delta,
+            )
+        ]
+        trainer = Trainer(
+            max_epochs=cfg.training.max_epochs,
+            accelerator=cfg.training.accelerator,
+            devices=cfg.training.devices,
+            logger=False,
+            enable_checkpointing=False,
+            enable_progress_bar=False,
+            callbacks=callbacks,
+        )
+        trainer.fit(model, datamodule=datamodule)
+
+        test_keys: set[str] | None = None
+        if datamodule.split_series is not None:
+            resolved = datamodule.split_series
+            test_keys = set(resolved.index[resolved == "test"].astype(str))
+
+        step_dir = recorder.paths.step_dir(step, task_name)
+        step_metrics: dict[str, dict[str, float]] = {}
+        for name in task_order[:step]:  # evaluate ALL learned heads, regardless of interval
+            metric = _evaluate_task(
+                model, catalog, name, recorder, step_dir, is_new=(name == task_name), test_keys=test_keys
+            )
+            step_metrics[name] = metric
+            metric_history[name].append((step, metric["primary"]))
+
+        recorder.save_step_checkpoint(step, task_name, model, list(active))
+        record = {"step": step, "new_task": task_name, "epochs_run": trainer.current_epoch, "metrics": step_metrics}
+        records.append(record)
+        recorder.append_record(record)
+
+    fig = plots.plot_forgetting(metric_history, task_colors=task_colors, clf_tasks=clf_tasks)
+    recorder.save_figure("training/forgetting_trajectory.png", fig)
+    plots.plt.close(fig)
+    recorder.write_records()
+    recorder.write_metrics_table()
+    recorder.save_final_model(model, list(task_order), _task_spec_dump(cfg, catalog, task_order))
+    return records
+
+
+def _build_empty_model(cfg: PretrainConfig, catalog: TaskCatalog) -> FlexibleMultiTaskModel:
+    encoder_config = MLPEncoderConfig(
+        hidden_dims=[catalog.descriptor_dim, cfg.model.encoder_hidden, cfg.model.latent_dim]
+    )
+    model = FlexibleMultiTaskModel(
+        task_configs=[],
+        encoder_config=encoder_config,
+        enable_autoencoder=True,
+        shared_block_optimizer=OptimizerConfig(lr=cfg.training.encoder_lr, weight_decay=1e-2),
+    )
+    # AE head always trains; only its LR is configurable (ae_lr).
+    if _AE_NAME in model.task_configs_map:
+        model.task_configs_map[_AE_NAME].optimizer = OptimizerConfig(lr=cfg.training.ae_lr)
+    return model
+
+
+def _build_task_config(cfg: PretrainConfig, catalog: TaskCatalog, name: str, *, masking_ratio: float) -> Any:
+    spec = catalog.task_spec(name)
+    if spec.kind is TaskKind.KERNEL_REGRESSION:
+        lr, weight_decay = cfg.training.kr_lr, cfg.training.kr_weight_decay
+    else:
+        lr, weight_decay = cfg.training.head_lr, _HEAD_WEIGHT_DECAY
+    return catalog.build_task_config(
+        name,
+        latent_dim=cfg.model.latent_dim,
+        head_hidden_dim=cfg.model.head_hidden_dim,
+        n_kernel=cfg.model.n_kernel,
+        lr=lr,
+        weight_decay=weight_decay,
+        masking_ratio=masking_ratio,
+    )
+
+
+def _replay_ratio_for(cfg: PretrainConfig, catalog: TaskCatalog, name: str) -> float:
+    replay = cfg.rehearsal.per_task.get(name, cfg.rehearsal.default_replay)
+    if isinstance(replay, float):
+        return replay
+    return replay_to_ratio(replay, _n_valid_train_labels(catalog, name))
+
+
+def _n_valid_train_labels(catalog: TaskCatalog, name: str) -> int:
+    spec = catalog.task_spec(name)
+    frame = catalog.task_frames([name])[name]
+    mask = frame[spec.column].notna()
+    if "split" in frame.columns:
+        mask &= frame["split"] == "train"
+    return int(mask.sum())
+
+
+def _task_spec_dump(cfg: PretrainConfig, catalog: TaskCatalog, task_order: Sequence[str]) -> dict[str, Any]:
+    dump: dict[str, Any] = {}
+    for name in task_order:
+        spec = catalog.task_spec(name)
+        dump[name] = {"kind": spec.kind.value, "column": spec.column, "source": spec.dataset}
+    return dump
+
+
+def _test_rows(catalog: TaskCatalog, name: str, test_keys: set[str] | None) -> list[str]:
+    spec = catalog.task_spec(name)
+    frame = catalog.task_frames([name])[name]
+    mask = frame[spec.column].notna()
+    if test_keys is not None:
+        mask &= frame.index.isin(test_keys)
+    elif "split" in frame.columns:
+        mask &= frame["split"] == "test"
+    return list(frame.index[mask])
+
+
+def _descriptor_tensor(catalog: TaskCatalog, comps: list[str], device: torch.device) -> tuple[torch.Tensor, list[str]]:
+    desc = catalog.descriptor_fn()(comps)
+    kept = [c for c in comps if c in desc.index]
+    tensor = torch.tensor(desc.loc[kept].values, dtype=torch.float32, device=device)
+    return tensor, kept
+
+
+def _evaluate_task(
+    model: FlexibleMultiTaskModel,
+    catalog: TaskCatalog,
+    name: str,
+    recorder: RunRecorder,
+    step_dir: Path,
+    *,
+    is_new: bool,
+    test_keys: set[str] | None,
+) -> dict[str, float]:
+    """Evaluate one head on the fixed test split; dump parquet + metrics (+ plot if new)."""
+
+    spec = catalog.task_spec(name)
+    model.eval()
+    device = next(model.parameters()).device
+    comps = _test_rows(catalog, name, test_keys)
+    if not comps:
+        return {"primary": float("nan"), "samples": 0}
+    frame = catalog.task_frames([name])[name]
+    head = model.task_heads[name]
+
+    with torch.no_grad():
+        if spec.kind in (TaskKind.REGRESSION, TaskKind.CLASSIFICATION):
+            x, comps = _descriptor_tensor(catalog, comps, device)
+            if not comps:
+                return {"primary": float("nan"), "samples": 0}
+            h = torch.tanh(model.encoder(x))
+            if spec.kind is TaskKind.REGRESSION:
+                pred = catalog.inverse_transform(name, head(h).squeeze(-1).cpu().numpy())
+                true = catalog.inverse_transform(name, frame.loc[comps, spec.column].astype(float).to_numpy())
+                r2 = float(r2_score(true, pred))
+                metric = {"r2": r2, "mae": float(mean_absolute_error(true, pred)), "samples": len(comps), "primary": r2}
+                recorder.dump_predictions(
+                    step_dir, name, pd.DataFrame({"composition": comps, "true": true, "pred": pred})
+                )
+                recorder.dump_metrics(step_dir, name, metric)
+                if is_new:
+                    fig = plots.plot_parity(true, pred, r2=r2, title=name)
+                    recorder.save_figure(_fig_rel(recorder, step_dir, f"{name}_parity.png"), fig)
+                    plots.plt.close(fig)
+                return metric
+            logits = head(h)
+            pred = logits.argmax(dim=-1).cpu().numpy()
+            true = frame.loc[comps, spec.column].astype(int).to_numpy()
+            acc = float(accuracy_score(true, pred))
+            metric = {
+                "accuracy": acc,
+                "macro_f1": float(f1_score(true, pred, average="macro", zero_division=0)),
+                "samples": len(comps),
+                "primary": acc,
+            }
+            recorder.dump_predictions(step_dir, name, pd.DataFrame({"composition": comps, "true": true, "pred": pred}))
+            recorder.dump_metrics(step_dir, name, metric)
+            if is_new:
+                assert spec.num_classes is not None
+                fig = plots.plot_confusion(
+                    true,
+                    pred,
+                    num_classes=spec.num_classes,
+                    acc=acc,
+                    title=name,
+                    special_material_type=(name == "material_type"),
+                )
+                recorder.save_figure(_fig_rel(recorder, step_dir, f"{name}_confusion.png"), fig)
+                plots.plt.close(fig)
+            return metric
+
+        # kernel regression
+        assert spec.t_column is not None
+        keep: list[str] = []
+        t_list: list[np.ndarray] = []
+        true_parts: list[np.ndarray] = []
+        for comp in comps:
+            if catalog.descriptor_fn()([comp]).empty:
+                continue
+            y_arr = _as_float_array(frame.at[comp, spec.column])
+            t_arr = _as_float_array(frame.at[comp, spec.t_column])
+            if y_arr.size == 0 or y_arr.size != t_arr.size:
+                continue
+            keep.append(comp)
+            t_list.append(t_arr)
+            true_parts.append(y_arr)
+        if not keep:
+            return {"primary": float("nan"), "samples": 0}
+        xk, _ = _descriptor_tensor(catalog, keep, device)
+        h_k = torch.tanh(model.encoder(xk))
+        t_tensors = [torch.tensor(t, dtype=torch.float32, device=device) for t in t_list]
+        expanded_h, expanded_t = model._expand_for_kernel_regression(h_k, t_tensors)
+        pred = catalog.inverse_transform(name, head(expanded_h, t=expanded_t).squeeze(-1).cpu().numpy())
+        true = catalog.inverse_transform(name, np.concatenate(true_parts))
+        r2 = float(r2_score(true, pred))
+        metric = {
+            "r2": r2,
+            "mae": float(mean_absolute_error(true, pred)),
+            "samples": len(keep),
+            "points": int(true.size),
+            "primary": r2,
+        }
+        recorder.dump_predictions(step_dir, name, _kr_long_frame(keep, t_list, true_parts, pred))
+        recorder.dump_metrics(step_dir, name, metric)
+        if is_new:
+            kr_fig = plots.plot_kr_sequences(keep, t_list, true_parts, pred, title=name)
+            if kr_fig is not None:
+                recorder.save_figure(_fig_rel(recorder, step_dir, f"{name}_sequences.png"), kr_fig)
+                plots.plt.close(kr_fig)
+        return metric
+
+
+def _kr_long_frame(
+    comps: list[str], t_list: list[np.ndarray], true_parts: list[np.ndarray], pred: np.ndarray
+) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+    offset = 0
+    for comp, t_arr, y_true in zip(comps, t_list, true_parts):
+        n = int(y_true.size)
+        for k in range(n):
+            rows.append(
+                {"composition": comp, "t": float(t_arr[k]), "true": float(y_true[k]), "pred": float(pred[offset + k])}
+            )
+        offset += n
+    return pd.DataFrame(rows)
+
+
+def _fig_rel(recorder: RunRecorder, step_dir: Path, filename: str) -> str:
+    return str((step_dir / filename).relative_to(recorder.paths.root))

--- a/src/foundation_model/workflows/pretrain.py
+++ b/src/foundation_model/workflows/pretrain.py
@@ -33,7 +33,7 @@ from lightning import Trainer, seed_everything
 from lightning.pytorch.callbacks import Callback, EarlyStopping
 from loguru import logger
 from sklearn.metrics import accuracy_score, f1_score, mean_absolute_error, r2_score  # type: ignore[import-untyped]
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
 
 from foundation_model.data.datamodule import CompoundDataModule
 from foundation_model.models.flexible_multi_task_model import FlexibleMultiTaskModel
@@ -240,15 +240,19 @@ class _DropLastTrainCompoundDataModule(CompoundDataModule):
         base = super().train_dataloader()
         if base is None:
             return None
-        return DataLoader(
-            base.dataset,
+        kwargs: dict[str, Any] = dict(
             batch_size=base.batch_size,
-            shuffle=True,
             num_workers=base.num_workers,
             pin_memory=base.pin_memory,
             collate_fn=base.collate_fn,
             drop_last=True,
         )
+        # Preserve a non-default sampler (e.g. a DistributedSampler) instead of forcing
+        # shuffle=True, so the loader stays correct if ever run under DDP; otherwise shuffle.
+        sampler = base.sampler
+        if isinstance(sampler, (RandomSampler, SequentialSampler)):
+            return DataLoader(base.dataset, shuffle=True, **kwargs)
+        return DataLoader(base.dataset, sampler=sampler, **kwargs)
 
 
 def _as_float_array(cell: Any) -> np.ndarray:
@@ -270,26 +274,31 @@ def run(cfg: PretrainConfig, recorder: RunRecorder | None = None) -> dict[str, A
     """
 
     catalog = TaskCatalog(cfg.catalog)
+    owns_recorder = recorder is None  # close only the recorder we create (leave callers' alone)
     root_recorder = recorder or RunRecorder(cfg.output_dir)
     aggregate: list[dict[str, Any]] = []
 
-    for run_idx in range(cfg.n_runs):
-        run_seed = cfg.training.seed + run_idx
-        order = _run_task_order(cfg, run_seed)
-        if cfg.n_runs == 1:
-            run_recorder = root_recorder
-        else:
-            run_recorder = RunRecorder(cfg.output_dir / "runs" / f"run{run_idx:02d}")
-        logger.info(f"=== pretrain run {run_idx + 1}/{cfg.n_runs} (seed={run_seed}) order={order} ===")
-        records = _run_single(cfg, catalog, run_recorder, task_order=order, seed=run_seed)
-        for rec in records:
-            aggregate.append({"run": run_idx, **rec})
-        if run_recorder is not root_recorder:
-            run_recorder.close()
+    try:
+        for run_idx in range(cfg.n_runs):
+            run_seed = cfg.training.seed + run_idx
+            order = _run_task_order(cfg, run_seed)
+            if cfg.n_runs == 1:
+                run_recorder = root_recorder
+            else:
+                run_recorder = RunRecorder(cfg.output_dir / "runs" / f"run{run_idx:02d}")
+            logger.info(f"=== pretrain run {run_idx + 1}/{cfg.n_runs} (seed={run_seed}) order={order} ===")
+            records = _run_single(cfg, catalog, run_recorder, task_order=order, seed=run_seed)
+            for rec in records:
+                aggregate.append({"run": run_idx, **rec})
+            if run_recorder is not root_recorder:
+                run_recorder.close()
 
-    cfg.output_dir.mkdir(parents=True, exist_ok=True)
-    (cfg.output_dir / "experiment_records.json").write_text(json.dumps(aggregate, indent=2), encoding="utf-8")
-    return {"records": aggregate}
+        cfg.output_dir.mkdir(parents=True, exist_ok=True)
+        (cfg.output_dir / "experiment_records.json").write_text(json.dumps(aggregate, indent=2), encoding="utf-8")
+        return {"records": aggregate}
+    finally:
+        if owns_recorder:
+            root_recorder.close()
 
 
 def _run_task_order(cfg: PretrainConfig, seed: int) -> list[str]:
@@ -533,11 +542,14 @@ def _evaluate_task(
 
         # kernel regression
         assert spec.t_column is not None
+        # Compute descriptors once for the whole test set, then filter by availability
+        # (cheaper than a 1-row descriptor call per composition).
+        available = set(catalog.descriptor_fn()(comps).index)
         keep: list[str] = []
         t_list: list[np.ndarray] = []
         true_parts: list[np.ndarray] = []
         for comp in comps:
-            if catalog.descriptor_fn()([comp]).empty:
+            if comp not in available:
                 continue
             y_arr = _as_float_array(frame.at[comp, spec.column])
             t_arr = _as_float_array(frame.at[comp, spec.t_column])

--- a/src/foundation_model/workflows/pretrain_test.py
+++ b/src/foundation_model/workflows/pretrain_test.py
@@ -1,0 +1,256 @@
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for :mod:`foundation_model.workflows.pretrain`."""
+
+from __future__ import annotations
+
+import json
+import tomllib
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from foundation_model.workflows.pretrain import (
+    active_old_tasks,
+    build_pretrain_config,
+    replay_to_ratio,
+)
+from foundation_model.workflows.pretrain import run as pretrain_run
+from foundation_model.workflows.recording import RunRecorder
+
+# 24 distinct real-element binary/ternary formulas so KMD descriptors are computable.
+_ELEMENTS = ["Fe", "Al", "Cu", "Ni", "Ti", "Zn", "Mg", "Ca", "Na", "Cl", "O", "Si"]
+_FORMULAS = [f"{a}2 {b}3" for i, a in enumerate(_ELEMENTS) for b in _ELEMENTS[i + 1 :]][:24]
+
+
+def _config_toml(*, pretrain_extra: str = "", rehearsal: str = "") -> str:
+    return f"""
+[descriptor]
+kind = "kmd"
+n_grids = 4
+
+[datasets.d1]
+path = "data/x.parquet"
+
+[[tasks]]
+name = "a"
+kind = "regression"
+dataset = "d1"
+column = "a"
+
+[[tasks]]
+name = "b"
+kind = "regression"
+dataset = "d1"
+column = "b"
+
+[pretrain]
+{pretrain_extra}
+{rehearsal}
+"""
+
+
+def _build(toml_str: str):
+    return build_pretrain_config(tomllib.loads(toml_str), output_dir="out")
+
+
+# --- config validation -------------------------------------------------------------------
+
+
+def test_build_happy_path_defaults_task_sequence() -> None:
+    cfg = _build(_config_toml())
+    assert cfg.task_sequence == ["a", "b"]  # defaults to [[tasks]] order
+    assert cfg.n_runs == 1 and cfg.rehearsal.interval == 1
+
+
+def test_interval_below_one_raises() -> None:
+    with pytest.raises(ValueError, match="interval must be >= 1"):
+        _build(_config_toml(rehearsal="[pretrain.rehearsal]\ninterval = 0"))
+
+
+def test_unknown_task_in_sequence_raises() -> None:
+    with pytest.raises(ValueError, match="unknown task"):
+        _build(_config_toml(pretrain_extra='task_sequence = ["a", "nope"]'))
+
+
+def test_invalid_task_order_raises() -> None:
+    with pytest.raises(ValueError):
+        _build(_config_toml(pretrain_extra='task_order = "weird"'))
+
+
+def test_per_task_replay_unknown_task_raises() -> None:
+    with pytest.raises(ValueError, match="unknown task"):
+        _build(_config_toml(rehearsal="[pretrain.rehearsal.per_task]\nnope = 0.1"))
+
+
+def test_per_task_replay_bad_value_raises() -> None:
+    with pytest.raises(ValueError, match="replay"):
+        _build(_config_toml(rehearsal="[pretrain.rehearsal.per_task]\na = 0.0"))
+
+
+# --- pure helpers ------------------------------------------------------------------------
+
+
+def test_active_old_tasks_interval_schedule() -> None:
+    order = ["t1", "t2", "t3", "t4"]
+    participating_sets = []
+    for step, task in enumerate(order, start=1):
+        learned = order[: step - 1]
+        active = [task, *active_old_tasks(step, learned, 2)]
+        participating_sets.append(active)
+    assert participating_sets == [["t1"], ["t2", "t1"], ["t3"], ["t4", "t1", "t2", "t3"]]
+
+
+def test_active_old_tasks_interval_one_always_replays() -> None:
+    assert active_old_tasks(3, ["t1", "t2"], 1) == ["t1", "t2"]
+
+
+@pytest.mark.parametrize(
+    ("replay", "n_valid", "expected"),
+    [(0.1, 100, 0.1), (500, 100, 1.0), (50, 100, 0.5), (5, 0, 1.0)],
+)
+def test_replay_to_ratio(replay: float, n_valid: int, expected: float) -> None:
+    assert replay_to_ratio(replay, n_valid) == expected
+
+
+def test_random_order_same_seed_same_permutation() -> None:
+    from foundation_model.workflows.pretrain import _run_task_order
+
+    cfg = _build(_config_toml(pretrain_extra='task_sequence = ["a", "b"]\ntask_order = "random"'))
+    assert _run_task_order(cfg, 7) == _run_task_order(cfg, 7)
+
+
+# --- end-to-end smoke --------------------------------------------------------------------
+
+
+@pytest.fixture
+def smoke_dir(tmp_path):
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame(
+        {
+            "composition": _FORMULAS,
+            "a": rng.normal(size=len(_FORMULAS)),
+            "b": rng.normal(size=len(_FORMULAS)),
+        }
+    )
+    df.to_parquet(tmp_path / "x.parquet")
+    return tmp_path
+
+
+def _smoke_config(smoke_dir, output_dir):
+    toml = f"""
+[data]
+batch_size = 8
+
+[descriptor]
+kind = "kmd"
+n_grids = 4
+
+[datasets.d1]
+path = "{smoke_dir / "x.parquet"}"
+
+[[tasks]]
+name = "a"
+kind = "regression"
+dataset = "d1"
+column = "a"
+
+[[tasks]]
+name = "b"
+kind = "regression"
+dataset = "d1"
+column = "b"
+
+[model]
+latent_dim = 8
+encoder_hidden = 16
+head_hidden_dim = 8
+n_kernel = 4
+
+[training]
+max_epochs = 1
+accelerator = "cpu"
+seed = 1
+
+[pretrain]
+task_sequence = ["a", "b"]
+
+[pretrain.rehearsal]
+interval = 1
+default_replay = 0.5
+"""
+    return build_pretrain_config(tomllib.loads(toml), output_dir=str(output_dir))
+
+
+def test_pretrain_smoke_end_to_end(smoke_dir, tmp_path) -> None:
+    out = tmp_path / "run"
+    cfg = _smoke_config(smoke_dir, out)
+    recorder = RunRecorder(out)
+    recorder.write_provenance(config=cfg, argv=["fm", "pretrain"], seeds={"seed": 1})
+    result = pretrain_run(cfg, recorder)
+    recorder.close()
+
+    # n_runs == 1 → outputs directly under the root.
+    assert (out / "run_provenance.json").exists()
+    assert (out / "run.log").exists()
+    training = out / "training"
+    assert (training / "final_model.pt").exists()
+    assert (training / "final_model_taskconfigs.json").exists()
+    assert (training / "experiment_records.json").exists()
+    assert (training / "metrics_table.csv").exists()
+    assert (training / "forgetting_trajectory.png").exists()
+    # step dirs + per-task artifacts (2 heads evaluated at step 2).
+    step2 = training / "step02_b"
+    assert (step2 / "checkpoint.pt").exists()
+    for task in ("a", "b"):
+        assert (step2 / f"{task}_pred.parquet").exists()
+        assert (step2 / f"{task}_metrics.json").exists()
+    assert (step2 / "b_parity.png").exists()  # newest head plotted
+    assert len(result["records"]) == 2  # one record per step
+
+
+def test_pretrain_nruns_sweep_layout(smoke_dir, tmp_path) -> None:
+    out = tmp_path / "sweep"
+    toml = f"""
+[descriptor]
+kind = "kmd"
+n_grids = 4
+
+[datasets.d1]
+path = "{smoke_dir / "x.parquet"}"
+
+[[tasks]]
+name = "a"
+kind = "regression"
+dataset = "d1"
+column = "a"
+
+[[tasks]]
+name = "b"
+kind = "regression"
+dataset = "d1"
+column = "b"
+
+[model]
+latent_dim = 8
+encoder_hidden = 16
+head_hidden_dim = 8
+
+[training]
+max_epochs = 1
+accelerator = "cpu"
+seed = 1
+
+[pretrain]
+n_runs = 2
+"""
+    cfg = build_pretrain_config(tomllib.loads(toml), output_dir=str(out))
+    pretrain_run(cfg)
+
+    assert (out / "runs" / "run00" / "training" / "final_model.pt").exists()
+    assert (out / "runs" / "run01" / "training" / "final_model.pt").exists()
+    aggregate = json.loads((out / "experiment_records.json").read_text())
+    assert sorted({r["run"] for r in aggregate}) == [0, 1]
+    assert not (out / "training").exists()  # root training/ stays absent for n_runs > 1

--- a/src/foundation_model/workflows/recording.py
+++ b/src/foundation_model/workflows/recording.py
@@ -73,7 +73,8 @@ class RunRecorder:
     def __init__(self, root: Path) -> None:
         self.paths = RunPaths(root=Path(root), training=Path(root) / "training")
         self.paths.root.mkdir(parents=True, exist_ok=True)
-        self.paths.training.mkdir(parents=True, exist_ok=True)
+        # ``training/`` is created lazily by the methods that write into it, so a root recorder
+        # used only for provenance (e.g. the n_runs>1 sweep root) leaves no empty ``training/``.
         self._records: list[dict[str, Any]] = []
         self._log_sink_id: int | None = logger.add(self.paths.root / "run.log", level="INFO", enqueue=False)
 
@@ -129,6 +130,7 @@ class RunRecorder:
     def save_final_model(self, model: Any, task_sequence: list[str], task_spec_dump: dict[str, Any]) -> Path:
         """``training/final_model.pt`` + ``training/final_model_taskconfigs.json`` (legacy schema)."""
 
+        self.paths.training.mkdir(parents=True, exist_ok=True)
         path = self.paths.training / "final_model.pt"
         torch.save({"model": model.state_dict(), "task_sequence": list(task_sequence)}, path)
         (self.paths.training / "final_model_taskconfigs.json").write_text(
@@ -172,6 +174,7 @@ class RunRecorder:
     def write_records(self) -> Path:
         """``training/experiment_records.json``."""
 
+        self.paths.training.mkdir(parents=True, exist_ok=True)
         path = self.paths.training / "experiment_records.json"
         path.write_text(json.dumps(self._records, indent=2, default=_json_default), encoding="utf-8")
         return path
@@ -194,6 +197,7 @@ class RunRecorder:
                     rows.append(row)
             else:
                 rows.append(dict(context))
+        self.paths.training.mkdir(parents=True, exist_ok=True)
         path = self.paths.training / "metrics_table.csv"
         pd.DataFrame(rows).to_csv(path, index=False)
         return path

--- a/uv.lock
+++ b/uv.lock
@@ -661,6 +661,7 @@ name = "foundation-model"
 version = "0.2.1"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "joblib" },
     { name = "lightning", extra = ["pytorch-extra"] },
     { name = "loguru" },
@@ -696,6 +697,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.1" },
     { name = "joblib", specifier = ">=1.5.0" },
     { name = "lightning", extras = ["pytorch-extra"], specifier = ">=2.5.5" },
     { name = "loguru", specifier = ">=0.7.3" },


### PR DESCRIPTION
## Summary

Second PR of the `fm` CLI refactor (stacked on #21). Adds the pretraining engine, the pure
plotting layer, and the click-based `fm` command with its first subcommand.

- **`workflows/pretrain.py`** — continual-rehearsal engine migrated from
  `continual_rehearsal_full` with three deliberate changes:
  1. **Rehearsal interval** — old tasks join training only every Nth step (`active_old_tasks`);
     evaluation still covers all learned heads every step.
  2. **Replay amount** — a `default_replay` + per-task overrides (fraction `<1` or count `>=1`),
     replacing the legacy `fixed_tail`/`replay_ratio_high` two-tier design.
  3. **n_runs sweep** — `runs/runNN/` with per-run seed + optional random task order, aggregated
     into a top-level `experiment_records.json`.
- **`workflows/plots.py`** — pure figure builders (parity / confusion / kr-sequences /
  forgetting) returning `Figure`s; the forgetting plot is refactored off runner `self` state.
  `matplotlib.use("Agg")`.
- **`cli/main.py`** — click `fm` group + `pretrain` subcommand, shared
  `--config`/`--set`/`--output-dir`/`--seed`/`--accelerator`/`--sample`, TOML-value `--set`
  overrides. Thin dispatch: load → override → build config → provenance → `run()`.
- **`pyproject.toml`** — `fm` entry point + `click>=8.1`. Legacy `fm-trainer` etc. untouched.

## Design notes

- The AE head always trains; its LR is set via `ae_lr`. The 4-way LR split (encoder/head/kr/ae)
  is realized through `shared_block_optimizer.lr` + per-head `OptimizerConfig` (the model has no
  native split).
- Eval preserves the legacy manual head path (`tanh(encoder(x))` → head; KR via
  `_expand_for_kernel_regression`) and metric definitions (reg r2/mae, clf accuracy/macro_f1).
- `recording.py` now creates `training/` lazily so the sweep root has no empty `training/`.

## Validation

- `fm pretrain --config samples/pretrain_smoke.toml` completes on CPU (2 runs × 3 tasks,
  interval=2) and produces the full artifact layout + provenance.
- Full suite → **418 passed, 1 skipped**; ruff/mypy clean on all new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCoVwB3pntFi25YnpoHYwY