### PR TITLE
PR3 — fm finetune: frozen-encoder head fine-tuning

### DIFF
--- a/samples/finetune_smoke.toml
+++ b/samples/finetune_smoke.toml
@@ -1,0 +1,64 @@
+# Smoke-test config for `fm finetune` — fine-tune one head on a pretrain-smoke checkpoint.
+#
+# The catalog + model dims match samples/pretrain_smoke.toml so the checkpoint loads cleanly.
+#
+#   fm finetune --config samples/finetune_smoke.toml \
+#       --checkpoint artifacts/pretrain_smoke/runs/run00/training/final_model.pt
+
+[data]
+composition_column = "composition"
+batch_size = 64
+
+[descriptor]
+kind = "kmd"
+n_grids = 8
+
+[datasets.supercon]
+path = "data/NEMAD_superconductor_20260425.parquet"
+sample = 200
+
+[datasets.magnetic]
+path = "data/NEMAD_magnetic_20260419.parquet"
+sample = 200
+
+[[tasks]]
+name = "tc"
+kind = "regression"
+dataset = "supercon"
+column = "Transition temperature[K]"
+
+[[tasks]]
+name = "pressure"
+kind = "regression"
+dataset = "supercon"
+column = "Pressure[GPa]"
+
+[[tasks]]
+name = "moment"
+kind = "regression"
+dataset = "magnetic"
+column = "Magnetic moment[μB/f.u.]"
+
+[model]
+latent_dim = 32
+encoder_hidden = 64
+head_hidden_dim = 32
+n_kernel = 8
+
+[training]
+max_epochs = 100
+early_stop_patience = 3
+accelerator = "cpu"
+devices = 1
+seed = 2025
+head_lr = 5e-3
+ae_lr = 5e-3
+
+[finetune]
+checkpoint = "artifacts/pretrain_smoke/runs/run00/training/final_model.pt"
+tasks = ["moment"]
+epochs = 2
+freeze_encoder = true
+
+[output]
+dir = "artifacts/finetune_smoke"

--- a/src/foundation_model/cli/main.py
+++ b/src/foundation_model/cli/main.py
@@ -18,6 +18,8 @@ from typing import Any
 
 import click
 
+from foundation_model.workflows.finetune import FinetuneConfig, build_finetune_config
+from foundation_model.workflows.finetune import run as finetune_run
 from foundation_model.workflows.pretrain import PretrainConfig, build_pretrain_config
 from foundation_model.workflows.pretrain import run as pretrain_run
 from foundation_model.workflows.recording import RunRecorder
@@ -125,6 +127,49 @@ def pretrain_cmd(
     recorder = RunRecorder(cfg.output_dir)
     recorder.write_provenance(config=cfg, argv=list(sys.argv), seeds={"seed": cfg.training.seed})
     pretrain_run(cfg, recorder)
+    recorder.close()
+
+
+def _finetune_config(
+    config_path: str,
+    overrides: Sequence[str],
+    output_dir: str | None,
+    seed: int | None,
+    accelerator: str | None,
+    sample: int | None,
+    checkpoint: str | None,
+    tasks: str | None,
+    epochs: int | None,
+) -> FinetuneConfig:
+    raw = load_raw_config(config_path, overrides, seed=seed, accelerator=accelerator, sample=sample)
+    if tasks is not None:
+        _set_dotted(raw, "finetune.tasks", [t.strip() for t in tasks.split(",") if t.strip()])
+    if epochs is not None:
+        _set_dotted(raw, "finetune.epochs", epochs)
+    return build_finetune_config(raw, output_dir=output_dir, checkpoint=checkpoint)
+
+
+@main.command("finetune")
+@common_options
+@click.option("--checkpoint", default=None, type=click.Path(dir_okay=False), help="Checkpoint to fine-tune from.")
+@click.option("--tasks", default=None, help="Comma-separated heads to fine-tune (overrides finetune.tasks).")
+@click.option("--epochs", type=int, default=None, help="Override finetune.epochs.")
+def finetune_cmd(
+    config_path: str,
+    output_dir: str | None,
+    overrides: tuple[str, ...],
+    seed: int | None,
+    accelerator: str | None,
+    sample: int | None,
+    checkpoint: str | None,
+    tasks: str | None,
+    epochs: int | None,
+) -> None:
+    """Frozen-encoder fine-tuning of selected task heads."""
+    cfg = _finetune_config(config_path, overrides, output_dir, seed, accelerator, sample, checkpoint, tasks, epochs)
+    recorder = RunRecorder(cfg.output_dir)
+    recorder.write_provenance(config=cfg, argv=list(sys.argv), seeds={"seed": cfg.training.seed})
+    finetune_run(cfg, recorder)
     recorder.close()
 
 

--- a/src/foundation_model/cli/main_test.py
+++ b/src/foundation_model/cli/main_test.py
@@ -9,7 +9,40 @@ import click
 import pytest
 from click.testing import CliRunner
 
-from foundation_model.cli.main import _parse_toml_value, _pretrain_config, load_raw_config, main
+from foundation_model.cli.main import (
+    _finetune_config,
+    _parse_toml_value,
+    _pretrain_config,
+    load_raw_config,
+    main,
+)
+
+_FINETUNE_CONFIG = """
+[descriptor]
+kind = "kmd"
+
+[datasets.d1]
+path = "data/x.parquet"
+
+[[tasks]]
+name = "a"
+kind = "regression"
+dataset = "d1"
+column = "a"
+
+[[tasks]]
+name = "b"
+kind = "regression"
+dataset = "d1"
+column = "b"
+
+[finetune]
+tasks = ["a"]
+checkpoint = "ck.pt"
+
+[output]
+dir = "out"
+"""
 
 _CONFIG = """
 [descriptor]
@@ -83,7 +116,17 @@ def test_missing_config_file_errors() -> None:
     assert "does not exist" in result.output.lower()
 
 
-def test_help_lists_pretrain() -> None:
+def test_help_lists_subcommands() -> None:
     result = CliRunner().invoke(main, ["--help"])
     assert result.exit_code == 0
     assert "pretrain" in result.output
+    assert "finetune" in result.output
+
+
+def test_finetune_tasks_and_checkpoint_flags(tmp_path) -> None:
+    path = tmp_path / "ft.toml"
+    path.write_text(_FINETUNE_CONFIG)
+    cfg = _finetune_config(str(path), (), None, None, None, None, "override.pt", "a,b", 7)
+    assert cfg.tasks == ["a", "b"]  # --tasks overrides finetune.tasks
+    assert str(cfg.checkpoint) == "override.pt"  # --checkpoint wins
+    assert cfg.epochs == 7

--- a/src/foundation_model/workflows/_engine.py
+++ b/src/foundation_model/workflows/_engine.py
@@ -1,0 +1,256 @@
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared engine internals for the training workflows (pretrain / finetune).
+
+Model construction (``build_empty_model`` / ``build_head_config``), the ``drop_last`` train
+datamodule, and per-head evaluation (``evaluate_task`` + dumps/plots) live here so both engines
+use one implementation. Only :class:`RunRecorder` writes files.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import torch
+from sklearn.metrics import accuracy_score, f1_score, mean_absolute_error, r2_score  # type: ignore[import-untyped]
+from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
+
+from foundation_model.data.datamodule import CompoundDataModule
+from foundation_model.models.flexible_multi_task_model import FlexibleMultiTaskModel
+from foundation_model.models.model_config import MLPEncoderConfig, OptimizerConfig
+
+from . import plots
+from ._sections import ModelSectionConfig, TrainingSectionConfig
+from .recording import RunRecorder
+from .task_catalog import TaskCatalog, TaskConfig, TaskKind
+
+# Reserved built-in autoencoder head name (see FlexibleMultiTaskModel).
+AE_NAME = "__reconstruction__"
+# Legacy weight decay for regression / classification heads (kernel heads use kr_weight_decay).
+_HEAD_WEIGHT_DECAY = 1e-5
+
+
+def build_empty_model(
+    catalog: TaskCatalog, model: ModelSectionConfig, training: TrainingSectionConfig
+) -> FlexibleMultiTaskModel:
+    """Bare model (AE head only). The AE always trains; only ``ae_lr`` is configurable."""
+    encoder_config = MLPEncoderConfig(hidden_dims=[catalog.descriptor_dim, model.encoder_hidden, model.latent_dim])
+    built = FlexibleMultiTaskModel(
+        task_configs=[],
+        encoder_config=encoder_config,
+        enable_autoencoder=True,
+        shared_block_optimizer=OptimizerConfig(lr=training.encoder_lr, weight_decay=1e-2),
+    )
+    if AE_NAME in built.task_configs_map:
+        built.task_configs_map[AE_NAME].optimizer = OptimizerConfig(lr=training.ae_lr)
+    return built
+
+
+def build_head_config(
+    catalog: TaskCatalog,
+    model: ModelSectionConfig,
+    training: TrainingSectionConfig,
+    name: str,
+    *,
+    masking_ratio: float = 1.0,
+    init_from_data: bool = True,
+) -> TaskConfig:
+    """Build a task's head config with the right LR/weight-decay for its kind."""
+    spec = catalog.task_spec(name)
+    if spec.kind is TaskKind.KERNEL_REGRESSION:
+        lr, weight_decay = training.kr_lr, training.kr_weight_decay
+    else:
+        lr, weight_decay = training.head_lr, _HEAD_WEIGHT_DECAY
+    return catalog.build_task_config(
+        name,
+        latent_dim=model.latent_dim,
+        head_hidden_dim=model.head_hidden_dim,
+        n_kernel=model.n_kernel,
+        lr=lr,
+        weight_decay=weight_decay,
+        masking_ratio=masking_ratio,
+        init_from_data=init_from_data,
+    )
+
+
+class DropLastTrainCompoundDataModule(CompoundDataModule):
+    """``CompoundDataModule`` whose train loader drops the final partial batch.
+
+    Guards against BatchNorm1d crashing on a size-1 tail batch. Only the train loader is
+    affected; val/test/predict keep every held-out row. A non-default sampler (e.g. a
+    ``DistributedSampler``) is preserved rather than replaced with ``shuffle=True``.
+    """
+
+    def train_dataloader(self) -> DataLoader | None:  # type: ignore[override]
+        base = super().train_dataloader()
+        if base is None:
+            return None
+        kwargs: dict[str, Any] = dict(
+            batch_size=base.batch_size,
+            num_workers=base.num_workers,
+            pin_memory=base.pin_memory,
+            collate_fn=base.collate_fn,
+            drop_last=True,
+        )
+        sampler = base.sampler
+        if isinstance(sampler, (RandomSampler, SequentialSampler)):
+            return DataLoader(base.dataset, shuffle=True, **kwargs)
+        return DataLoader(base.dataset, sampler=sampler, **kwargs)
+
+
+def as_float_array(cell: Any) -> np.ndarray:
+    if isinstance(cell, str):
+        cell = ast.literal_eval(cell)
+    return np.asarray(cell, dtype=float).ravel()
+
+
+def test_rows(catalog: TaskCatalog, name: str, test_keys: set[str] | None) -> list[str]:
+    """Compositions with a non-NaN target on the resolved test split."""
+    spec = catalog.task_spec(name)
+    frame = catalog.task_frames([name])[name]
+    mask = frame[spec.column].notna()
+    if test_keys is not None:
+        mask &= frame.index.isin(test_keys)
+    elif "split" in frame.columns:
+        mask &= frame["split"] == "test"
+    return list(frame.index[mask])
+
+
+def descriptor_tensor(catalog: TaskCatalog, comps: list[str], device: torch.device) -> tuple[torch.Tensor, list[str]]:
+    desc = catalog.descriptor_fn()(comps)
+    kept = [c for c in comps if c in desc.index]
+    tensor = torch.tensor(desc.loc[kept].values, dtype=torch.float32, device=device)
+    return tensor, kept
+
+
+def _kr_long_frame(
+    comps: list[str], t_list: list[np.ndarray], true_parts: list[np.ndarray], pred: np.ndarray
+) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+    offset = 0
+    for comp, t_arr, y_true in zip(comps, t_list, true_parts):
+        n = int(y_true.size)
+        for k in range(n):
+            rows.append(
+                {"composition": comp, "t": float(t_arr[k]), "true": float(y_true[k]), "pred": float(pred[offset + k])}
+            )
+        offset += n
+    return pd.DataFrame(rows)
+
+
+def fig_rel(recorder: RunRecorder, step_dir: Path, filename: str) -> str:
+    return str((step_dir / filename).relative_to(recorder.paths.root))
+
+
+def evaluate_task(
+    model: FlexibleMultiTaskModel,
+    catalog: TaskCatalog,
+    name: str,
+    recorder: RunRecorder,
+    step_dir: Path,
+    *,
+    is_new: bool,
+    test_keys: set[str] | None,
+) -> dict[str, float]:
+    """Evaluate one head on the fixed test split; dump parquet + metrics (+ plot if new)."""
+
+    spec = catalog.task_spec(name)
+    model.eval()
+    device = next(model.parameters()).device
+    comps = test_rows(catalog, name, test_keys)
+    if not comps:
+        return {"primary": float("nan"), "samples": 0}
+    frame = catalog.task_frames([name])[name]
+    head = model.task_heads[name]
+
+    with torch.no_grad():
+        if spec.kind in (TaskKind.REGRESSION, TaskKind.CLASSIFICATION):
+            x, comps = descriptor_tensor(catalog, comps, device)
+            if not comps:
+                return {"primary": float("nan"), "samples": 0}
+            h = torch.tanh(model.encoder(x))
+            if spec.kind is TaskKind.REGRESSION:
+                pred = catalog.inverse_transform(name, head(h).squeeze(-1).cpu().numpy())
+                true = catalog.inverse_transform(name, frame.loc[comps, spec.column].astype(float).to_numpy())
+                r2 = float(r2_score(true, pred))
+                metric = {"r2": r2, "mae": float(mean_absolute_error(true, pred)), "samples": len(comps), "primary": r2}
+                recorder.dump_predictions(
+                    step_dir, name, pd.DataFrame({"composition": comps, "true": true, "pred": pred})
+                )
+                recorder.dump_metrics(step_dir, name, metric)
+                if is_new:
+                    fig = plots.plot_parity(true, pred, r2=r2, title=name)
+                    recorder.save_figure(fig_rel(recorder, step_dir, f"{name}_parity.png"), fig)
+                    plots.plt.close(fig)
+                return metric
+            logits = head(h)
+            pred = logits.argmax(dim=-1).cpu().numpy()
+            true = frame.loc[comps, spec.column].astype(int).to_numpy()
+            acc = float(accuracy_score(true, pred))
+            metric = {
+                "accuracy": acc,
+                "macro_f1": float(f1_score(true, pred, average="macro", zero_division=0)),
+                "samples": len(comps),
+                "primary": acc,
+            }
+            recorder.dump_predictions(step_dir, name, pd.DataFrame({"composition": comps, "true": true, "pred": pred}))
+            recorder.dump_metrics(step_dir, name, metric)
+            if is_new:
+                assert spec.num_classes is not None
+                fig = plots.plot_confusion(
+                    true,
+                    pred,
+                    num_classes=spec.num_classes,
+                    acc=acc,
+                    title=name,
+                    special_material_type=(name == "material_type"),
+                )
+                recorder.save_figure(fig_rel(recorder, step_dir, f"{name}_confusion.png"), fig)
+                plots.plt.close(fig)
+            return metric
+
+        # kernel regression
+        assert spec.t_column is not None
+        available = set(catalog.descriptor_fn()(comps).index)
+        keep: list[str] = []
+        t_list: list[np.ndarray] = []
+        true_parts: list[np.ndarray] = []
+        for comp in comps:
+            if comp not in available:
+                continue
+            y_arr = as_float_array(frame.at[comp, spec.column])
+            t_arr = as_float_array(frame.at[comp, spec.t_column])
+            if y_arr.size == 0 or y_arr.size != t_arr.size:
+                continue
+            keep.append(comp)
+            t_list.append(t_arr)
+            true_parts.append(y_arr)
+        if not keep:
+            return {"primary": float("nan"), "samples": 0}
+        xk, _ = descriptor_tensor(catalog, keep, device)
+        h_k = torch.tanh(model.encoder(xk))
+        t_tensors = [torch.tensor(t, dtype=torch.float32, device=device) for t in t_list]
+        expanded_h, expanded_t = model._expand_for_kernel_regression(h_k, t_tensors)
+        pred = catalog.inverse_transform(name, head(expanded_h, t=expanded_t).squeeze(-1).cpu().numpy())
+        true = catalog.inverse_transform(name, np.concatenate(true_parts))
+        r2 = float(r2_score(true, pred))
+        metric = {
+            "r2": r2,
+            "mae": float(mean_absolute_error(true, pred)),
+            "samples": len(keep),
+            "points": int(true.size),
+            "primary": r2,
+        }
+        recorder.dump_predictions(step_dir, name, _kr_long_frame(keep, t_list, true_parts, pred))
+        recorder.dump_metrics(step_dir, name, metric)
+        if is_new:
+            kr_fig = plots.plot_kr_sequences(keep, t_list, true_parts, pred, title=name)
+            if kr_fig is not None:
+                recorder.save_figure(fig_rel(recorder, step_dir, f"{name}_sequences.png"), kr_fig)
+                plots.plt.close(kr_fig)
+        return metric

--- a/src/foundation_model/workflows/_sections.py
+++ b/src/foundation_model/workflows/_sections.py
@@ -1,0 +1,67 @@
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared config sections used by more than one workflow (``[model]`` / ``[training]``)."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+def reject_unknown(section: str, raw: Mapping[str, Any], known: set[str]) -> None:
+    """Raise ``ValueError`` naming any key in ``raw`` outside ``known``."""
+    unknown = sorted(set(raw) - known)
+    if unknown:
+        raise ValueError(f"[{section}]: unknown key(s) {unknown}; allowed keys are {sorted(known)}.")
+
+
+@dataclass(kw_only=True)
+class ModelSectionConfig:
+    """``[model]`` — architecture dims shared by pretrain and finetune."""
+
+    latent_dim: int = 128
+    encoder_hidden: int = 256
+    head_hidden_dim: int = 64
+    n_kernel: int = 15
+
+    def __post_init__(self) -> None:
+        for name in ("latent_dim", "encoder_hidden", "head_hidden_dim", "n_kernel"):
+            if getattr(self, name) < 1:
+                raise ValueError(f"model.{name} must be >= 1, got {getattr(self, name)}.")
+
+
+@dataclass(kw_only=True)
+class TrainingSectionConfig:
+    """``[training]`` — epochs, early-stop, learning rates, accelerator (pretrain + finetune)."""
+
+    max_epochs: int = 100
+    early_stop_patience: int = 8
+    early_stop_min_delta: float = 1e-4
+    encoder_lr: float = 5e-3
+    head_lr: float = 5e-3
+    kr_lr: float = 5e-4
+    kr_weight_decay: float = 5e-5
+    ae_lr: float = 5e-3
+    accelerator: str = "auto"
+    devices: int = 1
+    seed: int = 2025
+
+    def __post_init__(self) -> None:
+        if self.max_epochs < 1:
+            raise ValueError(f"training.max_epochs must be >= 1, got {self.max_epochs}.")
+        if self.early_stop_patience < 1:
+            raise ValueError(f"training.early_stop_patience must be >= 1, got {self.early_stop_patience}.")
+
+
+def build_model_section(raw: Mapping[str, Any]) -> ModelSectionConfig:
+    data = dict(raw)
+    reject_unknown("model", data, set(ModelSectionConfig.__dataclass_fields__))
+    return ModelSectionConfig(**data)
+
+
+def build_training_section(raw: Mapping[str, Any]) -> TrainingSectionConfig:
+    data = dict(raw)
+    reject_unknown("training", data, set(TrainingSectionConfig.__dataclass_fields__))
+    return TrainingSectionConfig(**data)

--- a/src/foundation_model/workflows/finetune.py
+++ b/src/foundation_model/workflows/finetune.py
@@ -24,7 +24,13 @@ from lightning import Trainer, seed_everything
 from lightning.pytorch.callbacks import Callback, EarlyStopping
 from loguru import logger
 
-from ._engine import AE_NAME, build_empty_model, build_head_config, evaluate_task
+from ._engine import (
+    AE_NAME,
+    DropLastTrainCompoundDataModule,
+    build_empty_model,
+    build_head_config,
+    evaluate_task,
+)
 from ._sections import (
     ModelSectionConfig,
     TrainingSectionConfig,
@@ -100,11 +106,10 @@ def build_finetune_config(
 def apply_freeze_policy(model: Any, target_tasks: Sequence[str], *, freeze_encoder: bool) -> dict[str, bool]:
     """Freeze the encoder (optional) + non-target heads (except the AE) + task_log_sigmas.
 
-    Returns a ``{param_name: requires_grad}`` snapshot for provenance. The autoencoder head
-    (``"__reconstruction__"``) always stays trainable — the intentional behaviour change vs. the
-    legacy ``freeze_except`` (which froze it).
+    Returns the resulting ``{param_name: requires_grad}`` snapshot (taken AFTER applying the
+    policy) for provenance. The autoencoder head (``"__reconstruction__"``) always stays
+    trainable — the intentional behaviour change vs. the legacy ``freeze_except`` (which froze it).
     """
-    snapshot = {name: p.requires_grad for name, p in model.named_parameters()}
     if freeze_encoder:
         for p in model.encoder.parameters():
             p.requires_grad_(False)
@@ -115,7 +120,19 @@ def apply_freeze_policy(model: Any, target_tasks: Sequence[str], *, freeze_encod
             p.requires_grad_(trainable)
     for p in model.task_log_sigmas.parameters():
         p.requires_grad_(False)
-    return snapshot
+    return {name: p.requires_grad for name, p in model.named_parameters()}
+
+
+class _FrozenEncoderEval(Callback):
+    """Keep a frozen encoder in eval mode during fit.
+
+    Freezing ``requires_grad`` stops gradients but Lightning still puts the module in train mode,
+    so the encoder's ``BatchNorm1d`` ``running_mean``/``running_var`` would keep updating and the
+    saved encoder would differ. Forcing eval mode each train epoch freezes those buffers too.
+    """
+
+    def on_train_epoch_start(self, trainer: Any, pl_module: Any) -> None:
+        pl_module.encoder.eval()
 
 
 def _task_names_from_state(state_dict: Mapping[str, Any]) -> list[str]:
@@ -181,7 +198,11 @@ def run(cfg: FinetuneConfig, recorder: RunRecorder | None = None) -> dict[str, A
         if disabled:
             model.disable_task(*disabled)
 
-        datamodule = catalog.build_datamodule(cfg.tasks, masking_ratios={t: 1.0 for t in cfg.tasks})
+        datamodule = catalog.build_datamodule(
+            cfg.tasks,
+            masking_ratios={t: 1.0 for t in cfg.tasks},
+            datamodule_cls=DropLastTrainCompoundDataModule,  # drop size-1 tail batch (BatchNorm)
+        )
         datamodule.setup("fit")
         test_keys = _test_keys(datamodule)
 
@@ -200,6 +221,8 @@ def run(cfg: FinetuneConfig, recorder: RunRecorder | None = None) -> dict[str, A
                 min_delta=cfg.training.early_stop_min_delta,
             )
         ]
+        if cfg.freeze_encoder:
+            callbacks.append(_FrozenEncoderEval())  # keep frozen encoder's BatchNorm buffers fixed
         trainer = Trainer(
             max_epochs=cfg.epochs,
             accelerator=cfg.training.accelerator,

--- a/src/foundation_model/workflows/finetune.py
+++ b/src/foundation_model/workflows/finetune.py
@@ -1,0 +1,258 @@
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``fm finetune`` — frozen-encoder fine-tuning of selected task heads.
+
+Rebuilds the checkpoint's model from the :class:`TaskCatalog`, loads its weights with
+``strict=False``, optionally adds heads absent from the checkpoint, then fine-tunes only the
+requested heads. Freeze policy (rewrite of ``finetune_inverse_heads.freeze_except`` with one
+intentional change): the encoder and every non-target head are frozen, **except the built-in
+autoencoder head which always stays trainable** (at ``ae_lr``); ``task_log_sigmas`` are frozen.
+Non-target heads are disabled for the fit and restored before saving so the checkpoint keeps
+every head.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from lightning import Trainer, seed_everything
+from lightning.pytorch.callbacks import Callback, EarlyStopping
+from loguru import logger
+
+from ._engine import AE_NAME, build_empty_model, build_head_config, evaluate_task
+from ._sections import (
+    ModelSectionConfig,
+    TrainingSectionConfig,
+    build_model_section,
+    build_training_section,
+    reject_unknown,
+)
+from .recording import RunRecorder, load_checkpoint_state
+from .task_catalog import TaskCatalog, TaskCatalogConfig, build_task_catalog_config
+
+_FINETUNE_ROOT_KEYS = {"data", "descriptor", "datasets", "tasks", "model", "training", "finetune", "output"}
+_CATALOG_KEYS = {"data", "descriptor", "datasets", "tasks"}
+
+
+@dataclass(kw_only=True)
+class FinetuneConfig:
+    catalog: TaskCatalogConfig
+    model: ModelSectionConfig
+    training: TrainingSectionConfig
+    checkpoint: Path
+    tasks: list[str]
+    output_dir: Path
+    epochs: int = 20
+    freeze_encoder: bool = True
+    add_new_tasks: bool = True
+
+    def __post_init__(self) -> None:
+        self.checkpoint = Path(self.checkpoint)
+        self.output_dir = Path(self.output_dir)
+        if not self.tasks:
+            raise ValueError("finetune.tasks must be non-empty.")
+        if self.epochs < 1:
+            raise ValueError(f"finetune.epochs must be >= 1, got {self.epochs}.")
+        catalog_tasks = {t.name for t in self.catalog.tasks}
+        unknown = [t for t in self.tasks if t not in catalog_tasks]
+        if unknown:
+            raise ValueError(f"finetune.tasks references unknown task(s): {unknown}.")
+
+
+def build_finetune_config(
+    raw: Mapping[str, Any], *, output_dir: str | Path | None = None, checkpoint: str | Path | None = None
+) -> FinetuneConfig:
+    """Normalize a parsed-TOML tree into a :class:`FinetuneConfig`."""
+
+    reject_unknown("<root>", raw, _FINETUNE_ROOT_KEYS)
+    catalog = build_task_catalog_config({k: raw[k] for k in _CATALOG_KEYS if k in raw})
+    model = build_model_section(raw.get("model", {}))
+    training = build_training_section(raw.get("training", {}))
+
+    ft_raw = dict(raw.get("finetune", {}))
+    reject_unknown("finetune", ft_raw, {"checkpoint", "tasks", "epochs", "freeze_encoder", "add_new_tasks"})
+
+    resolved_checkpoint = checkpoint if checkpoint is not None else ft_raw.get("checkpoint")
+    if resolved_checkpoint is None:
+        raise ValueError("checkpoint must be given via --checkpoint or [finetune].checkpoint.")
+    resolved_output = output_dir if output_dir is not None else raw.get("output", {}).get("dir")
+    if resolved_output is None:
+        raise ValueError("output directory must be given via --output-dir or [output].dir.")
+
+    return FinetuneConfig(
+        catalog=catalog,
+        model=model,
+        training=training,
+        checkpoint=Path(resolved_checkpoint),
+        tasks=list(ft_raw.get("tasks", [])),
+        output_dir=Path(resolved_output),
+        epochs=int(ft_raw.get("epochs", 20)),
+        freeze_encoder=bool(ft_raw.get("freeze_encoder", True)),
+        add_new_tasks=bool(ft_raw.get("add_new_tasks", True)),
+    )
+
+
+def apply_freeze_policy(model: Any, target_tasks: Sequence[str], *, freeze_encoder: bool) -> dict[str, bool]:
+    """Freeze the encoder (optional) + non-target heads (except the AE) + task_log_sigmas.
+
+    Returns a ``{param_name: requires_grad}`` snapshot for provenance. The autoencoder head
+    (``"__reconstruction__"``) always stays trainable — the intentional behaviour change vs. the
+    legacy ``freeze_except`` (which froze it).
+    """
+    snapshot = {name: p.requires_grad for name, p in model.named_parameters()}
+    if freeze_encoder:
+        for p in model.encoder.parameters():
+            p.requires_grad_(False)
+    keep = set(target_tasks) | {AE_NAME}  # AE always trainable
+    for head_name, head in model.task_heads.items():
+        trainable = head_name in keep
+        for p in head.parameters():
+            p.requires_grad_(trainable)
+    for p in model.task_log_sigmas.parameters():
+        p.requires_grad_(False)
+    return snapshot
+
+
+def _task_names_from_state(state_dict: Mapping[str, Any]) -> list[str]:
+    """Head task names present in a checkpoint state_dict (excludes the AE head)."""
+    names: list[str] = []
+    for key in state_dict:
+        if key.startswith("task_heads."):
+            name = key.split(".", 2)[1]
+            if name != AE_NAME and name not in names:
+                names.append(name)
+    return names
+
+
+def run(cfg: FinetuneConfig, recorder: RunRecorder | None = None) -> dict[str, Any]:
+    """Fine-tune ``cfg.tasks`` on top of ``cfg.checkpoint``; return the finetune summary dict."""
+
+    catalog = TaskCatalog(cfg.catalog)
+    owns_recorder = recorder is None
+    rec = recorder or RunRecorder(cfg.output_dir)
+    seed_everything(cfg.training.seed, workers=True)
+
+    try:
+        state = load_checkpoint_state(cfg.checkpoint)
+        ckpt_tasks = list(state.get("task_sequence") or _task_names_from_state(state["model"]))
+        catalog_tasks = {t.name for t in cfg.catalog.tasks}
+        missing_from_catalog = [t for t in ckpt_tasks if t not in catalog_tasks]
+        if missing_from_catalog:
+            raise ValueError(
+                f"Checkpoint tasks {missing_from_catalog} are not defined in the catalog "
+                f"(available: {sorted(catalog_tasks)})."
+            )
+
+        model = build_empty_model(catalog, cfg.model, cfg.training)
+        for name in ckpt_tasks:
+            model.add_task(build_head_config(catalog, cfg.model, cfg.training, name, masking_ratio=1.0))
+        incompatible = model.load_state_dict(state["model"], strict=False)
+        if incompatible.missing_keys:
+            logger.info(
+                f"load_state_dict missing keys ({len(incompatible.missing_keys)}): {incompatible.missing_keys[:8]}"
+            )
+        if incompatible.unexpected_keys:
+            logger.info(
+                f"load_state_dict unexpected keys ({len(incompatible.unexpected_keys)}): {incompatible.unexpected_keys[:8]}"
+            )
+
+        added_tasks = [t for t in cfg.tasks if t not in model.task_heads]
+        if added_tasks and not cfg.add_new_tasks:
+            raise ValueError(
+                f"Heads {added_tasks} are absent from the checkpoint and add_new_tasks=False "
+                f"(checkpoint heads: {sorted(model.task_heads)})."
+            )
+        for name in added_tasks:
+            logger.info(f"Adding new head '{name}' (absent from checkpoint).")
+            model.add_task(build_head_config(catalog, cfg.model, cfg.training, name, masking_ratio=1.0))
+
+        apply_freeze_policy(model, cfg.tasks, freeze_encoder=cfg.freeze_encoder)
+        frozen = sum(1 for _, p in model.named_parameters() if not p.requires_grad)
+        trainable = sum(1 for _, p in model.named_parameters() if p.requires_grad)
+
+        # Disable non-target supervised heads for the fit (keep the AE active + trainable); restore
+        # before saving so the checkpoint retains every head.
+        disabled = [n for n in list(model.task_heads) if n not in cfg.tasks and n != AE_NAME]
+        if disabled:
+            model.disable_task(*disabled)
+
+        datamodule = catalog.build_datamodule(cfg.tasks, masking_ratios={t: 1.0 for t in cfg.tasks})
+        datamodule.setup("fit")
+        test_keys = _test_keys(datamodule)
+
+        before = {
+            name: evaluate_task(
+                model, catalog, name, rec, rec.paths.training / "before_finetune", is_new=False, test_keys=test_keys
+            )
+            for name in cfg.tasks
+        }
+
+        callbacks: list[Callback] = [
+            EarlyStopping(
+                monitor="val_final_loss",
+                mode="min",
+                patience=cfg.training.early_stop_patience,
+                min_delta=cfg.training.early_stop_min_delta,
+            )
+        ]
+        trainer = Trainer(
+            max_epochs=cfg.epochs,
+            accelerator=cfg.training.accelerator,
+            devices=cfg.training.devices,
+            logger=False,
+            enable_checkpointing=False,
+            enable_progress_bar=False,
+            callbacks=callbacks,
+        )
+        trainer.fit(model, datamodule=datamodule)
+
+        if disabled:
+            model.enable_task(*disabled)
+
+        eval_dir = rec.paths.training / "finetune"
+        after: dict[str, dict[str, float]] = {}
+        for name in cfg.tasks:
+            after[name] = evaluate_task(model, catalog, name, rec, eval_dir, is_new=True, test_keys=test_keys)
+
+        rec.save_final_model(model, ckpt_tasks + added_tasks, _task_spec_dump(catalog, ckpt_tasks + added_tasks))
+        summary = {
+            "from_checkpoint": str(cfg.checkpoint),
+            "finetuned_heads": list(cfg.tasks),
+            "added_tasks": added_tasks,
+            "checkpoint_tasks": ckpt_tasks,
+            "epochs": cfg.epochs,
+            "epochs_run": trainer.current_epoch,
+            "freeze_encoder": cfg.freeze_encoder,
+            "frozen_params": frozen,
+            "trainable_params": trainable,
+            "metrics_before": before,
+            "metrics_after": after,
+        }
+        (rec.paths.training / "finetune_summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+        logger.info(
+            f"Fine-tuned {cfg.tasks} for {trainer.current_epoch} epochs → {rec.paths.training / 'final_model.pt'}"
+        )
+        return summary
+    finally:
+        if owns_recorder:
+            rec.close()
+
+
+def _test_keys(datamodule: Any) -> set[str] | None:
+    if datamodule.split_series is None:
+        return None
+    resolved = datamodule.split_series
+    return set(resolved.index[resolved == "test"].astype(str))
+
+
+def _task_spec_dump(catalog: TaskCatalog, task_names: Sequence[str]) -> dict[str, Any]:
+    dump: dict[str, Any] = {}
+    for name in task_names:
+        spec = catalog.task_spec(name)
+        dump[name] = {"kind": spec.kind.value, "column": spec.column, "source": spec.dataset}
+    return dump

--- a/src/foundation_model/workflows/finetune_test.py
+++ b/src/foundation_model/workflows/finetune_test.py
@@ -190,6 +190,21 @@ def test_add_new_task_head_added_and_trained(data_dir, tmp_path) -> None:
     assert any(k.startswith("task_heads.c.") for k in saved)
 
 
+def test_frozen_encoder_unchanged_after_finetune(data_dir, tmp_path) -> None:
+    # freeze_encoder=True must keep encoder params AND BatchNorm buffers fixed across the fit.
+    _, model = _model_with_heads(data_dir, ["a", "b"])
+    ckpt = tmp_path / "ck.pt"
+    _save_checkpoint(model, ["a", "b"], ckpt)
+    before = {k: v.clone() for k, v in torch.load(ckpt, weights_only=True)["model"].items() if k.startswith("encoder.")}
+
+    cfg = _finetune_cfg(data_dir, tmp_path / "frz", checkpoint=ckpt, tasks=["a"], epochs=2)
+    finetune_run(cfg)
+
+    after = torch.load(tmp_path / "frz" / "training" / "final_model.pt", weights_only=True)["model"]
+    for key, value in before.items():
+        assert torch.equal(value, after[key]), f"encoder tensor changed: {key}"
+
+
 def test_add_new_task_disabled_raises(data_dir, tmp_path) -> None:
     _, model = _model_with_heads(data_dir, ["a", "b"])
     ckpt = tmp_path / "ck.pt"

--- a/src/foundation_model/workflows/finetune_test.py
+++ b/src/foundation_model/workflows/finetune_test.py
@@ -1,0 +1,200 @@
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for :mod:`foundation_model.workflows.finetune`."""
+
+from __future__ import annotations
+
+import tomllib
+
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+from foundation_model.workflows._engine import AE_NAME, build_empty_model, build_head_config
+from foundation_model.workflows._sections import ModelSectionConfig, TrainingSectionConfig
+from foundation_model.workflows.finetune import apply_freeze_policy, build_finetune_config
+from foundation_model.workflows.finetune import run as finetune_run
+from foundation_model.workflows.recording import RunRecorder
+from foundation_model.workflows.task_catalog import TaskCatalog, build_task_catalog_config
+
+_ELEMENTS = ["Fe", "Al", "Cu", "Ni", "Ti", "Zn", "Mg", "Ca", "Na", "Cl", "O", "Si"]
+_FORMULAS = [f"{a}2 {b}3" for i, a in enumerate(_ELEMENTS) for b in _ELEMENTS[i + 1 :]][:24]
+
+_MODEL = ModelSectionConfig(latent_dim=8, encoder_hidden=16, head_hidden_dim=8, n_kernel=4)
+_TRAIN = TrainingSectionConfig(max_epochs=1, early_stop_patience=2, accelerator="cpu", seed=1)
+
+
+@pytest.fixture
+def data_dir(tmp_path):
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame(
+        {
+            "composition": _FORMULAS,
+            "a": rng.normal(size=len(_FORMULAS)),
+            "b": rng.normal(size=len(_FORMULAS)),
+            "c": rng.integers(0, 3, size=len(_FORMULAS)),
+        }
+    )
+    df.to_parquet(tmp_path / "x.parquet")
+    return tmp_path
+
+
+def _catalog_toml(data_dir) -> str:
+    return f"""
+[descriptor]
+kind = "kmd"
+n_grids = 4
+
+[datasets.d1]
+path = "{data_dir / "x.parquet"}"
+
+[[tasks]]
+name = "a"
+kind = "regression"
+dataset = "d1"
+column = "a"
+
+[[tasks]]
+name = "b"
+kind = "regression"
+dataset = "d1"
+column = "b"
+
+[[tasks]]
+name = "c"
+kind = "classification"
+dataset = "d1"
+column = "c"
+num_classes = 3
+"""
+
+
+def _catalog(data_dir) -> TaskCatalog:
+    return TaskCatalog(build_task_catalog_config(tomllib.loads(_catalog_toml(data_dir))))
+
+
+def _model_with_heads(data_dir, heads):
+    cat = _catalog(data_dir)
+    model = build_empty_model(cat, _MODEL, _TRAIN)
+    for name in heads:
+        model.add_task(build_head_config(cat, _MODEL, _TRAIN, name))
+    return cat, model
+
+
+def _save_checkpoint(model, tasks, path) -> None:
+    torch.save({"model": model.state_dict(), "task_sequence": list(tasks)}, path)
+
+
+def _finetune_cfg(data_dir, out, *, checkpoint, tasks, add_new_tasks=True, epochs=1):
+    toml = (
+        _catalog_toml(data_dir)
+        + f"""
+[model]
+latent_dim = 8
+encoder_hidden = 16
+head_hidden_dim = 8
+n_kernel = 4
+
+[training]
+max_epochs = 1
+accelerator = "cpu"
+seed = 1
+
+[finetune]
+tasks = {tasks!r}
+epochs = {epochs}
+add_new_tasks = {"true" if add_new_tasks else "false"}
+"""
+    )
+    return build_finetune_config(tomllib.loads(toml), output_dir=str(out), checkpoint=str(checkpoint))
+
+
+# --- freeze policy -----------------------------------------------------------------------
+
+
+def test_freeze_policy(data_dir) -> None:
+    _, model = _model_with_heads(data_dir, ["a", "b"])
+    apply_freeze_policy(model, ["a"], freeze_encoder=True)
+    assert all(p.requires_grad for p in model.task_heads["a"].parameters())  # target trainable
+    assert not any(p.requires_grad for p in model.task_heads["b"].parameters())  # non-target frozen
+    assert all(p.requires_grad for p in model.task_heads[AE_NAME].parameters())  # AE always trainable
+    assert not any(p.requires_grad for p in model.encoder.parameters())  # encoder frozen
+    assert not any(p.requires_grad for p in model.task_log_sigmas.parameters())  # balancer frozen
+
+
+def test_freeze_encoder_false_leaves_encoder_trainable(data_dir) -> None:
+    _, model = _model_with_heads(data_dir, ["a", "b"])
+    apply_freeze_policy(model, ["a"], freeze_encoder=False)
+    assert any(p.requires_grad for p in model.encoder.parameters())
+
+
+# --- config validation -------------------------------------------------------------------
+
+
+def test_empty_tasks_raises(data_dir) -> None:
+    toml = _catalog_toml(data_dir) + '\n[finetune]\ntasks = []\ncheckpoint = "ck.pt"\n\n[output]\ndir = "o"\n'
+    with pytest.raises(ValueError, match="tasks must be non-empty"):
+        build_finetune_config(tomllib.loads(toml))
+
+
+def test_task_not_in_catalog_raises(data_dir) -> None:
+    toml = _catalog_toml(data_dir) + '\n[finetune]\ntasks = ["nope"]\ncheckpoint = "ck.pt"\n\n[output]\ndir = "o"\n'
+    with pytest.raises(ValueError, match="unknown task"):
+        build_finetune_config(tomllib.loads(toml))
+
+
+def test_missing_checkpoint_raises(data_dir) -> None:
+    toml = _catalog_toml(data_dir) + '\n[finetune]\ntasks = ["a"]\n\n[output]\ndir = "o"\n'
+    with pytest.raises(ValueError, match="checkpoint must be given"):
+        build_finetune_config(tomllib.loads(toml))
+
+
+# --- engine ------------------------------------------------------------------------------
+
+
+def test_finetune_smoke_and_all_heads_saved(data_dir, tmp_path) -> None:
+    _, model = _model_with_heads(data_dir, ["a", "b"])
+    ckpt = tmp_path / "ck.pt"
+    _save_checkpoint(model, ["a", "b"], ckpt)
+
+    out = tmp_path / "ft"
+    cfg = _finetune_cfg(data_dir, out, checkpoint=ckpt, tasks=["a"], epochs=1)
+    rec = RunRecorder(out)  # mimic the CLI: provenance is written by the subcommand, not run()
+    rec.write_provenance(config=cfg, argv=["fm", "finetune"], seeds={"seed": cfg.training.seed})
+    summary = finetune_run(cfg, rec)
+    rec.close()
+
+    assert (out / "training" / "final_model.pt").exists()
+    assert (out / "training" / "finetune_summary.json").exists()
+    assert (out / "run_provenance.json").exists()
+    assert summary["finetuned_heads"] == ["a"]
+    assert "a" in summary["metrics_before"] and "a" in summary["metrics_after"]
+
+    # regression guard: the saved state_dict keeps ALL heads (disable/re-enable round-trip).
+    saved = torch.load(out / "training" / "final_model.pt", weights_only=True)["model"]
+    head_names = {k.split(".", 2)[1] for k in saved if k.startswith("task_heads.")}
+    assert {"a", "b", AE_NAME} <= head_names
+
+
+def test_add_new_task_head_added_and_trained(data_dir, tmp_path) -> None:
+    _, model = _model_with_heads(data_dir, ["a", "b"])
+    ckpt = tmp_path / "ck.pt"
+    _save_checkpoint(model, ["a", "b"], ckpt)
+
+    cfg = _finetune_cfg(data_dir, tmp_path / "add", checkpoint=ckpt, tasks=["c"], add_new_tasks=True)
+    summary = finetune_run(cfg)
+    assert summary["added_tasks"] == ["c"]
+    saved = torch.load(tmp_path / "add" / "training" / "final_model.pt", weights_only=True)["model"]
+    assert any(k.startswith("task_heads.c.") for k in saved)
+
+
+def test_add_new_task_disabled_raises(data_dir, tmp_path) -> None:
+    _, model = _model_with_heads(data_dir, ["a", "b"])
+    ckpt = tmp_path / "ck.pt"
+    _save_checkpoint(model, ["a", "b"], ckpt)
+
+    cfg = _finetune_cfg(data_dir, tmp_path / "noadd", checkpoint=ckpt, tasks=["c"], add_new_tasks=False)
+    with pytest.raises(ValueError, match="add_new_tasks"):
+        finetune_run(cfg)

--- a/src/foundation_model/workflows/pretrain.py
+++ b/src/foundation_model/workflows/pretrain.py
@@ -27,33 +27,33 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-import pandas as pd
-import torch
 from lightning import Trainer, seed_everything
 from lightning.pytorch.callbacks import Callback, EarlyStopping
 from loguru import logger
-from sklearn.metrics import accuracy_score, f1_score, mean_absolute_error, r2_score  # type: ignore[import-untyped]
-from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
-
-from foundation_model.data.datamodule import CompoundDataModule
-from foundation_model.models.flexible_multi_task_model import FlexibleMultiTaskModel
-from foundation_model.models.model_config import MLPEncoderConfig, OptimizerConfig
 
 from . import plots
+from ._engine import (
+    DropLastTrainCompoundDataModule,
+    build_empty_model,
+    build_head_config,
+    evaluate_task,
+)
+from ._sections import (
+    ModelSectionConfig,
+    TrainingSectionConfig,
+    build_model_section,
+    build_training_section,
+    reject_unknown,
+)
 from .recording import RunRecorder
 from .task_catalog import TaskCatalog, TaskCatalogConfig, TaskKind, build_task_catalog_config
 
-# Reserved built-in autoencoder head name (see FlexibleMultiTaskModel).
-_AE_NAME = "__reconstruction__"
-# Legacy head weight decay for regression / classification heads (kernel heads use kr_weight_decay).
-_HEAD_WEIGHT_DECAY = 1e-5
 # Stable qualitative palette so each task keeps one colour across the forgetting figure.
 _TASK_PALETTE = (
     "#4C72B0", "#DD8452", "#55A868", "#C44E52", "#8172B3", "#937860",
     "#DA8BC3", "#8C8C8C", "#CCB974", "#64B5CD", "#E377C2", "#17BECF",
 )  # fmt: skip
 
-# Root TOML sections a pretrain config may contain.
 _PRETRAIN_ROOT_KEYS = {"data", "descriptor", "datasets", "tasks", "model", "training", "pretrain", "output"}
 _CATALOG_KEYS = {"data", "descriptor", "datasets", "tasks"}
 
@@ -64,44 +64,6 @@ class TaskOrder(str, Enum):
 
 
 # --- config dataclasses -------------------------------------------------------------------
-
-
-@dataclass(kw_only=True)
-class ModelSectionConfig:
-    """[model] — architecture dims shared with finetune."""
-
-    latent_dim: int = 128
-    encoder_hidden: int = 256
-    head_hidden_dim: int = 64
-    n_kernel: int = 15
-
-    def __post_init__(self) -> None:
-        for name in ("latent_dim", "encoder_hidden", "head_hidden_dim", "n_kernel"):
-            if getattr(self, name) < 1:
-                raise ValueError(f"model.{name} must be >= 1, got {getattr(self, name)}.")
-
-
-@dataclass(kw_only=True)
-class TrainingSectionConfig:
-    """[training] — epochs, early-stop, learning rates, accelerator (shared with finetune)."""
-
-    max_epochs: int = 100
-    early_stop_patience: int = 8
-    early_stop_min_delta: float = 1e-4
-    encoder_lr: float = 5e-3
-    head_lr: float = 5e-3
-    kr_lr: float = 5e-4
-    kr_weight_decay: float = 5e-5
-    ae_lr: float = 5e-3
-    accelerator: str = "auto"
-    devices: int = 1
-    seed: int = 2025
-
-    def __post_init__(self) -> None:
-        if self.max_epochs < 1:
-            raise ValueError(f"training.max_epochs must be >= 1, got {self.max_epochs}.")
-        if self.early_stop_patience < 1:
-            raise ValueError(f"training.early_stop_patience must be >= 1, got {self.early_stop_patience}.")
 
 
 def _validate_replay_amount(value: float | int, *, where: str) -> None:
@@ -164,30 +126,18 @@ class PretrainConfig:
 # --- builder ------------------------------------------------------------------------------
 
 
-def _reject_unknown(section: str, raw: Mapping[str, Any], known: set[str]) -> None:
-    unknown = sorted(set(raw) - known)
-    if unknown:
-        raise ValueError(f"[{section}]: unknown key(s) {unknown}; allowed keys are {sorted(known)}.")
-
-
 def build_pretrain_config(raw: Mapping[str, Any], *, output_dir: str | Path | None = None) -> PretrainConfig:
     """Normalize a parsed-TOML tree into a :class:`PretrainConfig`."""
 
-    _reject_unknown("<root>", raw, _PRETRAIN_ROOT_KEYS)
+    reject_unknown("<root>", raw, _PRETRAIN_ROOT_KEYS)
     catalog = build_task_catalog_config({k: raw[k] for k in _CATALOG_KEYS if k in raw})
-
-    model_raw = dict(raw.get("model", {}))
-    _reject_unknown("model", model_raw, set(ModelSectionConfig.__dataclass_fields__))
-    model = ModelSectionConfig(**model_raw)
-
-    training_raw = dict(raw.get("training", {}))
-    _reject_unknown("training", training_raw, set(TrainingSectionConfig.__dataclass_fields__))
-    training = TrainingSectionConfig(**training_raw)
+    model = build_model_section(raw.get("model", {}))
+    training = build_training_section(raw.get("training", {}))
 
     pretrain_raw = dict(raw.get("pretrain", {}))
-    _reject_unknown("pretrain", pretrain_raw, {"task_sequence", "n_runs", "task_order", "rehearsal"})
+    reject_unknown("pretrain", pretrain_raw, {"task_sequence", "n_runs", "task_order", "rehearsal"})
     rehearsal_raw = dict(pretrain_raw.get("rehearsal", {}))
-    _reject_unknown("pretrain.rehearsal", rehearsal_raw, {"interval", "default_replay", "per_task"})
+    reject_unknown("pretrain.rehearsal", rehearsal_raw, {"interval", "default_replay", "per_task"})
     rehearsal = RehearsalConfig(
         interval=rehearsal_raw.get("interval", 1),
         default_replay=rehearsal_raw.get("default_replay", 0.05),
@@ -227,40 +177,6 @@ def replay_to_ratio(replay: float | int, n_valid: int) -> float:
     if n_valid <= 0:
         return 1.0
     return min(1.0, replay / n_valid)
-
-
-class _DropLastTrainCompoundDataModule(CompoundDataModule):
-    """``CompoundDataModule`` whose train loader drops the final partial batch.
-
-    Guards against BatchNorm1d crashing on a size-1 tail batch (``Expected more than 1 value per
-    channel``). Only the train loader is affected; val/test/predict keep every held-out row.
-    """
-
-    def train_dataloader(self) -> DataLoader | None:  # type: ignore[override]
-        base = super().train_dataloader()
-        if base is None:
-            return None
-        kwargs: dict[str, Any] = dict(
-            batch_size=base.batch_size,
-            num_workers=base.num_workers,
-            pin_memory=base.pin_memory,
-            collate_fn=base.collate_fn,
-            drop_last=True,
-        )
-        # Preserve a non-default sampler (e.g. a DistributedSampler) instead of forcing
-        # shuffle=True, so the loader stays correct if ever run under DDP; otherwise shuffle.
-        sampler = base.sampler
-        if isinstance(sampler, (RandomSampler, SequentialSampler)):
-            return DataLoader(base.dataset, shuffle=True, **kwargs)
-        return DataLoader(base.dataset, sampler=sampler, **kwargs)
-
-
-def _as_float_array(cell: Any) -> np.ndarray:
-    import ast
-
-    if isinstance(cell, str):
-        cell = ast.literal_eval(cell)
-    return np.asarray(cell, dtype=float).ravel()
 
 
 # --- engine -------------------------------------------------------------------------------
@@ -319,7 +235,7 @@ def _run_single(
     seed: int,
 ) -> list[dict[str, Any]]:
     seed_everything(seed, workers=True)
-    model = _build_empty_model(cfg, catalog)
+    model = build_empty_model(catalog, cfg.model, cfg.training)
 
     task_colors = {name: _TASK_PALETTE[i % len(_TASK_PALETTE)] for i, name in enumerate(task_order)}
     clf_tasks = frozenset(n for n in task_order if catalog.task_spec(n).kind is TaskKind.CLASSIFICATION)
@@ -329,18 +245,17 @@ def _run_single(
 
     for step, task_name in enumerate(task_order, start=1):
         logger.info(f"--- step {step}/{len(task_order)}: add '{task_name}' ---")
-        built[task_name] = _build_task_config(cfg, catalog, task_name, masking_ratio=1.0)
+        built[task_name] = build_head_config(catalog, cfg.model, cfg.training, task_name, masking_ratio=1.0)
         model.add_task(built[task_name])
 
         learned = list(task_order[: step - 1])
         participating = active_old_tasks(step, learned, cfg.rehearsal.interval)
         active = [task_name, *participating]
         for name in participating:
-            ratio = _replay_ratio_for(cfg, catalog, name)
-            built[name].task_masking_ratio = ratio
+            built[name].task_masking_ratio = _replay_ratio_for(cfg, catalog, name)
         built[task_name].task_masking_ratio = 1.0
 
-        datamodule = _DropLastTrainCompoundDataModule(
+        datamodule = DropLastTrainCompoundDataModule(
             task_configs=[built[name] for name in active],
             descriptor_fn=catalog.descriptor_fn(),
             task_frames={name: catalog.task_frames([name])[name] for name in active},
@@ -378,7 +293,7 @@ def _run_single(
         step_dir = recorder.paths.step_dir(step, task_name)
         step_metrics: dict[str, dict[str, float]] = {}
         for name in task_order[:step]:  # evaluate ALL learned heads, regardless of interval
-            metric = _evaluate_task(
+            metric = evaluate_task(
                 model, catalog, name, recorder, step_dir, is_new=(name == task_name), test_keys=test_keys
             )
             step_metrics[name] = metric
@@ -394,41 +309,8 @@ def _run_single(
     plots.plt.close(fig)
     recorder.write_records()
     recorder.write_metrics_table()
-    recorder.save_final_model(model, list(task_order), _task_spec_dump(cfg, catalog, task_order))
+    recorder.save_final_model(model, list(task_order), _task_spec_dump(catalog, task_order))
     return records
-
-
-def _build_empty_model(cfg: PretrainConfig, catalog: TaskCatalog) -> FlexibleMultiTaskModel:
-    encoder_config = MLPEncoderConfig(
-        hidden_dims=[catalog.descriptor_dim, cfg.model.encoder_hidden, cfg.model.latent_dim]
-    )
-    model = FlexibleMultiTaskModel(
-        task_configs=[],
-        encoder_config=encoder_config,
-        enable_autoencoder=True,
-        shared_block_optimizer=OptimizerConfig(lr=cfg.training.encoder_lr, weight_decay=1e-2),
-    )
-    # AE head always trains; only its LR is configurable (ae_lr).
-    if _AE_NAME in model.task_configs_map:
-        model.task_configs_map[_AE_NAME].optimizer = OptimizerConfig(lr=cfg.training.ae_lr)
-    return model
-
-
-def _build_task_config(cfg: PretrainConfig, catalog: TaskCatalog, name: str, *, masking_ratio: float) -> Any:
-    spec = catalog.task_spec(name)
-    if spec.kind is TaskKind.KERNEL_REGRESSION:
-        lr, weight_decay = cfg.training.kr_lr, cfg.training.kr_weight_decay
-    else:
-        lr, weight_decay = cfg.training.head_lr, _HEAD_WEIGHT_DECAY
-    return catalog.build_task_config(
-        name,
-        latent_dim=cfg.model.latent_dim,
-        head_hidden_dim=cfg.model.head_hidden_dim,
-        n_kernel=cfg.model.n_kernel,
-        lr=lr,
-        weight_decay=weight_decay,
-        masking_ratio=masking_ratio,
-    )
 
 
 def _replay_ratio_for(cfg: PretrainConfig, catalog: TaskCatalog, name: str) -> float:
@@ -447,157 +329,9 @@ def _n_valid_train_labels(catalog: TaskCatalog, name: str) -> int:
     return int(mask.sum())
 
 
-def _task_spec_dump(cfg: PretrainConfig, catalog: TaskCatalog, task_order: Sequence[str]) -> dict[str, Any]:
+def _task_spec_dump(catalog: TaskCatalog, task_order: Sequence[str]) -> dict[str, Any]:
     dump: dict[str, Any] = {}
     for name in task_order:
         spec = catalog.task_spec(name)
         dump[name] = {"kind": spec.kind.value, "column": spec.column, "source": spec.dataset}
     return dump
-
-
-def _test_rows(catalog: TaskCatalog, name: str, test_keys: set[str] | None) -> list[str]:
-    spec = catalog.task_spec(name)
-    frame = catalog.task_frames([name])[name]
-    mask = frame[spec.column].notna()
-    if test_keys is not None:
-        mask &= frame.index.isin(test_keys)
-    elif "split" in frame.columns:
-        mask &= frame["split"] == "test"
-    return list(frame.index[mask])
-
-
-def _descriptor_tensor(catalog: TaskCatalog, comps: list[str], device: torch.device) -> tuple[torch.Tensor, list[str]]:
-    desc = catalog.descriptor_fn()(comps)
-    kept = [c for c in comps if c in desc.index]
-    tensor = torch.tensor(desc.loc[kept].values, dtype=torch.float32, device=device)
-    return tensor, kept
-
-
-def _evaluate_task(
-    model: FlexibleMultiTaskModel,
-    catalog: TaskCatalog,
-    name: str,
-    recorder: RunRecorder,
-    step_dir: Path,
-    *,
-    is_new: bool,
-    test_keys: set[str] | None,
-) -> dict[str, float]:
-    """Evaluate one head on the fixed test split; dump parquet + metrics (+ plot if new)."""
-
-    spec = catalog.task_spec(name)
-    model.eval()
-    device = next(model.parameters()).device
-    comps = _test_rows(catalog, name, test_keys)
-    if not comps:
-        return {"primary": float("nan"), "samples": 0}
-    frame = catalog.task_frames([name])[name]
-    head = model.task_heads[name]
-
-    with torch.no_grad():
-        if spec.kind in (TaskKind.REGRESSION, TaskKind.CLASSIFICATION):
-            x, comps = _descriptor_tensor(catalog, comps, device)
-            if not comps:
-                return {"primary": float("nan"), "samples": 0}
-            h = torch.tanh(model.encoder(x))
-            if spec.kind is TaskKind.REGRESSION:
-                pred = catalog.inverse_transform(name, head(h).squeeze(-1).cpu().numpy())
-                true = catalog.inverse_transform(name, frame.loc[comps, spec.column].astype(float).to_numpy())
-                r2 = float(r2_score(true, pred))
-                metric = {"r2": r2, "mae": float(mean_absolute_error(true, pred)), "samples": len(comps), "primary": r2}
-                recorder.dump_predictions(
-                    step_dir, name, pd.DataFrame({"composition": comps, "true": true, "pred": pred})
-                )
-                recorder.dump_metrics(step_dir, name, metric)
-                if is_new:
-                    fig = plots.plot_parity(true, pred, r2=r2, title=name)
-                    recorder.save_figure(_fig_rel(recorder, step_dir, f"{name}_parity.png"), fig)
-                    plots.plt.close(fig)
-                return metric
-            logits = head(h)
-            pred = logits.argmax(dim=-1).cpu().numpy()
-            true = frame.loc[comps, spec.column].astype(int).to_numpy()
-            acc = float(accuracy_score(true, pred))
-            metric = {
-                "accuracy": acc,
-                "macro_f1": float(f1_score(true, pred, average="macro", zero_division=0)),
-                "samples": len(comps),
-                "primary": acc,
-            }
-            recorder.dump_predictions(step_dir, name, pd.DataFrame({"composition": comps, "true": true, "pred": pred}))
-            recorder.dump_metrics(step_dir, name, metric)
-            if is_new:
-                assert spec.num_classes is not None
-                fig = plots.plot_confusion(
-                    true,
-                    pred,
-                    num_classes=spec.num_classes,
-                    acc=acc,
-                    title=name,
-                    special_material_type=(name == "material_type"),
-                )
-                recorder.save_figure(_fig_rel(recorder, step_dir, f"{name}_confusion.png"), fig)
-                plots.plt.close(fig)
-            return metric
-
-        # kernel regression
-        assert spec.t_column is not None
-        # Compute descriptors once for the whole test set, then filter by availability
-        # (cheaper than a 1-row descriptor call per composition).
-        available = set(catalog.descriptor_fn()(comps).index)
-        keep: list[str] = []
-        t_list: list[np.ndarray] = []
-        true_parts: list[np.ndarray] = []
-        for comp in comps:
-            if comp not in available:
-                continue
-            y_arr = _as_float_array(frame.at[comp, spec.column])
-            t_arr = _as_float_array(frame.at[comp, spec.t_column])
-            if y_arr.size == 0 or y_arr.size != t_arr.size:
-                continue
-            keep.append(comp)
-            t_list.append(t_arr)
-            true_parts.append(y_arr)
-        if not keep:
-            return {"primary": float("nan"), "samples": 0}
-        xk, _ = _descriptor_tensor(catalog, keep, device)
-        h_k = torch.tanh(model.encoder(xk))
-        t_tensors = [torch.tensor(t, dtype=torch.float32, device=device) for t in t_list]
-        expanded_h, expanded_t = model._expand_for_kernel_regression(h_k, t_tensors)
-        pred = catalog.inverse_transform(name, head(expanded_h, t=expanded_t).squeeze(-1).cpu().numpy())
-        true = catalog.inverse_transform(name, np.concatenate(true_parts))
-        r2 = float(r2_score(true, pred))
-        metric = {
-            "r2": r2,
-            "mae": float(mean_absolute_error(true, pred)),
-            "samples": len(keep),
-            "points": int(true.size),
-            "primary": r2,
-        }
-        recorder.dump_predictions(step_dir, name, _kr_long_frame(keep, t_list, true_parts, pred))
-        recorder.dump_metrics(step_dir, name, metric)
-        if is_new:
-            kr_fig = plots.plot_kr_sequences(keep, t_list, true_parts, pred, title=name)
-            if kr_fig is not None:
-                recorder.save_figure(_fig_rel(recorder, step_dir, f"{name}_sequences.png"), kr_fig)
-                plots.plt.close(kr_fig)
-        return metric
-
-
-def _kr_long_frame(
-    comps: list[str], t_list: list[np.ndarray], true_parts: list[np.ndarray], pred: np.ndarray
-) -> pd.DataFrame:
-    rows: list[dict[str, Any]] = []
-    offset = 0
-    for comp, t_arr, y_true in zip(comps, t_list, true_parts):
-        n = int(y_true.size)
-        for k in range(n):
-            rows.append(
-                {"composition": comp, "t": float(t_arr[k]), "true": float(y_true[k]), "pred": float(pred[offset + k])}
-            )
-        offset += n
-    return pd.DataFrame(rows)
-
-
-def _fig_rel(recorder: RunRecorder, step_dir: Path, filename: str) -> str:
-    return str((step_dir / filename).relative_to(recorder.paths.root))

--- a/src/foundation_model/workflows/task_catalog.py
+++ b/src/foundation_model/workflows/task_catalog.py
@@ -622,11 +622,14 @@ class TaskCatalog:
         *,
         masking_ratios: Mapping[str, float] | None = None,
         predict_idx: str | Sequence[str] | None = None,
+        datamodule_cls: type[CompoundDataModule] = CompoundDataModule,
     ) -> CompoundDataModule:
-        """Assemble a :class:`CompoundDataModule` over ``active_tasks``.
+        """Assemble a datamodule over ``active_tasks``.
 
         ``masking_ratios`` overrides each task's keep-ratio (default 1.0); ``predict_idx`` is set
         on every active task config (literal split name or explicit composition sequence).
+        ``datamodule_cls`` lets callers request a ``CompoundDataModule`` subclass (e.g. the
+        drop-last training variant used during fit) without this module importing it.
         """
 
         masking_ratios = masking_ratios or {}
@@ -636,7 +639,7 @@ class TaskCatalog:
             for name in active_tasks
         ]
         data = self.config.data
-        return CompoundDataModule(
+        return datamodule_cls(
             task_configs=task_configs,
             descriptor_fn=self.descriptor_fn(),
             task_frames={name: frames[name] for name in active_tasks},


### PR DESCRIPTION
## Summary

Third PR of the `fm` CLI refactor (stacked on #22). Adds the finetune engine and extracts the
model/eval code shared with pretrain.

- **`workflows/finetune.py`** — rebuild the checkpoint's model from the `TaskCatalog`, load with
  `strict=False`, optionally `add_task` heads absent from the checkpoint (`add_new_tasks`), then
  apply the freeze policy and fine-tune only the requested heads. **Freeze policy** (rewrite of
  `finetune_inverse_heads.freeze_except`, one intentional change): encoder + every non-target head
  frozen, **except the AE head which always stays trainable** (`ae_lr`); `task_log_sigmas` frozen.
  Non-target heads are `disable_task`/`enable_task`'d around the fit so the saved state_dict keeps
  every head. Writes `final_model.pt`, `finetune_summary.json` (heads, epochs, frozen/trainable
  param counts, before/after metrics), and per-head parquet/metrics/plots.
- **`workflows/_sections.py`** — `ModelSectionConfig`/`TrainingSectionConfig` + builders, now
  shared by pretrain and finetune (moved out of `pretrain.py` per the plan).
- **`workflows/_engine.py`** — shared `build_empty_model` / `build_head_config` / `evaluate_task`
  / `DropLastTrainCompoundDataModule`; `pretrain.py` refactored to use them (no behaviour change).
- **`cli/main.py`** — `fm finetune` (`--checkpoint`/`--tasks`/`--epochs`).

## Validation

- `fm pretrain … && fm finetune --checkpoint <pretrain ckpt>` runs on CPU: encoder + non-target
  heads frozen, AE + target head trainable, disable/re-enable round-trip keeps all heads.
- Full suite → **429 passed, 1 skipped**; ruff/mypy clean on all new files. Legacy untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCoVwB3pntFi25YnpoHYwY