### PR TITLE
PR4 — fm inverse: scenario × path inverse-design engine

### DIFF
--- a/samples/finetune_smoke.toml
+++ b/samples/finetune_smoke.toml
@@ -13,31 +13,29 @@ batch_size = 64
 kind = "kmd"
 n_grids = 8
 
-[datasets.supercon]
-path = "data/NEMAD_superconductor_20260425.parquet"
-sample = 200
-
-[datasets.magnetic]
-path = "data/NEMAD_magnetic_20260419.parquet"
-sample = 200
+[datasets.qc]
+path = "data/qc_ac_te_mp_dos_reformat_20250615_enforce_quaternary_test.pd.parquet"
+preprocessing_path = "data/preprocessing_objects_20250615.pkl.z"
+sample = 300
 
 [[tasks]]
-name = "tc"
+name = "density"
 kind = "regression"
-dataset = "supercon"
-column = "Transition temperature[K]"
+dataset = "qc"
+column = "Density (normalized)"
 
 [[tasks]]
-name = "pressure"
+name = "formation_energy"
 kind = "regression"
-dataset = "supercon"
-column = "Pressure[GPa]"
+dataset = "qc"
+column = "Formation energy per atom (normalized)"
 
 [[tasks]]
-name = "moment"
-kind = "regression"
-dataset = "magnetic"
-column = "Magnetic moment[μB/f.u.]"
+name = "material_type"
+kind = "classification"
+dataset = "qc"
+column = "Material type (label)"
+num_classes = 5
 
 [model]
 latent_dim = 32
@@ -56,7 +54,7 @@ ae_lr = 5e-3
 
 [finetune]
 checkpoint = "artifacts/pretrain_smoke/runs/run00/training/final_model.pt"
-tasks = ["moment"]
+tasks = ["formation_energy"]
 epochs = 2
 freeze_encoder = true
 

--- a/samples/inverse_smoke.toml
+++ b/samples/inverse_smoke.toml
@@ -1,0 +1,78 @@
+# Smoke-test config for `fm inverse` — one scenario, 2 paths, on a smoke checkpoint.
+#
+# Catalog + model dims match samples/pretrain_smoke.toml. The checkpoint must contain the
+# regression heads (density, formation_energy) and the classification head (material_type).
+#
+#   fm inverse --config samples/inverse_smoke.toml \
+#       --checkpoint artifacts/finetune_smoke/training/final_model.pt
+
+[data]
+composition_column = "composition"
+batch_size = 64
+
+[descriptor]
+kind = "kmd"
+n_grids = 8
+
+[datasets.qc]
+path = "data/qc_ac_te_mp_dos_reformat_20250615_enforce_quaternary_test.pd.parquet"
+preprocessing_path = "data/preprocessing_objects_20250615.pkl.z"
+sample = 300
+
+[[tasks]]
+name = "density"
+kind = "regression"
+dataset = "qc"
+column = "Density (normalized)"
+
+[[tasks]]
+name = "formation_energy"
+kind = "regression"
+dataset = "qc"
+column = "Formation energy per atom (normalized)"
+
+[[tasks]]
+name = "material_type"
+kind = "classification"
+dataset = "qc"
+column = "Material type (label)"
+num_classes = 5
+
+[model]
+latent_dim = 32
+encoder_hidden = 64
+head_hidden_dim = 32
+n_kernel = 8
+
+[inverse]
+checkpoint = "artifacts/finetune_smoke/training/final_model.pt"
+steps = 5
+lr = 0.05
+class_weight = 5.0
+record_trajectory = true
+animation_formats = []
+
+[inverse.seeds]
+strategy = "top_qc"
+n = 4
+split = "test"
+
+[[inverse.scenarios]]
+name = "scenario_fe_down_density_up"
+reg_tasks = ["formation_energy", "density"]
+reg_targets = [-2.0, 2.0]
+class_task = "material_type"
+
+[[inverse.paths]]
+name = "latent_align1"
+method = "latent"
+ae_align_scale = 1.0
+
+[[inverse.paths]]
+name = "comp_seed_blend95"
+method = "composition"
+init = "seed"
+seed_blend = 0.95
+
+[output]
+dir = "artifacts/inverse_smoke"

--- a/samples/pretrain_smoke.toml
+++ b/samples/pretrain_smoke.toml
@@ -1,7 +1,9 @@
 # Smoke-test config for `fm pretrain` — a fast CPU end-to-end run.
 #
-# 3 regression tasks over 2 NEMAD datasets, KMD-1d descriptors, sample=200 rows/dataset,
-# rehearsal interval=2, a 2-run sweep, 2 epochs/step.
+# 2 regression + 1 classification task over the qc dataset (pre-normalized columns +
+# integer material-type label), KMD-1d descriptors, sample=300 rows, rehearsal interval=2,
+# a 2-run sweep, 2 epochs/step. Shares its catalog with the finetune/inverse/predict smoke
+# configs so the checkpoints chain cleanly.
 #
 #   fm pretrain --config samples/pretrain_smoke.toml
 
@@ -17,31 +19,29 @@ num_workers = 0
 kind = "kmd"
 n_grids = 8
 
-[datasets.supercon]
-path = "data/NEMAD_superconductor_20260425.parquet"
-sample = 200
-
-[datasets.magnetic]
-path = "data/NEMAD_magnetic_20260419.parquet"
-sample = 200
+[datasets.qc]
+path = "data/qc_ac_te_mp_dos_reformat_20250615_enforce_quaternary_test.pd.parquet"
+preprocessing_path = "data/preprocessing_objects_20250615.pkl.z"
+sample = 300
 
 [[tasks]]
-name = "tc"
+name = "density"
 kind = "regression"
-dataset = "supercon"
-column = "Transition temperature[K]"
+dataset = "qc"
+column = "Density (normalized)"
 
 [[tasks]]
-name = "pressure"
+name = "formation_energy"
 kind = "regression"
-dataset = "supercon"
-column = "Pressure[GPa]"
+dataset = "qc"
+column = "Formation energy per atom (normalized)"
 
 [[tasks]]
-name = "moment"
-kind = "regression"
-dataset = "magnetic"
-column = "Magnetic moment[μB/f.u.]"
+name = "material_type"
+kind = "classification"
+dataset = "qc"
+column = "Material type (label)"
+num_classes = 5
 
 [model]
 latent_dim = 32
@@ -62,7 +62,7 @@ devices = 1
 seed = 2025
 
 [pretrain]
-task_sequence = ["tc", "pressure", "moment"]
+task_sequence = ["density", "formation_energy", "material_type"]
 n_runs = 2
 task_order = "fixed"
 

--- a/src/foundation_model/cli/main.py
+++ b/src/foundation_model/cli/main.py
@@ -54,8 +54,15 @@ def load_raw_config(
     seed: int | None = None,
     accelerator: str | None = None,
     sample: int | None = None,
+    seed_key: str = "training.seed",
+    accelerator_key: str = "training.accelerator",
 ) -> dict[str, Any]:
-    """Load a TOML file and apply ``--set`` overrides plus common first-class flags."""
+    """Load a TOML file and apply ``--set`` overrides plus common first-class flags.
+
+    ``seed_key`` / ``accelerator_key`` route ``--seed`` / ``--accelerator`` to the right section
+    per subcommand (``[training]`` for pretrain/finetune, ``[inverse]`` / ``[predict]`` for those),
+    so they never inject a section the config builder would reject.
+    """
 
     with open(config_path, "rb") as fh:
         raw: dict[str, Any] = tomllib.load(fh)
@@ -67,9 +74,9 @@ def load_raw_config(
         _set_dotted(raw, key.strip(), _parse_toml_value(value.strip()))
 
     if seed is not None:
-        _set_dotted(raw, "training.seed", seed)
+        _set_dotted(raw, seed_key, seed)
     if accelerator is not None:
-        _set_dotted(raw, "training.accelerator", accelerator)
+        _set_dotted(raw, accelerator_key, accelerator)
     if sample is not None:
         for name in raw.get("datasets", {}):
             _set_dotted(raw, f"datasets.{name}.sample", sample)
@@ -187,7 +194,15 @@ def _inverse_config(
     no_trajectory: bool,
     animation_formats: str | None,
 ) -> InverseConfig:
-    raw = load_raw_config(config_path, overrides, seed=seed, accelerator=accelerator, sample=sample)
+    raw = load_raw_config(
+        config_path,
+        overrides,
+        seed=seed,
+        accelerator=accelerator,
+        sample=sample,
+        seed_key="inverse.seed",
+        accelerator_key="inverse.accelerator",
+    )
     if steps is not None:
         _set_dotted(raw, "inverse.steps", steps)
     if no_trajectory:

--- a/src/foundation_model/cli/main.py
+++ b/src/foundation_model/cli/main.py
@@ -20,6 +20,8 @@ import click
 
 from foundation_model.workflows.finetune import FinetuneConfig, build_finetune_config
 from foundation_model.workflows.finetune import run as finetune_run
+from foundation_model.workflows.inverse import InverseConfig, build_inverse_config
+from foundation_model.workflows.inverse import run as inverse_run
 from foundation_model.workflows.pretrain import PretrainConfig, build_pretrain_config
 from foundation_model.workflows.pretrain import run as pretrain_run
 from foundation_model.workflows.recording import RunRecorder
@@ -170,6 +172,68 @@ def finetune_cmd(
     recorder = RunRecorder(cfg.output_dir)
     recorder.write_provenance(config=cfg, argv=list(sys.argv), seeds={"seed": cfg.training.seed})
     finetune_run(cfg, recorder)
+    recorder.close()
+
+
+def _inverse_config(
+    config_path: str,
+    overrides: Sequence[str],
+    output_dir: str | None,
+    seed: int | None,
+    accelerator: str | None,
+    sample: int | None,
+    checkpoint: str | None,
+    steps: int | None,
+    no_trajectory: bool,
+    animation_formats: str | None,
+) -> InverseConfig:
+    raw = load_raw_config(config_path, overrides, seed=seed, accelerator=accelerator, sample=sample)
+    if steps is not None:
+        _set_dotted(raw, "inverse.steps", steps)
+    if no_trajectory:
+        _set_dotted(raw, "inverse.record_trajectory", False)
+    if animation_formats is not None:
+        fmts = [f.strip() for f in animation_formats.split(",") if f.strip()]
+        _set_dotted(raw, "inverse.animation_formats", fmts)
+    return build_inverse_config(raw, output_dir=output_dir, checkpoint=checkpoint)
+
+
+@main.command("inverse")
+@common_options
+@click.option("--checkpoint", default=None, type=click.Path(dir_okay=False), help="Checkpoint to inverse-design from.")
+@click.option("--scenario", "scenarios", multiple=True, help="Run only the named scenario(s) (repeatable).")
+@click.option("--steps", type=int, default=None, help="Override inverse.steps.")
+@click.option("--no-trajectory", is_flag=True, default=False, help="Disable trajectory recording.")
+@click.option("--animation-formats", default=None, help="Comma list of {gif,html,svg} (overrides config).")
+def inverse_cmd(
+    config_path: str,
+    output_dir: str | None,
+    overrides: tuple[str, ...],
+    seed: int | None,
+    accelerator: str | None,
+    sample: int | None,
+    checkpoint: str | None,
+    scenarios: tuple[str, ...],
+    steps: int | None,
+    no_trajectory: bool,
+    animation_formats: str | None,
+) -> None:
+    """Inverse design (scenarios × algorithm paths)."""
+    cfg = _inverse_config(
+        config_path,
+        overrides,
+        output_dir,
+        seed,
+        accelerator,
+        sample,
+        checkpoint,
+        steps,
+        no_trajectory,
+        animation_formats,
+    )
+    recorder = RunRecorder(cfg.output_dir)
+    recorder.write_provenance(config=cfg, argv=list(sys.argv), seeds={"seed": 2025})
+    inverse_run(cfg, recorder, only_scenarios=list(scenarios) or None)
     recorder.close()
 
 

--- a/src/foundation_model/workflows/inverse.py
+++ b/src/foundation_model/workflows/inverse.py
@@ -36,6 +36,7 @@ from loguru import logger  # noqa: E402
 from foundation_model.models.model_config import MLPEncoderConfig, OptimizerConfig  # noqa: E402
 from foundation_model.utils.kmd_plus import DEFAULT_ELEMENTS, formula_to_composition  # noqa: E402
 
+from . import inverse_trajectory  # noqa: E402
 from ._sections import ModelSectionConfig, build_model_section, reject_unknown  # noqa: E402
 from .plots import DISCOVERED_ELEMENT_COLOR, SCATTER_COLOR  # noqa: E402
 from .recording import RunRecorder, load_checkpoint_state  # noqa: E402
@@ -243,6 +244,8 @@ class InverseConfig:
     record_trajectory: bool = True
     per_seed_trajectories: bool = False
     animation_formats: list[str] = field(default_factory=lambda: ["gif"])
+    seed: int = 2025
+    accelerator: str = "auto"
 
     def __post_init__(self) -> None:
         self.checkpoint = Path(self.checkpoint)
@@ -305,6 +308,8 @@ def build_inverse_config(
             "record_trajectory",
             "per_seed_trajectories",
             "animation_formats",
+            "seed",
+            "accelerator",
             "seeds",
             "scenarios",
             "paths",
@@ -335,6 +340,8 @@ def build_inverse_config(
         record_trajectory=bool(inv_raw.get("record_trajectory", True)),
         per_seed_trajectories=bool(inv_raw.get("per_seed_trajectories", False)),
         animation_formats=list(inv_raw.get("animation_formats", ["gif"])),
+        seed=int(inv_raw.get("seed", 2025)),
+        accelerator=str(inv_raw.get("accelerator", "auto")),
     )
 
 
@@ -572,8 +579,10 @@ def _run_composition_path(
 
     if path.init == "seed":
         init_kwargs: dict[str, Any] = {"initial_weights": _seed_weights(seeds), "seed_blend": path.seed_blend}
+        n_rows = len(seeds)
     else:
-        init_kwargs = {"initial_weights": None, "n_starts": path.n_starts or len(seeds)}
+        n_rows = path.n_starts or len(seeds)  # random init yields n_starts rows, not len(seeds)
+        init_kwargs = {"initial_weights": None, "n_starts": n_rows}
 
     t0 = time.perf_counter()
     res = model.optimize_composition(
@@ -599,7 +608,7 @@ def _run_composition_path(
     achieved = res.optimized_target.cpu().numpy()
     after_qc = _qc_prob(model, optimized_desc, scenario.class_task, scenario.class_indices)
     after_reg = _reg_preds(model, optimized_desc, reg_names)
-    seed_labels = list(seeds) if path.init == "seed" else [f"random_start_{i}" for i in range(len(seeds))]
+    seed_labels = list(seeds) if path.init == "seed" else [f"random_start_{i}" for i in range(n_rows)]
     out = _result_dict(
         path,
         "composition",
@@ -649,6 +658,71 @@ def _result_dict(
 # --- engine -------------------------------------------------------------------------------
 
 
+def _resolve_device(accelerator: str) -> torch.device:
+    if accelerator == "cpu":
+        return torch.device("cpu")
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("cpu")
+
+
+def _reg_progress(
+    targets: np.ndarray, reg_names: Sequence[str], reg_targets: Mapping[str, float], seed_reg: Mapping[str, np.ndarray]
+) -> dict[str, np.ndarray]:
+    """Per-step mean progress (0 = seed baseline, 1 = target) for each regression task."""
+    progress: dict[str, np.ndarray] = {}
+    for j, task in enumerate(reg_names):
+        baseline = np.asarray(seed_reg[task], dtype=float)  # (B,)
+        denom = float(reg_targets[task]) - baseline
+        denom = np.where(np.abs(denom) < 1e-9, 1.0, denom)
+        traj = targets[:, :, j]  # (steps, B)
+        progress[task] = ((traj - baseline[None, :]) / denom[None, :]).mean(axis=1)
+    return progress
+
+
+def _emit_trajectory(
+    result: dict[str, Any],
+    targets: np.ndarray,
+    weights: np.ndarray,
+    reg_targets: Mapping[str, float],
+    seed_reg: Mapping[str, np.ndarray],
+    cfg: InverseConfig,
+    traj_dir: Path,
+) -> None:
+    """Write the static trajectory plot (+ requested animations) for one path."""
+    reg_names = list(reg_targets)
+    if targets.size == 0:
+        return
+    progress = _reg_progress(targets, reg_names, reg_targets, seed_reg)
+    inverse_trajectory.plot_trajectory_static(
+        progress, traj_dir / f"{result['path']}_trajectory.png", title=result["path"]
+    )
+
+    if cfg.animation_formats and weights.size:
+        qc_final = np.asarray(result["qc_after_decode"])
+        reg_final = {t: np.asarray(result["reg_after_decode"][t]) for t in reg_names}
+        best = min(
+            inverse_trajectory.best_seed_by_target_distance(qc_final, reg_final, reg_targets), weights.shape[1] - 1
+        )
+        out_paths = {fmt: traj_dir / f"{result['path']}_trajectory.{fmt}" for fmt in cfg.animation_formats}
+        inverse_trajectory.plot_trajectory_animation(
+            progress, weights[:, best, :], list(DEFAULT_ELEMENTS), out_paths, title=result["path"]
+        )
+
+    if cfg.per_seed_trajectories:
+        per_dir = traj_dir / f"{result['path']}_per_seed"
+        per_dir.mkdir(exist_ok=True)
+        for i in range(min(targets.shape[1], 20)):  # cap the per-seed fan-out
+            ps: dict[str, np.ndarray] = {}
+            for j, task in enumerate(reg_names):
+                baseline = float(np.asarray(seed_reg[task])[i])
+                denom = float(reg_targets[task]) - baseline
+                ps[task] = (targets[:, i, j] - baseline) / (denom if abs(denom) >= 1e-9 else 1.0)
+            inverse_trajectory.plot_trajectory_static(
+                ps, per_dir / f"seed{i:02d}.png", title=f"{result['path']} · seed {i}"
+            )
+
+
 def run(
     cfg: InverseConfig, recorder: RunRecorder | None = None, *, only_scenarios: Sequence[str] | None = None
 ) -> dict[str, Any]:
@@ -657,15 +731,21 @@ def run(
     catalog = TaskCatalog(cfg.catalog)
     owns_recorder = recorder is None
     rec = recorder or RunRecorder(cfg.output_dir)
-    seed_everything(2025, workers=True)
+    seed_everything(cfg.seed, workers=True)
 
     try:
         model, ckpt_tasks = _rebuild_model(cfg, catalog)
         _validate_heads(model, cfg)
-        device = next(model.parameters()).device
+        device = _resolve_device(cfg.accelerator)
+        model.to(device)
 
-        # Seeds are selected once per run using the first scenario's classification objective.
-        seed_scn = cfg.scenarios[0]
+        # Apply the --scenario filter FIRST, then select seeds using the first *selected* scenario's
+        # classification objective (so a filtered run doesn't depend on unrelated config order).
+        scenarios = [s for s in cfg.scenarios if only_scenarios is None or s.name in set(only_scenarios)]
+        if not scenarios:
+            raise ValueError(f"no scenarios match the filter {list(only_scenarios or [])}.")
+
+        seed_scn = scenarios[0]
         seeds = select_seeds(
             catalog,
             model,
@@ -680,7 +760,6 @@ def run(
         (rec.paths.root / "seeds.json").write_text(json.dumps({"seeds": list(seeds)}, indent=2), encoding="utf-8")
         logger.info(f"Selected {len(seeds)} seeds.")
 
-        scenarios = [s for s in cfg.scenarios if only_scenarios is None or s.name in set(only_scenarios)]
         all_summary: dict[str, Any] = {}
         for scenario in scenarios:
             logger.info(f"=== scenario '{scenario.name}' ({len(cfg.paths)} paths) ===")
@@ -752,20 +831,21 @@ def _run_scenario(
 
     summary = _summarise(results, reg_targets)
 
-    # Externalize trajectories to .npz, drop the big arrays from results.json.
+    # Trajectory outputs: static plot + requested animations, then externalize arrays to .npz.
     if cfg.record_trajectory:
         traj_dir = sc_dir / "trajectories"
         traj_dir.mkdir(exist_ok=True)
         for r in results:
             if "trajectory_targets" not in r:
                 continue
+            targets = np.asarray(r["trajectory_targets"], dtype=np.float32)
+            weights = np.asarray(r["trajectory_weights"], dtype=np.float32)
+            _emit_trajectory(r, targets, weights, reg_targets, seed_reg, cfg, traj_dir)
             npz = traj_dir / f"{r['path']}.npz"
-            np.savez_compressed(
-                npz,
-                targets=np.asarray(r.pop("trajectory_targets"), dtype=np.float32),
-                weights=np.asarray(r.pop("trajectory_weights"), dtype=np.float32),
-            )
+            np.savez_compressed(npz, targets=targets, weights=weights)
             r["trajectory_file"] = str(npz.relative_to(sc_dir))
+            del r["trajectory_targets"]
+            del r["trajectory_weights"]
 
     (sc_dir / "scenario.json").write_text(
         json.dumps(

--- a/src/foundation_model/workflows/inverse.py
+++ b/src/foundation_model/workflows/inverse.py
@@ -1,0 +1,961 @@
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``fm inverse`` — scenario × path inverse-design engine.
+
+For each scenario (a set of regression targets + a classification objective) the engine selects
+seed compositions once per run, then optimises them along each configured *path* — either
+latent-space optimisation with AE alignment (``optimize_latent``) or differentiable
+composition-space optimisation over element weights (``optimize_composition``). Migrated from
+``scripts/paper_inverse_comparison.py`` (per-path engine + figures), ``paper_inverse_3scenarios.py``
+(per-scenario loop) and the seed selection in ``continual_rehearsal_demo._select_seeds``.
+Trajectory analytics live in :mod:`foundation_model.workflows.inverse_trajectory`.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import torch  # noqa: E402
+from lightning import seed_everything  # noqa: E402
+from loguru import logger  # noqa: E402
+
+from foundation_model.models.model_config import MLPEncoderConfig, OptimizerConfig  # noqa: E402
+from foundation_model.utils.kmd_plus import DEFAULT_ELEMENTS, formula_to_composition  # noqa: E402
+
+from ._sections import ModelSectionConfig, build_model_section, reject_unknown  # noqa: E402
+from .plots import DISCOVERED_ELEMENT_COLOR, SCATTER_COLOR  # noqa: E402
+from .recording import RunRecorder, load_checkpoint_state  # noqa: E402
+from .task_catalog import TaskCatalog, TaskCatalogConfig, build_task_catalog_config  # noqa: E402
+
+# Reserved AE head name.
+_AE_NAME = "__reconstruction__"
+# Default QC class indices for the classification objective when class_target is unset.
+_DEFAULT_QC_CLASSES = [1]
+_ANIMATION_FORMATS = {"gif", "html", "svg"}
+_ELEMENT_TOKEN = re.compile(r"[A-Z][a-z]?")
+
+# 48-element feasible alloy palette (copied verbatim from paper_inverse_comparison.py).
+DEFAULT_ALLOY_PALETTE: list[str] = [
+    "Mg", "Ca", "B", "Al", "Ga", "In", "Tl", "Si", "Ge", "Sc", "Ti", "V", "Cr", "Mn", "Fe", "Co",
+    "Ni", "Cu", "Zn", "Y", "Zr", "Nb", "Mo", "Ru", "Rh", "Pd", "Ag", "Cd", "Hf", "Ta", "W", "Re",
+    "Os", "Ir", "Pt", "Au", "La", "Ce", "Pr", "Nd", "Sm", "Eu", "Gd", "Tb", "Dy", "Ho", "Er", "Yb",
+]  # fmt: skip
+assert len(DEFAULT_ALLOY_PALETTE) == 48
+
+_INVERSE_ROOT_KEYS = {"data", "descriptor", "datasets", "tasks", "model", "inverse", "output"}
+_CATALOG_KEYS = {"data", "descriptor", "datasets", "tasks"}
+
+
+class InverseMethod(str, Enum):
+    LATENT = "latent"
+    COMPOSITION = "composition"
+
+
+class SeedStrategy(str, Enum):
+    TOP_QC = "top_qc"
+    RANDOM = "random"
+    EXPLICIT = "explicit"
+
+
+# --- config dataclasses -------------------------------------------------------------------
+
+
+@dataclass(kw_only=True)
+class SeedConfig:
+    strategy: SeedStrategy = SeedStrategy.TOP_QC
+    n: int = 20
+    split: str = "test"
+    explicit: list[str] = field(default_factory=list)
+    explicit_append: list[str] = field(default_factory=list)
+    dedup_by_element_system: bool = True
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.strategy, SeedStrategy):
+            self.strategy = SeedStrategy(str(self.strategy))
+        if self.n < 1:
+            raise ValueError(f"seeds.n must be >= 1, got {self.n}.")
+        if self.split not in {"train", "val", "test", "all"}:
+            raise ValueError(f"seeds.split must be train/val/test/all, got {self.split!r}.")
+        if self.strategy is SeedStrategy.EXPLICIT and not self.explicit:
+            raise ValueError("seeds.strategy='explicit' requires a non-empty seeds.explicit list.")
+
+
+@dataclass(kw_only=True)
+class ScenarioConfig:
+    name: str
+    reg_tasks: list[str]
+    reg_targets: list[float]
+    class_task: str = "material_type"
+    class_target: int | None = None  # None → legacy QC default class index
+
+    def __post_init__(self) -> None:
+        if not self.reg_tasks:
+            raise ValueError(f"scenario '{self.name}': reg_tasks must be non-empty.")
+        if len(self.reg_tasks) != len(self.reg_targets):
+            raise ValueError(
+                f"scenario '{self.name}': reg_tasks ({len(self.reg_tasks)}) and reg_targets "
+                f"({len(self.reg_targets)}) must have equal length."
+            )
+
+    @property
+    def reg_target_map(self) -> dict[str, float]:
+        return {t: float(v) for t, v in zip(self.reg_tasks, self.reg_targets)}
+
+    @property
+    def class_indices(self) -> list[int]:
+        return _DEFAULT_QC_CLASSES if self.class_target is None else [int(self.class_target)]
+
+
+# Composition-path field defaults (used to reject latent-only / composition-only key misuse).
+_COMP_FIELD_DEFAULTS: dict[str, Any] = {
+    "init": "seed",
+    "seed_blend": 0.95,
+    "allowed_elements": "all",
+    "diversity_scale": 1.0,
+    "max_elements": None,
+    "element_step_scale": 1.0,
+    "annealing_scale": 0.5,
+    "annealing_schedule": None,
+    "n_starts": None,
+}
+_LATENT_DEFAULT_AE_ALIGN = 0.5
+
+
+@dataclass(kw_only=True)
+class PathConfig:
+    name: str
+    method: InverseMethod
+    # latent-only:
+    ae_align_scale: float = _LATENT_DEFAULT_AE_ALIGN
+    # composition-only:
+    init: str = "seed"
+    n_starts: int | None = None
+    seed_blend: float = 0.95
+    allowed_elements: list[str] | str = "all"
+    diversity_scale: float = 1.0
+    max_elements: int | None = None
+    element_step_scale: float | dict[str, float] = 1.0
+    fixed_amounts: dict[str, float] = field(default_factory=dict)
+    annealing_scale: float = 0.5
+    annealing_schedule: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.method, InverseMethod):
+            self.method = InverseMethod(str(self.method))
+        if self.method is InverseMethod.LATENT:
+            # Reject explicitly-set composition-only keys on a latent path.
+            bad = [k for k, dflt in _COMP_FIELD_DEFAULTS.items() if getattr(self, k) != dflt]
+            if self.fixed_amounts:
+                bad.append("fixed_amounts")
+            if bad:
+                raise ValueError(f"path '{self.name}' (latent): composition-only keys set: {sorted(bad)}.")
+            if self.init not in ("seed", "random"):
+                raise ValueError(f"path '{self.name}': init must be 'seed' or 'random'.")
+        else:
+            if self.ae_align_scale != _LATENT_DEFAULT_AE_ALIGN:
+                raise ValueError(f"path '{self.name}' (composition): latent-only key 'ae_align_scale' set.")
+            if self.init not in ("seed", "random"):
+                raise ValueError(f"path '{self.name}': init must be 'seed' or 'random'.")
+
+
+def _default_paths() -> list[PathConfig]:
+    """The 11 legacy DEFAULT_PATHS: 3 latent + 8 composition."""
+    P = DEFAULT_ALLOY_PALETTE
+    latent = [
+        PathConfig(name=f"latent_align{a:g}".replace(".", "p"), method=InverseMethod.LATENT, ae_align_scale=a)
+        for a in (0.0, 0.25, 1.0)
+    ]
+    comp = [
+        PathConfig(name="comp_seed", method=InverseMethod.COMPOSITION, init="seed", seed_blend=1.0),
+        PathConfig(name="comp_seed_blend95", method=InverseMethod.COMPOSITION, init="seed", seed_blend=0.95),
+        PathConfig(
+            name="comp_seed_blend95_elemlist",
+            method=InverseMethod.COMPOSITION,
+            init="seed",
+            seed_blend=0.95,
+            allowed_elements=P,
+        ),
+        PathConfig(
+            name="comp_seed_blend95_elemlist_lowdiv",
+            method=InverseMethod.COMPOSITION,
+            init="seed",
+            seed_blend=0.95,
+            allowed_elements=P,
+            diversity_scale=0.0,
+        ),
+        PathConfig(name="comp_random", method=InverseMethod.COMPOSITION, init="random", seed_blend=0.95),
+        PathConfig(
+            name="comp_seed_elemlist_k3",
+            method=InverseMethod.COMPOSITION,
+            init="seed",
+            seed_blend=0.95,
+            allowed_elements=P,
+            max_elements=3,
+        ),
+        PathConfig(
+            name="comp_seed_elemlist_k5",
+            method=InverseMethod.COMPOSITION,
+            init="seed",
+            seed_blend=0.95,
+            allowed_elements=P,
+            max_elements=5,
+        ),
+        PathConfig(
+            name="comp_seed_elemlist_k5_linear",
+            method=InverseMethod.COMPOSITION,
+            init="seed",
+            seed_blend=0.95,
+            allowed_elements=P,
+            max_elements=5,
+            annealing_scale=0.715,
+            annealing_schedule={"step": [1.0], "scale": [0.0], "annealing_func": ["linear"]},
+        ),
+    ]
+    return latent + comp
+
+
+@dataclass(kw_only=True)
+class InverseConfig:
+    catalog: TaskCatalogConfig
+    model: ModelSectionConfig
+    checkpoint: Path
+    seeds: SeedConfig
+    scenarios: list[ScenarioConfig]
+    paths: list[PathConfig]
+    output_dir: Path
+    steps: int = 300
+    lr: float = 0.05
+    class_weight: float = 5.0
+    record_trajectory: bool = True
+    per_seed_trajectories: bool = False
+    animation_formats: list[str] = field(default_factory=lambda: ["gif"])
+
+    def __post_init__(self) -> None:
+        self.checkpoint = Path(self.checkpoint)
+        self.output_dir = Path(self.output_dir)
+        if not self.scenarios:
+            raise ValueError("at least one [[inverse.scenarios]] is required.")
+        names = [s.name for s in self.scenarios]
+        dupes = sorted({n for n in names if names.count(n) > 1})
+        if dupes:
+            raise ValueError(f"duplicate scenario names: {dupes}.")
+        if not self.paths:
+            self.paths = _default_paths()
+        bad_fmt = [f for f in self.animation_formats if f not in _ANIMATION_FORMATS]
+        if bad_fmt:
+            raise ValueError(f"animation_formats must be a subset of {sorted(_ANIMATION_FORMATS)}, got {bad_fmt}.")
+        # composition paths require an invertible KMD descriptor
+        if self.catalog.descriptor.kind != "kmd" and any(p.method is InverseMethod.COMPOSITION for p in self.paths):
+            raise ValueError("composition paths require descriptor.kind == 'kmd' (an invertible KMD descriptor).")
+
+
+# --- builder ------------------------------------------------------------------------------
+
+
+def _build_seed_config(raw: Mapping[str, Any]) -> SeedConfig:
+    data = dict(raw)
+    reject_unknown("inverse.seeds", data, set(SeedConfig.__dataclass_fields__))
+    return SeedConfig(**data)
+
+
+def _build_scenario(raw: Mapping[str, Any]) -> ScenarioConfig:
+    data = dict(raw)
+    reject_unknown(f"inverse.scenarios.{data.get('name', '?')}", data, set(ScenarioConfig.__dataclass_fields__))
+    return ScenarioConfig(**data)
+
+
+def _build_path(raw: Mapping[str, Any]) -> PathConfig:
+    data = dict(raw)
+    reject_unknown(f"inverse.paths.{data.get('name', '?')}", data, set(PathConfig.__dataclass_fields__))
+    return PathConfig(**data)
+
+
+def build_inverse_config(
+    raw: Mapping[str, Any], *, output_dir: str | Path | None = None, checkpoint: str | Path | None = None
+) -> InverseConfig:
+    """Normalize a parsed-TOML tree into an :class:`InverseConfig`."""
+
+    reject_unknown("<root>", raw, _INVERSE_ROOT_KEYS)
+    catalog = build_task_catalog_config({k: raw[k] for k in _CATALOG_KEYS if k in raw})
+    model = build_model_section(raw.get("model", {}))
+
+    inv_raw = dict(raw.get("inverse", {}))
+    reject_unknown(
+        "inverse",
+        inv_raw,
+        {
+            "checkpoint",
+            "steps",
+            "lr",
+            "class_weight",
+            "record_trajectory",
+            "per_seed_trajectories",
+            "animation_formats",
+            "seeds",
+            "scenarios",
+            "paths",
+        },
+    )
+    resolved_checkpoint = checkpoint if checkpoint is not None else inv_raw.get("checkpoint")
+    if resolved_checkpoint is None:
+        raise ValueError("checkpoint must be given via --checkpoint or [inverse].checkpoint.")
+    resolved_output = output_dir if output_dir is not None else raw.get("output", {}).get("dir")
+    if resolved_output is None:
+        raise ValueError("output directory must be given via --output-dir or [output].dir.")
+
+    seeds = _build_seed_config(inv_raw.get("seeds", {}))
+    scenarios = [_build_scenario(s) for s in inv_raw.get("scenarios", [])]
+    paths = [_build_path(p) for p in inv_raw.get("paths", [])]
+
+    return InverseConfig(
+        catalog=catalog,
+        model=model,
+        checkpoint=Path(resolved_checkpoint),
+        seeds=seeds,
+        scenarios=scenarios,
+        paths=paths,
+        output_dir=Path(resolved_output),
+        steps=int(inv_raw.get("steps", 300)),
+        lr=float(inv_raw.get("lr", 0.05)),
+        class_weight=float(inv_raw.get("class_weight", 5.0)),
+        record_trajectory=bool(inv_raw.get("record_trajectory", True)),
+        per_seed_trajectories=bool(inv_raw.get("per_seed_trajectories", False)),
+        animation_formats=list(inv_raw.get("animation_formats", ["gif"])),
+    )
+
+
+# --- prediction helpers -------------------------------------------------------------------
+
+
+def _qc_prob(model: Any, x: torch.Tensor, class_task: str, class_indices: Sequence[int]) -> np.ndarray:
+    with torch.no_grad():
+        h = torch.tanh(model.encoder(x))
+        probs = torch.softmax(model.task_heads[class_task](h), dim=-1)
+        return probs[:, list(class_indices)].sum(dim=-1).cpu().numpy()
+
+
+def _reg_preds(model: Any, x: torch.Tensor, tasks: Sequence[str]) -> dict[str, np.ndarray]:
+    with torch.no_grad():
+        h = torch.tanh(model.encoder(x))
+        return {t: model.task_heads[t](h).squeeze(-1).cpu().numpy() for t in tasks}
+
+
+def _seed_weights(seeds: Sequence[str]) -> torch.Tensor:
+    rows = []
+    for comp in seeds:
+        w = formula_to_composition(comp)
+        if w is None:
+            raise ValueError(f"cannot parse seed composition '{comp}' to element weights.")
+        rows.append(np.asarray(w, dtype=np.float64))
+    return torch.tensor(np.stack(rows), dtype=torch.float64)
+
+
+def _format_weights(weights: np.ndarray, *, top_k: int = 6, eps: float = 1e-3) -> list[str]:
+    out = []
+    for row in np.asarray(weights):
+        order = np.argsort(row)[::-1]
+        parts = [f"{DEFAULT_ELEMENTS[int(i)]}{row[int(i)]:.3f}" for i in order[:top_k] if row[int(i)] > eps]
+        out.append(" ".join(parts) if parts else "<empty>")
+    return out
+
+
+def _element_system(composition: str) -> frozenset[str]:
+    return frozenset(_ELEMENT_TOKEN.findall(composition))
+
+
+# --- model rebuild + seed selection -------------------------------------------------------
+
+
+def _rebuild_model(cfg: InverseConfig, catalog: TaskCatalog) -> tuple[Any, list[str]]:
+    from foundation_model.models.flexible_multi_task_model import FlexibleMultiTaskModel
+
+    state = load_checkpoint_state(cfg.checkpoint)
+    ckpt_tasks = list(state.get("task_sequence") or _task_names_from_state(state["model"]))
+    catalog_tasks = {t.name for t in cfg.catalog.tasks}
+    missing = [t for t in ckpt_tasks if t not in catalog_tasks]
+    if missing:
+        raise ValueError(f"checkpoint tasks {missing} are not in the catalog (have {sorted(catalog_tasks)}).")
+
+    encoder_config = MLPEncoderConfig(
+        hidden_dims=[catalog.descriptor_dim, cfg.model.encoder_hidden, cfg.model.latent_dim]
+    )
+    model = FlexibleMultiTaskModel(
+        task_configs=[],
+        encoder_config=encoder_config,
+        enable_autoencoder=True,
+        shared_block_optimizer=OptimizerConfig(lr=5e-3, weight_decay=1e-2),
+    )
+    for name in ckpt_tasks:
+        model.add_task(
+            catalog.build_task_config(
+                name,
+                latent_dim=cfg.model.latent_dim,
+                head_hidden_dim=cfg.model.head_hidden_dim,
+                n_kernel=cfg.model.n_kernel,
+                lr=5e-3,
+            )
+        )
+    model.load_state_dict(state["model"], strict=False)
+    model.eval()
+    return model, ckpt_tasks
+
+
+def _task_names_from_state(state_dict: Mapping[str, Any]) -> list[str]:
+    names: list[str] = []
+    for key in state_dict:
+        if key.startswith("task_heads."):
+            name = key.split(".", 2)[1]
+            if name != _AE_NAME and name not in names:
+                names.append(name)
+    return names
+
+
+def _dedup_by_system(candidates: Sequence[str], n: int, *, enabled: bool) -> list[str]:
+    if not enabled:
+        return list(candidates)[:n]
+    seen: set[frozenset[str]] = set()
+    out: list[str] = []
+    for comp in candidates:
+        key = _element_system(comp)
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        out.append(comp)
+        if len(out) >= n:
+            break
+    return out
+
+
+def select_seeds(
+    catalog: TaskCatalog,
+    model: Any,
+    seed_cfg: SeedConfig,
+    *,
+    class_task: str,
+    class_indices: Sequence[int],
+    device: torch.device,
+) -> list[str]:
+    """Select seed compositions per :class:`SeedConfig` (mirrors the legacy ``_select_seeds``)."""
+
+    descriptor_fn = catalog.descriptor_fn()
+
+    def _has_descriptor(comp: str) -> bool:
+        return not descriptor_fn([comp]).empty
+
+    appended: list[str] = []
+    for raw in seed_cfg.explicit_append:
+        if not _has_descriptor(raw):
+            raise ValueError(f"seeds.explicit_append entry {raw!r} has no computable descriptor.")
+        appended.append(raw)
+    appended = _dedup_by_system(appended, len(appended), enabled=seed_cfg.dedup_by_element_system)
+    n_strategy = max(0, seed_cfg.n - len(appended))
+
+    def _merge(strategy_seeds: Sequence[str]) -> list[str]:
+        seen = {_element_system(c) for c in appended}
+        kept = [c for c in strategy_seeds if _element_system(c) not in seen]
+        return kept[:n_strategy] + appended
+
+    if seed_cfg.strategy is SeedStrategy.EXPLICIT:
+        pool = [c for c in seed_cfg.explicit if _has_descriptor(c)]
+        return _merge(_dedup_by_system(pool, n_strategy, enabled=seed_cfg.dedup_by_element_system))
+
+    frame = catalog.task_frames([class_task])[class_task]
+    if seed_cfg.split == "all" or "split" not in frame.columns:
+        index = list(frame.index)
+    else:
+        index = list(frame.index[frame["split"] == seed_cfg.split])
+    pool = [c for c in index if _has_descriptor(c)]
+    if not pool:
+        return appended
+
+    if seed_cfg.strategy is SeedStrategy.RANDOM:
+        rng = np.random.default_rng(0)
+        shuffled = [pool[i] for i in rng.permutation(len(pool))]
+        return _merge(_dedup_by_system(shuffled, n_strategy, enabled=seed_cfg.dedup_by_element_system))
+
+    # top_qc
+    x, pool = _descriptor_tensor(catalog, pool, device)
+    probs = _qc_prob(model, x, class_task, class_indices)
+    ranked = [pool[i] for i in np.argsort(probs)[::-1]]
+    return _merge(_dedup_by_system(ranked, n_strategy, enabled=seed_cfg.dedup_by_element_system))
+
+
+def _descriptor_tensor(
+    catalog: TaskCatalog, comps: Sequence[str], device: torch.device
+) -> tuple[torch.Tensor, list[str]]:
+    desc = catalog.descriptor_fn()(list(comps))
+    kept = [c for c in comps if c in desc.index]
+    return torch.tensor(desc.loc[kept].values, dtype=torch.float32, device=device), kept
+
+
+# --- per-path dispatch --------------------------------------------------------------------
+
+
+def _run_latent_path(
+    model: Any,
+    catalog: TaskCatalog,
+    seeds: list[str],
+    x_seed: torch.Tensor,
+    path: PathConfig,
+    scenario: ScenarioConfig,
+    *,
+    class_weight: float,
+    steps: int,
+    lr: float,
+    record_trajectory: bool,
+) -> dict[str, Any]:
+    reg_targets = scenario.reg_target_map
+    reg_names = list(reg_targets)
+    t0 = time.perf_counter()
+    res = model.optimize_latent(
+        initial_input=x_seed,
+        task_targets=reg_targets,
+        class_targets={scenario.class_task: scenario.class_indices},
+        class_target_weight=class_weight,
+        ae_align_scale=path.ae_align_scale,
+        optimize_space="latent",
+        steps=steps,
+        lr=lr,
+        record_input_trajectory=record_trajectory,
+    )
+    elapsed = time.perf_counter() - t0
+    kmd = catalog.kmd()
+    achieved = res.optimized_target[:, 0, :].cpu().numpy()
+    optimized_desc = res.optimized_input[:, 0, :]
+    after_qc = _qc_prob(model, optimized_desc, scenario.class_task, scenario.class_indices)
+    after_reg = _reg_preds(model, optimized_desc, reg_names)
+    desc_np = optimized_desc.detach().cpu().numpy()
+    weights = kmd.inverse(desc_np) if kmd is not None else np.zeros((desc_np.shape[0], len(DEFAULT_ELEMENTS)))
+    out = _result_dict(path, "latent", seeds, after_qc, achieved, after_reg, reg_names, weights, desc_np, elapsed)
+    if record_trajectory:
+        out["trajectory_targets"] = res.trajectory[:, 0, :, :].cpu().numpy().transpose(1, 0, 2)
+        if kmd is not None and res.input_trajectory is not None:
+            steps_in = res.input_trajectory[:, 0, :, :].cpu().numpy().transpose(1, 0, 2)
+            out["trajectory_weights"] = np.stack([kmd.inverse(steps_in[s]) for s in range(steps_in.shape[0])], axis=0)
+        else:
+            out["trajectory_weights"] = np.zeros((0, 0, 0))
+    return out
+
+
+def _run_composition_path(
+    model: Any,
+    catalog: TaskCatalog,
+    seeds: list[str],
+    path: PathConfig,
+    scenario: ScenarioConfig,
+    *,
+    class_weight: float,
+    steps: int,
+    lr: float,
+    record_trajectory: bool,
+) -> dict[str, Any]:
+    reg_targets = scenario.reg_target_map
+    reg_names = list(reg_targets)
+    kmd = catalog.kmd()
+    assert kmd is not None  # guaranteed by config validation
+    device, dtype = next(model.parameters()).device, next(model.parameters()).dtype
+    kernel = kmd.kernel_torch(device=device, dtype=dtype)
+
+    if path.init == "seed":
+        init_kwargs: dict[str, Any] = {"initial_weights": _seed_weights(seeds), "seed_blend": path.seed_blend}
+    else:
+        init_kwargs = {"initial_weights": None, "n_starts": path.n_starts or len(seeds)}
+
+    t0 = time.perf_counter()
+    res = model.optimize_composition(
+        kernel,
+        task_targets=reg_targets,
+        class_targets={scenario.class_task: scenario.class_indices},
+        class_target_weight=class_weight,
+        diversity_scale=path.diversity_scale,
+        allowed_elements=path.allowed_elements,
+        element_step_scale=path.element_step_scale,
+        fixed_amounts=path.fixed_amounts or None,
+        max_elements=path.max_elements,
+        annealing_scale=path.annealing_scale,
+        annealing_schedule=path.annealing_schedule,
+        steps=steps,
+        lr=lr,
+        record_weights_trajectory=record_trajectory,
+        **init_kwargs,
+    )
+    elapsed = time.perf_counter() - t0
+    optimized_desc = res.optimized_descriptor
+    weights = res.optimized_weights.cpu().numpy()
+    achieved = res.optimized_target.cpu().numpy()
+    after_qc = _qc_prob(model, optimized_desc, scenario.class_task, scenario.class_indices)
+    after_reg = _reg_preds(model, optimized_desc, reg_names)
+    seed_labels = list(seeds) if path.init == "seed" else [f"random_start_{i}" for i in range(len(seeds))]
+    out = _result_dict(
+        path,
+        "composition",
+        seed_labels,
+        after_qc,
+        achieved,
+        after_reg,
+        reg_names,
+        weights,
+        optimized_desc.detach().cpu().numpy(),
+        elapsed,
+    )
+    if record_trajectory:
+        out["trajectory_targets"] = res.trajectory.cpu().numpy()
+        out["trajectory_weights"] = (
+            res.weights_trajectory.cpu().numpy() if res.weights_trajectory is not None else np.zeros((0, 0, 0))
+        )
+    return out
+
+
+def _result_dict(
+    path: PathConfig,
+    method: str,
+    seeds: list[str],
+    after_qc: np.ndarray,
+    achieved: np.ndarray,
+    after_reg: dict[str, np.ndarray],
+    reg_names: list[str],
+    weights: np.ndarray,
+    descriptor: np.ndarray,
+    elapsed: float,
+) -> dict[str, Any]:
+    return {
+        "path": path.name,
+        "method": method,
+        "ae_align_scale": path.ae_align_scale if method == "latent" else None,
+        "elapsed_s": elapsed,
+        "seeds": seeds,
+        "qc_after_decode": after_qc.tolist(),
+        "reg_achieved_latent": {t: achieved[:, j].tolist() for j, t in enumerate(reg_names)},
+        "reg_after_decode": {t: after_reg[t].tolist() for t in reg_names},
+        "decoded_composition": _format_weights(weights),
+        "optimized_weights": np.asarray(weights).tolist(),
+    }
+
+
+# --- engine -------------------------------------------------------------------------------
+
+
+def run(
+    cfg: InverseConfig, recorder: RunRecorder | None = None, *, only_scenarios: Sequence[str] | None = None
+) -> dict[str, Any]:
+    """Run inverse design for every scenario × path. Returns the nested all-scenario summary."""
+
+    catalog = TaskCatalog(cfg.catalog)
+    owns_recorder = recorder is None
+    rec = recorder or RunRecorder(cfg.output_dir)
+    seed_everything(2025, workers=True)
+
+    try:
+        model, ckpt_tasks = _rebuild_model(cfg, catalog)
+        _validate_heads(model, cfg)
+        device = next(model.parameters()).device
+
+        # Seeds are selected once per run using the first scenario's classification objective.
+        seed_scn = cfg.scenarios[0]
+        seeds = select_seeds(
+            catalog,
+            model,
+            cfg.seeds,
+            class_task=seed_scn.class_task,
+            class_indices=seed_scn.class_indices,
+            device=device,
+        )
+        if not seeds:
+            raise RuntimeError("no seed compositions selected.")
+        x_seed, seeds = _descriptor_tensor(catalog, seeds, device)
+        (rec.paths.root / "seeds.json").write_text(json.dumps({"seeds": list(seeds)}, indent=2), encoding="utf-8")
+        logger.info(f"Selected {len(seeds)} seeds.")
+
+        scenarios = [s for s in cfg.scenarios if only_scenarios is None or s.name in set(only_scenarios)]
+        all_summary: dict[str, Any] = {}
+        for scenario in scenarios:
+            logger.info(f"=== scenario '{scenario.name}' ({len(cfg.paths)} paths) ===")
+            summary = _run_scenario(cfg, catalog, model, scenario, seeds, x_seed, rec)
+            all_summary[scenario.name] = summary
+
+        (rec.paths.root / "inverse_design.json").write_text(json.dumps(all_summary, indent=2), encoding="utf-8")
+        _write_root_summary(rec.paths.root, all_summary, cfg)
+        return all_summary
+    finally:
+        if owns_recorder:
+            rec.close()
+
+
+def _validate_heads(model: Any, cfg: InverseConfig) -> None:
+    heads = set(model.task_heads)
+    for scenario in cfg.scenarios:
+        needed = set(scenario.reg_tasks) | {scenario.class_task}
+        missing = sorted(needed - heads)
+        if missing:
+            raise ValueError(
+                f"scenario '{scenario.name}': checkpoint is missing head(s) {missing} (have {sorted(heads)})."
+            )
+
+
+def _run_scenario(
+    cfg: InverseConfig,
+    catalog: TaskCatalog,
+    model: Any,
+    scenario: ScenarioConfig,
+    seeds: list[str],
+    x_seed: torch.Tensor,
+    rec: RunRecorder,
+) -> list[dict[str, Any]]:
+    sc_dir = rec.paths.root / scenario.name
+    sc_dir.mkdir(parents=True, exist_ok=True)
+    reg_targets = scenario.reg_target_map
+    seed_qc = _qc_prob(model, x_seed, scenario.class_task, scenario.class_indices)
+    seed_reg = _reg_preds(model, x_seed, list(reg_targets))
+
+    results: list[dict[str, Any]] = []
+    for path in cfg.paths:
+        if path.method is InverseMethod.LATENT:
+            r = _run_latent_path(
+                model,
+                catalog,
+                seeds,
+                x_seed,
+                path,
+                scenario,
+                class_weight=cfg.class_weight,
+                steps=cfg.steps,
+                lr=cfg.lr,
+                record_trajectory=cfg.record_trajectory,
+            )
+        else:
+            r = _run_composition_path(
+                model,
+                catalog,
+                seeds,
+                path,
+                scenario,
+                class_weight=cfg.class_weight,
+                steps=cfg.steps,
+                lr=cfg.lr,
+                record_trajectory=cfg.record_trajectory,
+            )
+        results.append(r)
+
+    summary = _summarise(results, reg_targets)
+
+    # Externalize trajectories to .npz, drop the big arrays from results.json.
+    if cfg.record_trajectory:
+        traj_dir = sc_dir / "trajectories"
+        traj_dir.mkdir(exist_ok=True)
+        for r in results:
+            if "trajectory_targets" not in r:
+                continue
+            npz = traj_dir / f"{r['path']}.npz"
+            np.savez_compressed(
+                npz,
+                targets=np.asarray(r.pop("trajectory_targets"), dtype=np.float32),
+                weights=np.asarray(r.pop("trajectory_weights"), dtype=np.float32),
+            )
+            r["trajectory_file"] = str(npz.relative_to(sc_dir))
+
+    (sc_dir / "scenario.json").write_text(
+        json.dumps(
+            {
+                "name": scenario.name,
+                "reg_tasks": scenario.reg_tasks,
+                "reg_targets": scenario.reg_targets,
+                "class_task": scenario.class_task,
+                "class_indices": scenario.class_indices,
+                "primary_objective": f"P({scenario.class_task} in {scenario.class_indices}) ↑",
+                "checkpoint": str(cfg.checkpoint),
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    (sc_dir / "results.json").write_text(
+        json.dumps(
+            {
+                "reg_targets": reg_targets,
+                "seed_predictions": {"qc": seed_qc.tolist(), "reg": {t: v.tolist() for t, v in seed_reg.items()}},
+                "results": results,
+                "summary": summary,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    (sc_dir / "targets.json").write_text(json.dumps(reg_targets, indent=2), encoding="utf-8")
+    (sc_dir / "summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    _write_scenario_md(sc_dir, scenario, summary)
+
+    # figures
+    rel = scenario.name
+    _plot_comparison(results, reg_targets, rec, f"{rel}/comparison.png")
+    _plot_qc_vs_secondary(results, reg_targets, seed_qc, seed_reg, rec, f"{rel}/qc_vs_secondary_scatter.png")
+    _plot_element_frequency(results, list(seeds), rec, f"{rel}/element_frequency_heatmap.png")
+    for r in results:
+        if r["method"] == "composition" and r["path"].endswith("random"):
+            continue  # random init: no per-seed correspondence
+        _plot_seed_to_optimized(list(seeds), r, seed_qc, rec, f"{rel}/seed_to_optimized__{r['path']}.png")
+    return summary
+
+
+def _summarise(results: list[dict[str, Any]], reg_targets: Mapping[str, float]) -> list[dict[str, Any]]:
+    rows = []
+    for r in results:
+        row: dict[str, Any] = {
+            "path": r["path"],
+            "method": r["method"],
+            "ae_align_scale": r["ae_align_scale"],
+            "elapsed_s": round(r["elapsed_s"], 2),
+            "qc_after_mean": round(float(np.mean(r["qc_after_decode"])), 4),
+            "qc_after_std": round(float(np.std(r["qc_after_decode"])), 4),
+        }
+        for t in reg_targets:
+            vals = np.asarray(r["reg_after_decode"][t], dtype=float)
+            row[f"{t}_after_mean"] = round(float(vals.mean()), 3)
+            row[f"{t}_after_std"] = round(float(vals.std()), 3)
+        rows.append(row)
+    return rows
+
+
+# --- figures (compact reimplementations) --------------------------------------------------
+
+
+def _method_color(method: str) -> str:
+    return "#55A868" if method == "latent" else SCATTER_COLOR
+
+
+def _plot_comparison(
+    results: list[dict[str, Any]], reg_targets: Mapping[str, float], rec: RunRecorder, rel: str
+) -> None:
+    panels = ["QC", *reg_targets]
+    fig, axes = plt.subplots(1, len(panels), figsize=(4.4 * len(panels), 5.0), squeeze=False)
+    labels = [r["path"] for r in results]
+    colors = [_method_color(r["method"]) for r in results]
+    x = np.arange(len(results))
+    for ax, panel in zip(axes[0], panels):
+        if panel == "QC":
+            means = [float(np.mean(r["qc_after_decode"])) for r in results]
+            stds = [float(np.std(r["qc_after_decode"])) for r in results]
+            ax.axhline(1.0, color="#C44E52", ls="--", lw=1.0)
+            ax.set_title("P(QC)")
+        else:
+            means = [float(np.mean(r["reg_after_decode"][panel])) for r in results]
+            stds = [float(np.std(r["reg_after_decode"][panel])) for r in results]
+            ax.axhline(float(reg_targets[panel]), color="#C44E52", ls="--", lw=1.0)
+            ax.set_title(panel)
+        ax.bar(x, means, yerr=stds, color=colors, alpha=0.85, capsize=3)
+        ax.set_xticks(x, labels, rotation=75, ha="right", fontsize=7)
+    fig.suptitle("Inverse-design paths — achieved objectives", y=1.02)
+    rec.save_figure(rel, fig)
+    plt.close(fig)
+
+
+def _plot_qc_vs_secondary(
+    results: list[dict[str, Any]],
+    reg_targets: Mapping[str, float],
+    seed_qc: np.ndarray,
+    seed_reg: dict[str, np.ndarray],
+    rec: RunRecorder,
+    rel: str,
+) -> None:
+    reg_names = list(reg_targets)
+    fig, axes = plt.subplots(1, len(reg_names), figsize=(5.2 * len(reg_names), 5.0), squeeze=False)
+    for ax, task in zip(axes[0], reg_names):
+        ax.scatter(seed_qc, seed_reg[task], marker="*", s=70, color=DISCOVERED_ELEMENT_COLOR, label="seed", zorder=1)
+        for r in results:
+            ax.scatter(
+                r["qc_after_decode"],
+                r["reg_after_decode"][task],
+                s=18,
+                alpha=0.6,
+                color=_method_color(r["method"]),
+                zorder=2,
+            )
+        ax.axvline(1.0, color="#C44E52", ls="--", lw=1.0)
+        ax.axhline(float(reg_targets[task]), color="#C44E52", ls="--", lw=1.0)
+        ax.set_xlabel("P(QC)")
+        ax.set_ylabel(task)
+    fig.suptitle("QC probability vs secondary properties", y=1.02)
+    rec.save_figure(rel, fig)
+    plt.close(fig)
+
+
+def _plot_seed_to_optimized(
+    seeds: list[str], result: dict[str, Any], seed_qc: np.ndarray, rec: RunRecorder, rel: str
+) -> None:
+    decoded = result["decoded_composition"]
+    opt_qc = np.asarray(result["qc_after_decode"])
+    n = min(len(seeds), len(decoded))
+    fig, ax = plt.subplots(figsize=(9.0, max(3.0, 0.32 * n + 1)))
+    ax.axis("off")
+    ax.set_title(f"Seed → optimised · {result['path']}", fontsize=11)
+    for i in range(n):
+        y = n - i
+        ax.text(0.01, y, f"{seeds[i]}  (QC={seed_qc[i] * 100:.0f}%)", fontsize=8, family="monospace", va="center")
+        ax.text(0.42, y, "→", fontsize=10, va="center")
+        ax.text(0.47, y, f"{decoded[i]}  (QC={opt_qc[i] * 100:.0f}%)", fontsize=8, family="monospace", va="center")
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, n + 1)
+    rec.save_figure(rel, fig)
+    plt.close(fig)
+
+
+def _plot_element_frequency(results: list[dict[str, Any]], seeds: list[str], rec: RunRecorder, rel: str) -> None:
+    seed_elements = set().union(*[_element_system(s) for s in seeds]) if seeds else set()
+    counts: dict[str, dict[str, int]] = {}
+    all_elems: dict[str, int] = {}
+    for r in results:
+        c: dict[str, int] = {}
+        for formula in r["decoded_composition"]:
+            for el in _element_system(formula):
+                c[el] = c.get(el, 0) + 1
+                all_elems[el] = all_elems.get(el, 0) + 1
+        counts[r["path"]] = c
+    top = [el for el, _ in sorted(all_elems.items(), key=lambda kv: -kv[1])[:25]]
+    matrix = np.array([[counts[r["path"]].get(el, 0) for el in top] for r in results], dtype=float)
+    fig, ax = plt.subplots(figsize=(max(6.0, 0.4 * len(top)), max(4.0, 0.4 * len(results))))
+    im = ax.imshow(matrix, aspect="auto", cmap="viridis")
+    ax.set_xticks(range(len(top)), top, rotation=90, fontsize=7)
+    for tick, el in zip(ax.get_xticklabels(), top):
+        if el not in seed_elements:  # discovered elements (not in any seed) highlighted
+            tick.set_color(DISCOVERED_ELEMENT_COLOR)
+    ax.set_yticks(range(len(results)), [r["path"] for r in results], fontsize=7)
+    fig.colorbar(im, ax=ax, label="occurrences", fraction=0.03)
+    ax.set_title("Element frequency across paths (orange = discovered)")
+    rec.save_figure(rel, fig)
+    plt.close(fig)
+
+
+def _write_scenario_md(sc_dir: Path, scenario: ScenarioConfig, summary: list[dict[str, Any]]) -> None:
+    lines = [f"# Inverse design — {scenario.name}", ""]
+    lines.append(f"Primary objective: P({scenario.class_task} in {scenario.class_indices}) ↑")
+    lines.append(f"Regression targets: {scenario.reg_target_map}")
+    lines.append("")
+    lines.append("| path | method | QC (mean±std) | elapsed(s) |")
+    lines.append("|---|---|---|---|")
+    for row in summary:
+        lines.append(
+            f"| {row['path']} | {row['method']} | {row['qc_after_mean']}±{row['qc_after_std']} | {row['elapsed_s']} |"
+        )
+    (sc_dir / "SUMMARY.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_root_summary(root: Path, all_summary: Mapping[str, Any], cfg: InverseConfig) -> None:
+    lines = ["# Inverse design — all scenarios", "", f"Checkpoint: `{cfg.checkpoint}`", ""]
+    for name, summary in all_summary.items():
+        best = max(summary, key=lambda row: row["qc_after_mean"]) if summary else None
+        best_str = f"best QC path: **{best['path']}** ({best['qc_after_mean']})" if best else "(no paths)"
+        lines.append(f"- **{name}** — {best_str}")
+    (root / "SUMMARY.md").write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/src/foundation_model/workflows/inverse_test.py
+++ b/src/foundation_model/workflows/inverse_test.py
@@ -260,6 +260,35 @@ def test_seed_selection_explicit_append_reduces_budget(data_dir) -> None:
 # --- end-to-end smoke --------------------------------------------------------------------
 
 
+def test_seed_and_accelerator_config(data_dir, tmp_path) -> None:
+    # --seed/--accelerator route into [inverse] and must not be rejected as unknown root keys.
+    cfg = build_inverse_config(
+        tomllib.loads(
+            _catalog_toml(data_dir) + '\n[inverse]\nseed = 7\naccelerator = "cpu"\n'
+            "[inverse.seeds]\nn = 2\n"
+            '[[inverse.scenarios]]\nname = "sc1"\nreg_tasks = ["a"]\nreg_targets = [1.0]\nclass_task = "mat"\n'
+            '[[inverse.paths]]\nname = "latent1"\nmethod = "latent"\n'
+            '[output]\ndir = "o"\n'
+        ),
+        checkpoint="ck.pt",
+    )
+    assert cfg.seed == 7 and cfg.accelerator == "cpu"
+
+
+def test_trajectory_static_and_svg_animation_emitted(data_dir, tmp_path) -> None:
+    ckpt = tmp_path / "ck.pt"
+    _checkpoint(data_dir, ckpt)
+    out = tmp_path / "inv"
+    cfg = _inverse_cfg(data_dir, out, ckpt, animation='["svg"]')  # svg avoids slow FuncAnimation writers
+    rec = RunRecorder(out)
+    rec.write_provenance(config=cfg, argv=["fm", "inverse"], seeds={"seed": 2025})
+    inverse_run(cfg, rec)
+    rec.close()
+    traj = out / "sc1" / "trajectories"
+    assert (traj / "latent_align1_trajectory.png").exists()  # static plot always
+    assert (traj / "latent_align1_trajectory.svg").exists()  # requested animation format
+
+
 def test_inverse_smoke_end_to_end(data_dir, tmp_path) -> None:
     ckpt = tmp_path / "ck.pt"
     _checkpoint(data_dir, ckpt)

--- a/src/foundation_model/workflows/inverse_test.py
+++ b/src/foundation_model/workflows/inverse_test.py
@@ -1,0 +1,291 @@
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for :mod:`foundation_model.workflows.inverse`."""
+
+from __future__ import annotations
+
+import json
+import tomllib
+
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+from foundation_model.workflows._engine import build_empty_model, build_head_config
+from foundation_model.workflows._sections import ModelSectionConfig, TrainingSectionConfig
+from foundation_model.workflows.inverse import (
+    DEFAULT_ALLOY_PALETTE,
+    InverseConfig,
+    InverseMethod,
+    PathConfig,
+    ScenarioConfig,
+    SeedConfig,
+    SeedStrategy,
+    _default_paths,
+    build_inverse_config,
+    select_seeds,
+)
+from foundation_model.workflows.inverse import run as inverse_run
+from foundation_model.workflows.recording import RunRecorder
+from foundation_model.workflows.task_catalog import TaskCatalog, build_task_catalog_config
+
+_ELEMENTS = ["Fe", "Al", "Cu", "Ni", "Ti", "Zn", "Mg", "Ca", "Na", "Cl", "O", "Si", "K", "Mn"]
+_FORMULAS = [f"{a}2 {b}3" for i, a in enumerate(_ELEMENTS) for b in _ELEMENTS[i + 1 :]][:30]
+
+_MODEL = ModelSectionConfig(latent_dim=8, encoder_hidden=16, head_hidden_dim=8, n_kernel=4)
+_TRAIN = TrainingSectionConfig(max_epochs=1, accelerator="cpu", seed=1)
+
+
+# --- config validation (no model needed) -------------------------------------------------
+
+
+def test_scenario_reg_length_mismatch() -> None:
+    with pytest.raises(ValueError, match="equal length"):
+        ScenarioConfig(name="s", reg_tasks=["a"], reg_targets=[1.0, 2.0])
+
+
+def test_latent_path_rejects_composition_key() -> None:
+    with pytest.raises(ValueError, match="composition-only"):
+        PathConfig(name="p", method=InverseMethod.LATENT, seed_blend=0.9)
+
+
+def test_composition_path_rejects_ae_align_scale() -> None:
+    with pytest.raises(ValueError, match="ae_align_scale"):
+        PathConfig(name="p", method=InverseMethod.COMPOSITION, ae_align_scale=0.9)
+
+
+def test_default_paths_count_and_kwargs() -> None:
+    paths = _default_paths()
+    assert len(paths) == 11
+    latent = [p for p in paths if p.method is InverseMethod.LATENT]
+    comp = [p for p in paths if p.method is InverseMethod.COMPOSITION]
+    assert len(latent) == 3 and len(comp) == 8
+    assert sorted(p.ae_align_scale for p in latent) == [0.0, 0.25, 1.0]
+    k5_linear = next(p for p in comp if p.name.endswith("k5_linear"))
+    assert k5_linear.max_elements == 5
+    assert k5_linear.annealing_scale == 0.715
+    assert k5_linear.annealing_schedule == {"step": [1.0], "scale": [0.0], "annealing_func": ["linear"]}
+    assert len(DEFAULT_ALLOY_PALETTE) == 48
+    # composition paths with an element list use the palette
+    assert any(p.allowed_elements == DEFAULT_ALLOY_PALETTE for p in comp)
+
+
+# --- fixtures ----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def data_dir(tmp_path):
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame(
+        {
+            "composition": _FORMULAS,
+            "a": rng.normal(size=len(_FORMULAS)),
+            "b": rng.normal(size=len(_FORMULAS)),
+            "mat": rng.integers(0, 3, size=len(_FORMULAS)),
+            "split": (["train", "val", "test"] * len(_FORMULAS))[: len(_FORMULAS)],
+        }
+    )
+    df.to_parquet(tmp_path / "x.parquet")
+    return tmp_path
+
+
+def _catalog_toml(data_dir) -> str:
+    return f"""
+[descriptor]
+kind = "kmd"
+n_grids = 4
+
+[datasets.d1]
+path = "{data_dir / "x.parquet"}"
+
+[[tasks]]
+name = "a"
+kind = "regression"
+dataset = "d1"
+column = "a"
+
+[[tasks]]
+name = "b"
+kind = "regression"
+dataset = "d1"
+column = "b"
+
+[[tasks]]
+name = "mat"
+kind = "classification"
+dataset = "d1"
+column = "mat"
+num_classes = 3
+"""
+
+
+def _catalog(data_dir) -> TaskCatalog:
+    return TaskCatalog(build_task_catalog_config(tomllib.loads(_catalog_toml(data_dir))))
+
+
+def _checkpoint(data_dir, path) -> None:
+    cat = _catalog(data_dir)
+    model = build_empty_model(cat, _MODEL, _TRAIN)
+    for name in ["a", "b", "mat"]:
+        model.add_task(build_head_config(cat, _MODEL, _TRAIN, name))
+    torch.save({"model": model.state_dict(), "task_sequence": ["a", "b", "mat"]}, path)
+
+
+def _inverse_cfg(data_dir, out, checkpoint, *, animation: str = "[]") -> InverseConfig:
+    toml = (
+        _catalog_toml(data_dir)
+        + f"""
+[model]
+latent_dim = 8
+encoder_hidden = 16
+head_hidden_dim = 8
+n_kernel = 4
+
+[inverse]
+steps = 2
+lr = 0.05
+record_trajectory = true
+animation_formats = {animation}
+
+[inverse.seeds]
+strategy = "top_qc"
+n = 3
+split = "all"
+
+[[inverse.scenarios]]
+name = "sc1"
+reg_tasks = ["a", "b"]
+reg_targets = [-1.0, 1.0]
+class_task = "mat"
+
+[[inverse.paths]]
+name = "latent_align1"
+method = "latent"
+ae_align_scale = 1.0
+
+[[inverse.paths]]
+name = "comp_seed_blend95"
+method = "composition"
+init = "seed"
+seed_blend = 0.95
+
+[output]
+dir = "o"
+"""
+    )
+    return build_inverse_config(tomllib.loads(toml), output_dir=str(out), checkpoint=str(checkpoint))
+
+
+# --- InverseConfig-level validation ------------------------------------------------------
+
+
+def test_empty_scenarios_raises(data_dir) -> None:
+    toml = _catalog_toml(data_dir) + '\n[inverse]\nsteps = 2\n[inverse.seeds]\nn = 2\n[output]\ndir = "o"\n'
+    with pytest.raises(ValueError, match="scenario"):
+        build_inverse_config(tomllib.loads(toml), checkpoint="ck.pt")
+
+
+def test_bad_animation_format_raises(data_dir, tmp_path) -> None:
+    with pytest.raises(ValueError, match="animation_formats"):
+        _inverse_cfg(data_dir, tmp_path / "o", "ck.pt", animation='["mp4"]')
+
+
+def test_precomputed_descriptor_plus_composition_path_raises(tmp_path) -> None:
+    desc = pd.DataFrame(np.arange(6.0).reshape(3, 2), columns=["f0", "f1"])
+    desc["composition"] = ["Fe2 O3", "Al2 O3", "Na1 Cl1"]
+    desc.to_parquet(tmp_path / "desc.parquet")
+    df = pd.DataFrame({"composition": ["Fe2 O3", "Al2 O3", "Na1 Cl1"], "a": [1.0, 2, 3], "mat": [0, 1, 2]})
+    df.to_parquet(tmp_path / "x.parquet")
+    toml = f"""
+[descriptor]
+kind = "precomputed"
+path = "{tmp_path / "desc.parquet"}"
+
+[datasets.d1]
+path = "{tmp_path / "x.parquet"}"
+
+[[tasks]]
+name = "a"
+kind = "regression"
+dataset = "d1"
+column = "a"
+
+[[tasks]]
+name = "mat"
+kind = "classification"
+dataset = "d1"
+column = "mat"
+num_classes = 3
+
+[[inverse.scenarios]]
+name = "sc1"
+reg_tasks = ["a"]
+reg_targets = [1.0]
+class_task = "mat"
+
+[[inverse.paths]]
+name = "comp"
+method = "composition"
+"""
+    with pytest.raises(ValueError, match="composition paths require descriptor.kind == 'kmd'"):
+        build_inverse_config(tomllib.loads(toml), output_dir="o", checkpoint="ck.pt")
+
+
+# --- seed selection ----------------------------------------------------------------------
+
+
+def test_seed_selection_explicit_verbatim(data_dir) -> None:
+    cat = _catalog(data_dir)
+    model = build_empty_model(cat, _MODEL, _TRAIN)
+    for name in ["a", "b", "mat"]:
+        model.add_task(build_head_config(cat, _MODEL, _TRAIN, name))
+    seed_cfg = SeedConfig(strategy=SeedStrategy.EXPLICIT, n=2, explicit=["Fe2 O3", "Al2 O3"])
+    seeds = select_seeds(cat, model, seed_cfg, class_task="mat", class_indices=[1], device=torch.device("cpu"))
+    assert set(seeds) <= {"Fe2 O3", "Al2 O3"}
+
+
+def test_seed_selection_explicit_append_reduces_budget(data_dir) -> None:
+    cat = _catalog(data_dir)
+    model = build_empty_model(cat, _MODEL, _TRAIN)
+    for name in ["a", "b", "mat"]:
+        model.add_task(build_head_config(cat, _MODEL, _TRAIN, name))
+    seed_cfg = SeedConfig(strategy=SeedStrategy.TOP_QC, n=4, split="all", explicit_append=["Fe2 O3"])
+    seeds = select_seeds(cat, model, seed_cfg, class_task="mat", class_indices=[1], device=torch.device("cpu"))
+    assert "Fe2 O3" in seeds  # appended seed always survives
+    assert len(seeds) <= 4
+
+
+# --- end-to-end smoke --------------------------------------------------------------------
+
+
+def test_inverse_smoke_end_to_end(data_dir, tmp_path) -> None:
+    ckpt = tmp_path / "ck.pt"
+    _checkpoint(data_dir, ckpt)
+    out = tmp_path / "inv"
+    cfg = _inverse_cfg(data_dir, out, ckpt)
+    rec = RunRecorder(out)
+    rec.write_provenance(config=cfg, argv=["fm", "inverse"], seeds={"seed": 2025})
+    summary = inverse_run(cfg, rec)
+    rec.close()
+
+    assert (out / "seeds.json").exists()
+    assert (out / "inverse_design.json").exists()
+    assert (out / "run_provenance.json").exists()
+    sc = out / "sc1"
+    for name in (
+        "scenario.json",
+        "results.json",
+        "summary.json",
+        "targets.json",
+        "comparison.png",
+        "qc_vs_secondary_scatter.png",
+        "element_frequency_heatmap.png",
+    ):
+        assert (sc / name).exists(), name
+    assert (sc / "seed_to_optimized__latent_align1.png").exists()
+    results = json.loads((sc / "results.json").read_text())["results"]
+    assert [r["path"] for r in results] == ["latent_align1", "comp_seed_blend95"]
+    assert "qc_after_decode" in results[0] and "decoded_composition" in results[0]
+    assert "sc1" in summary and len(summary["sc1"]) == 2

--- a/src/foundation_model/workflows/inverse_trajectory.py
+++ b/src/foundation_model/workflows/inverse_trajectory.py
@@ -20,7 +20,8 @@ the QC head), these are enough to visualise:
 2. How the recipe evolves across the optimisation (animated bar chart of the per-step composition
    on the side, frame per step).
 
-This module hosts the pure helpers; ``paper_inverse_comparison.run()`` is the only caller.
+This module hosts the pure helpers; :func:`foundation_model.workflows.inverse.run` drives them
+(via ``_emit_trajectory``), and they are unit-tested directly.
 """
 
 from __future__ import annotations

--- a/src/foundation_model/workflows/inverse_trajectory.py
+++ b/src/foundation_model/workflows/inverse_trajectory.py
@@ -1,0 +1,474 @@
+# Copyright 2026 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-step trajectory analytics + plots + animations for inverse-design runs.
+
+Each call to :meth:`FlexibleMultiTaskModel.optimize_latent` /
+:meth:`FlexibleMultiTaskModel.optimize_composition` can now optionally record:
+
+* ``trajectory_targets``  — shape ``(steps, B, T)``: per-step predicted target values
+  (one column per regression task in ``reg_targets`` order; QC is separate).
+* ``trajectory_weights``  — shape ``(steps, B, n_components)``: per-step element weights
+  (the optimisation variable for ``optimize_composition``; decoded via ``KMD.inverse`` from the
+  per-step AE-decoded ``x`` for ``optimize_latent``).
+
+Together with the per-step QC trajectory (also collected from the raw target predictions for
+the QC head), these are enough to visualise:
+
+1. How fast each target converges relative to the others (static line plot, normalised so all
+   targets are on the same y-axis).
+2. How the recipe evolves across the optimisation (animated bar chart of the per-step composition
+   on the side, frame per step).
+
+This module hosts the pure helpers; ``paper_inverse_comparison.run()`` is the only caller.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Iterable
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.animation as manimation
+import matplotlib.pyplot as plt
+import numpy as np
+from loguru import logger
+
+
+# --- representative-seed picker -----------------------------------------------------------------
+
+
+def best_seed_by_target_distance(
+    qc_final: np.ndarray,
+    reg_final: dict[str, np.ndarray],
+    reg_targets: Mapping[str, float],
+) -> int:
+    """Pick the seed whose final state minimises the joint normalised distance to all targets.
+
+    "Joint distance" = $\\sqrt{(1 - \\text{QC})^2 + \\sum_t ((y_t - \\text{target}_t) / s_t)^2}$
+    where $s_t$ is the per-task scale (we use the absolute target value as a stand-in so each
+    task contributes on a comparable scale; a target of ±2 σ in z-scored space gives a scale of 2).
+
+    The QC term uses ``1 - QC`` so closer-to-1 wins; the regression terms use signed deviation
+    so an under-shoot and an over-shoot are penalised equally.
+    """
+    qc_final = np.asarray(qc_final, dtype=float)
+    n = qc_final.shape[0]
+    if n == 0:
+        raise ValueError("best_seed_by_target_distance: empty qc_final array.")
+    dist_sq = (1.0 - qc_final) ** 2
+    for task, target in reg_targets.items():
+        scale = max(abs(float(target)), 1.0)  # avoid divide-by-zero if target == 0
+        vals = np.asarray(reg_final[task], dtype=float)
+        dist_sq = dist_sq + ((vals - float(target)) / scale) ** 2
+    return int(np.argmin(dist_sq))
+
+
+# --- trajectory normalisation -----------------------------------------------------------------
+
+
+def normalize_target_trajectories(
+    qc_trajectory: np.ndarray,
+    reg_trajectory: dict[str, np.ndarray],
+    reg_targets: Mapping[str, float],
+    seed_qc: np.ndarray,
+    seed_reg: Mapping[str, np.ndarray],
+) -> dict[str, np.ndarray]:
+    """Map per-step target predictions to a [0, 1] "progress" fraction.
+
+    For each target, 0 = "at seed baseline", 1 = "exactly at target". Values can exceed [0, 1]
+    if the optimiser overshoots. The transform is per-(task, seed): for seed *i* we compute
+    ``(y[step, i] - baseline[i]) / (target - baseline[i])`` so a noisy seed-to-seed baseline
+    doesn't dilute the average. After per-seed normalisation we mean over seeds so the static
+    plot shows the average progress across the seed cohort.
+
+    Returns: dict ``{"QC": (steps,), task_name: (steps,)}`` of mean progress values.
+    """
+    out: dict[str, np.ndarray] = {}
+
+    # QC always targets 1.0.
+    qc_baseline = np.asarray(seed_qc, dtype=float)  # (B,)
+    qc_target = 1.0
+    qc_denom = qc_target - qc_baseline
+    qc_denom = np.where(np.abs(qc_denom) < 1e-9, 1.0, qc_denom)  # protect against /0
+    qc_progress = (np.asarray(qc_trajectory, dtype=float) - qc_baseline[None, :]) / qc_denom[None, :]
+    out["QC"] = qc_progress.mean(axis=1)
+
+    for task, target in reg_targets.items():
+        baseline = np.asarray(seed_reg[task], dtype=float)  # (B,)
+        denom = float(target) - baseline
+        denom = np.where(np.abs(denom) < 1e-9, 1.0, denom)
+        traj = np.asarray(reg_trajectory[task], dtype=float)  # (steps, B)
+        progress = (traj - baseline[None, :]) / denom[None, :]
+        out[task] = progress.mean(axis=1)
+
+    return out
+
+
+# --- static plot -------------------------------------------------------------------------------
+
+
+_TARGET_COLOR_QC = "#C44E52"  # red — matches the target lines used elsewhere
+_TARGET_COLORS_REG = ["#2563EB", "#55A868", "#E67E22", "#9467bd"]  # blue / green / orange / purple
+
+
+def plot_trajectory_static(
+    progress: Mapping[str, np.ndarray],
+    out_path: Path,
+    *,
+    title: str,
+    seed_composition: str | None = None,
+) -> None:
+    """Line plot of normalised progress vs step.
+
+    QC is drawn in red; the regression tasks cycle through the project's blue / green / orange
+    palette. The y-axis is "progress fraction" (0 = at seed, 1 = at target); a horizontal dashed
+    line at 1.0 marks the joint target. The reader gets a one-glance answer to the question the
+    user asked: "do the targets converge together, or does the recipe stabilise early and the
+    targets keep moving?" — divergence between the QC line and the reg lines, or between the reg
+    lines themselves, surfaces immediately.
+
+    When ``seed_composition`` is provided (the per-seed composition string, e.g.
+    ``"Au65 Ga20 Gd15"``), it's appended to the figure title under the main title in a monospace
+    font — the reader can identify the seed by chemistry rather than by index.
+    """
+    fig, ax = plt.subplots(figsize=(8.0, 5.0), dpi=150)
+    steps = np.arange(len(next(iter(progress.values()))))
+
+    # QC first so it's visually behind the reg lines (the user usually cares about reg
+    # convergence; QC's behavior is rarely surprising).
+    if "QC" in progress:
+        ax.plot(steps, progress["QC"], color=_TARGET_COLOR_QC, lw=2.0, label="QC (P(quasicrystal))")
+    reg_keys = [k for k in progress if k != "QC"]
+    for i, key in enumerate(reg_keys):
+        ax.plot(
+            steps,
+            progress[key],
+            color=_TARGET_COLORS_REG[i % len(_TARGET_COLORS_REG)],
+            lw=1.8,
+            label=key,
+        )
+
+    ax.axhline(1.0, color="#666", ls="--", lw=1.0, alpha=0.7, label="target (progress = 1.0)")
+    ax.axhline(0.0, color="#bbb", ls=":", lw=0.8, alpha=0.5)
+    ax.set_xlabel("Optimisation step")
+    ax.set_ylabel("Progress  (0 = seed, 1 = target)")
+    if seed_composition:
+        # Two-line layout: bold main title on top + seed composition underneath, with extra
+        # ``pad`` so the title doesn't sit flush against the upper axes line. Putting the
+        # seed-comp as a text annotation at y=1.02 collided with the title when matplotlib's
+        # default title-pad was applied — fix is to render both lines via set_title and a
+        # second matching text() at a clearly-distinct y position.
+        ax.set_title(title, fontsize=12, fontweight="bold", pad=22)
+        ax.text(
+            0.5, 1.005, f"seed:  {seed_composition}",
+            transform=ax.transAxes, ha="center", va="bottom",
+            fontsize=10, family="monospace", color="#444",
+        )
+    else:
+        ax.set_title(title, fontsize=12, fontweight="bold")
+    ax.legend(loc="best", fontsize=9, frameon=False)
+    ax.grid(True, alpha=0.2)
+    fig.tight_layout()
+    fig.savefig(out_path, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+    logger.info(f"Wrote trajectory static plot to {out_path}")
+
+
+# --- animation ---------------------------------------------------------------------------------
+
+
+def _topk_composition_frame(weights: np.ndarray, element_symbols: list[str], top_k: int = 10) -> list[tuple[str, float]]:
+    """Top-K elements by weight, sorted descending. Used as one frame of the animation's comp panel."""
+    idx = np.argsort(weights)[::-1][:top_k]
+    return [(element_symbols[int(i)], float(weights[int(i)])) for i in idx if weights[int(i)] > 1e-4]
+
+
+def plot_trajectory_animation(
+    progress: Mapping[str, np.ndarray],
+    per_step_weights: np.ndarray,
+    element_symbols: list[str],
+    out_paths_by_format: Mapping[str, Path],
+    *,
+    title: str,
+    seed_composition: str | None = None,
+    top_k_elements: int = 10,
+    fps: int = 15,
+    max_frames: int = 120,
+) -> None:
+    """Targets-vs-step line plot (top panel) + per-step top-K element bar chart (right panel).
+
+    The line plot draws the full curve from step 0; a vertical "current step" marker advances
+    one tick per frame. The bar chart on the right re-draws each frame to show the current
+    composition's top-K elements (so the viewer can see "what is the recipe right now?" as the
+    targets evolve). For long runs (steps > ``max_frames``) we subsample uniformly so the GIF
+    stays under a few seconds at fps=15.
+
+    Writers:
+      - ``gif``  → ``PillowWriter`` (no external deps; embeddable anywhere).
+      - ``html`` → ``HTMLWriter`` (JS-controlled play/pause/scrub; great for inspection).
+      - ``svg``  → custom SMIL-animated single-file SVG (browsers play it; PPT cannot embed).
+    """
+    n_steps = len(next(iter(progress.values())))
+    if n_steps == 0:
+        logger.warning("plot_trajectory_animation: empty progress arrays — skipping.")
+        return
+    if per_step_weights.shape[0] != n_steps:
+        logger.warning(
+            f"plot_trajectory_animation: per_step_weights step count ({per_step_weights.shape[0]}) "
+            f"does not match progress step count ({n_steps}); skipping animation."
+        )
+        return
+
+    # Uniform subsample down to ``max_frames`` so GIFs stay manageable. The line plot still uses
+    # the full curve; only the marker / weights frames are subsampled.
+    frame_steps = np.linspace(0, n_steps - 1, num=min(n_steps, max_frames)).astype(int)
+    frame_steps = np.unique(frame_steps)  # in case of duplicate indices for very small n_steps
+
+    fig = plt.figure(figsize=(12.0, 5.5), dpi=120)
+    gs = fig.add_gridspec(1, 2, width_ratios=[2.0, 1.0], wspace=0.30)
+    ax_line = fig.add_subplot(gs[0, 0])
+    ax_bar = fig.add_subplot(gs[0, 1])
+
+    # --- Static line plot in left panel ---
+    steps = np.arange(n_steps)
+    if "QC" in progress:
+        ax_line.plot(steps, progress["QC"], color=_TARGET_COLOR_QC, lw=2.0, label="QC (P(quasicrystal))")
+    for i, key in enumerate([k for k in progress if k != "QC"]):
+        ax_line.plot(
+            steps,
+            progress[key],
+            color=_TARGET_COLORS_REG[i % len(_TARGET_COLORS_REG)],
+            lw=1.8,
+            label=key,
+        )
+    ax_line.axhline(1.0, color="#666", ls="--", lw=1.0, alpha=0.6)
+    ax_line.axhline(0.0, color="#bbb", ls=":", lw=0.8, alpha=0.5)
+    ax_line.set_xlabel("Optimisation step")
+    ax_line.set_ylabel("Progress  (0 = seed, 1 = target)")
+    if seed_composition:
+        # Two-line title: bold panel title on top + monospace seed-composition underneath. The
+        # ``pad=22`` lifts the title clear of the second line; without the pad they overlap
+        # because matplotlib's default title baseline sits where the text annotation lands.
+        ax_line.set_title(title, fontsize=11, fontweight="bold", pad=22)
+        ax_line.text(
+            0.5, 1.005, f"seed:  {seed_composition}",
+            transform=ax_line.transAxes, ha="center", va="bottom",
+            fontsize=10, family="monospace", color="#444",
+        )
+    else:
+        ax_line.set_title(title, fontsize=11, fontweight="bold")
+    ax_line.legend(loc="best", fontsize=8, frameon=False)
+    ax_line.grid(True, alpha=0.2)
+    marker = ax_line.axvline(0, color="#444", lw=1.2, alpha=0.85)
+
+    # --- Bar chart in right panel (redrawn per frame) ---
+    ax_bar.set_title("Composition  (top-K by weight)", fontsize=10)
+    ax_bar.set_xlim(0, 1.0)
+    ax_bar.set_xlabel("weight")
+
+    def _draw_bar(step_idx: int) -> None:
+        ax_bar.clear()
+        frame = _topk_composition_frame(per_step_weights[step_idx], element_symbols, top_k=top_k_elements)
+        if not frame:
+            ax_bar.text(0.5, 0.5, "(no elements above threshold)", ha="center", va="center", transform=ax_bar.transAxes)
+        else:
+            symbols, weights = zip(*frame)
+            y_pos = np.arange(len(symbols))
+            ax_bar.barh(y_pos, weights, color="#2563EB", alpha=0.75, edgecolor="#222", linewidth=0.5)
+            ax_bar.set_yticks(y_pos)
+            ax_bar.set_yticklabels(symbols, fontsize=9)
+            ax_bar.invert_yaxis()  # largest on top
+        ax_bar.set_xlim(0, max(0.5, float(per_step_weights[step_idx].max()) * 1.1))
+        ax_bar.set_xlabel("weight")
+        ax_bar.set_title(f"Composition  (step {step_idx + 1}/{n_steps})", fontsize=10)
+        ax_bar.grid(True, axis="x", alpha=0.2)
+
+    def _init() -> Iterable[Any]:
+        _draw_bar(int(frame_steps[0]))
+        marker.set_xdata([int(frame_steps[0])])
+        return (marker,)
+
+    def _update(frame_idx: int) -> Iterable[Any]:
+        step_idx = int(frame_steps[frame_idx])
+        _draw_bar(step_idx)
+        marker.set_xdata([step_idx])
+        return (marker,)
+
+    # Only build the matplotlib FuncAnimation when at least one matplotlib-native format
+    # (gif / html) is requested. For svg-only output we render a handwritten SMIL SVG without
+    # touching the animation object — building it anyway would emit a "Animation was deleted
+    # without rendering anything" UserWarning on test runs.
+    needs_mpl_anim = any(fmt in ("gif", "html") for fmt in out_paths_by_format)
+    anim = (
+        manimation.FuncAnimation(
+            fig,
+            _update,
+            frames=len(frame_steps),
+            init_func=_init,
+            interval=1000 // fps,
+            blit=False,  # the bar chart redraw isn't blittable cleanly
+        )
+        if needs_mpl_anim
+        else None
+    )
+
+    for fmt, out_path in out_paths_by_format.items():
+        try:
+            if fmt == "gif":
+                assert anim is not None  # gif ⇒ needs_mpl_anim ⇒ anim built
+                anim.save(str(out_path), writer=manimation.PillowWriter(fps=fps))
+            elif fmt == "html":
+                assert anim is not None  # html ⇒ needs_mpl_anim ⇒ anim built
+                # ``to_jshtml`` returns a single self-contained HTML string with frames embedded
+                # as base64 PNGs. The ``HTMLWriter`` alternative drops a separate ``*_frames/``
+                # folder of 120+ PNGs alongside, which clutters the output dir and makes the
+                # artefact non-portable. The base64 version is bigger per-file (~3 MB vs the
+                # multi-file's ~10 MB total) but is one self-contained file.
+                out_path.write_text(anim.to_jshtml(fps=fps), encoding="utf-8")
+            elif fmt == "svg":
+                _save_smil_svg(progress, per_step_weights, element_symbols, frame_steps, out_path, title=title, fps=fps)
+            else:
+                logger.warning(f"plot_trajectory_animation: unknown format {fmt!r} — skipping.")
+                continue
+            logger.info(f"Wrote trajectory animation ({fmt}) to {out_path}")
+        except Exception as exc:  # pragma: no cover  (writer-specific failure modes)
+            logger.warning(f"plot_trajectory_animation: failed to write {fmt} → {out_path}: {exc}")
+
+    plt.close(fig)
+
+
+# --- SMIL SVG writer ---------------------------------------------------------------------------
+
+
+def _save_smil_svg(
+    progress: Mapping[str, np.ndarray],
+    per_step_weights: np.ndarray,
+    element_symbols: list[str],
+    frame_steps: np.ndarray,
+    out_path: Path,
+    *,
+    title: str,
+    fps: int,
+    top_k_elements: int = 10,
+) -> None:
+    """Single-file SMIL-animated SVG.
+
+    matplotlib doesn't have a native SVG-animation writer; rather than render N PNGs and ship a
+    multi-frame SVG (would defeat the "one file" goal), we emit a compact handwritten SVG with
+    the static line plot as a vector overlay + ``<animate>`` tags for the per-step marker and
+    per-element bar widths. Plays in any modern browser (Firefox / Chrome / Safari); PowerPoint
+    and Keynote cannot embed it directly — for those use the GIF.
+    """
+    n_steps = len(next(iter(progress.values())))
+    duration_s = max(1.0, len(frame_steps) / fps)
+    # Coordinate system: 800 × 400 viewBox, line plot in [40, 480] × [40, 360], bar plot in
+    # [520, 780] × [40, 360]. Bars are horizontal, top-K elements, redrawn via <animate>.
+
+    # ---- header ----
+    parts: list[str] = []
+    parts.append(
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 420" '
+        'width="800" height="420" font-family="system-ui, sans-serif" font-size="11">'
+    )
+    parts.append(f'<title>{title}</title>')
+    parts.append(f'<text x="400" y="18" text-anchor="middle" font-size="13" font-weight="bold">{title}</text>')
+
+    # ---- line plot (static) ----
+    parts.append('<rect x="40" y="40" width="440" height="320" fill="white" stroke="#888" />')
+    parts.append('<text x="260" y="395" text-anchor="middle">Optimisation step</text>')
+    parts.append(
+        '<text x="20" y="200" text-anchor="middle" transform="rotate(-90 20 200)">'
+        "Progress  (0 = seed, 1 = target)</text>"
+    )
+
+    # Compute y-range across all curves so 0 and 1 are at fixed pixels.
+    all_vals = np.concatenate([np.asarray(v) for v in progress.values()])
+    y_min, y_max = float(min(all_vals.min(), 0.0)), float(max(all_vals.max(), 1.0))
+    y_pad = (y_max - y_min) * 0.05
+    y_min -= y_pad
+    y_max += y_pad
+
+    def _to_x(step_idx: int) -> float:
+        return 40 + (step_idx / max(n_steps - 1, 1)) * 440
+
+    def _to_y(val: float) -> float:
+        return 360 - (val - y_min) / (y_max - y_min) * 320
+
+    # Static gridlines + axis labels at 0 / 1.
+    y0, y1 = _to_y(0.0), _to_y(1.0)
+    parts.append(f'<line x1="40" x2="480" y1="{y0}" y2="{y0}" stroke="#bbb" stroke-dasharray="2,3" />')
+    parts.append(f'<line x1="40" x2="480" y1="{y1}" y2="{y1}" stroke="#666" stroke-dasharray="4,3" />')
+    parts.append(f'<text x="34" y="{y0 + 4}" text-anchor="end" fill="#888">0</text>')
+    parts.append(f'<text x="34" y="{y1 + 4}" text-anchor="end" fill="#666">1</text>')
+
+    color_map = {"QC": _TARGET_COLOR_QC}
+    reg_keys = [k for k in progress if k != "QC"]
+    for i, key in enumerate(reg_keys):
+        color_map[key] = _TARGET_COLORS_REG[i % len(_TARGET_COLORS_REG)]
+
+    # Polyline per target.
+    legend_y = 50
+    for key, vals in progress.items():
+        pts = " ".join(f"{_to_x(s):.1f},{_to_y(float(v)):.1f}" for s, v in enumerate(vals))
+        color = color_map[key]
+        parts.append(f'<polyline points="{pts}" fill="none" stroke="{color}" stroke-width="1.8" />')
+        parts.append(f'<circle cx="455" cy="{legend_y}" r="4" fill="{color}" />')
+        parts.append(f'<text x="462" y="{legend_y + 4}" fill="#222">{key}</text>')
+        legend_y += 14
+
+    # ---- animated step marker (vertical line in line plot) ----
+    x_values_str = ";".join(f"{_to_x(int(s)):.1f}" for s in frame_steps)
+    parts.append(
+        f'<line y1="40" y2="360" stroke="#444" stroke-width="1.2" opacity="0.85">'
+        f'  <animate attributeName="x1" values="{x_values_str}" dur="{duration_s:.2f}s" repeatCount="indefinite" />'
+        f'  <animate attributeName="x2" values="{x_values_str}" dur="{duration_s:.2f}s" repeatCount="indefinite" />'
+        f"</line>"
+    )
+
+    # ---- bar chart (top-K, animated per element) ----
+    parts.append('<rect x="520" y="40" width="260" height="320" fill="white" stroke="#888" />')
+    parts.append('<text x="650" y="32" text-anchor="middle" font-weight="bold">Composition (top-K, step animated)</text>')
+
+    # Use the union of top-K-per-frame elements across all frames so each bar is one stable row.
+    seen_idx: list[int] = []
+    for s in frame_steps:
+        top = np.argsort(per_step_weights[int(s)])[::-1][:top_k_elements]
+        for idx in top:
+            if int(idx) not in seen_idx:
+                seen_idx.append(int(idx))
+    # Cap at 2× top_k to keep the SVG tidy.
+    seen_idx = seen_idx[: 2 * top_k_elements]
+    n_rows = len(seen_idx)
+    bar_y_top = 50
+    bar_height = min(20.0, 300.0 / max(n_rows, 1))
+    bar_x_left = 560
+    bar_max_w = 200
+
+    # Per-bar animation values (weight per frame, scaled).
+    for row_i, elem_idx in enumerate(seen_idx):
+        y_row = bar_y_top + row_i * bar_height
+        widths = [per_step_weights[int(s), elem_idx] for s in frame_steps]
+        w_str = ";".join(f"{max(0.0, float(w)) * bar_max_w:.1f}" for w in widths)
+        parts.append(f'<text x="{bar_x_left - 4}" y="{y_row + bar_height - 4:.1f}" text-anchor="end">{element_symbols[elem_idx]}</text>')
+        parts.append(
+            f'<rect x="{bar_x_left}" y="{y_row:.1f}" height="{bar_height - 2:.1f}" fill="#2563EB" opacity="0.75">'
+            f'  <animate attributeName="width" values="{w_str}" dur="{duration_s:.2f}s" repeatCount="indefinite" />'
+            f"</rect>"
+        )
+
+    # Step counter at the bottom.
+    step_label_values = ";".join(f"step {int(s) + 1}/{n_steps}" for s in frame_steps)
+    parts.append(
+        f'<text x="650" y="395" text-anchor="middle" fill="#444">'
+        f'  step 1/{n_steps}'
+        f'  <animate attributeName="textContent" values="{step_label_values}" dur="{duration_s:.2f}s" repeatCount="indefinite" />'
+        f"</text>"
+    )
+
+    parts.append("</svg>")
+    out_path.write_text("\n".join(parts), encoding="utf-8")

--- a/src/foundation_model/workflows/inverse_trajectory_test.py
+++ b/src/foundation_model/workflows/inverse_trajectory_test.py
@@ -1,0 +1,192 @@
+# Copyright 2026 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the pure helpers in :mod:`foundation_model.workflows.inverse_trajectory`.
+
+The full ``_emit_trajectory_outputs`` orchestrator needs a real trained checkpoint to exercise;
+this file covers the pure functions — seed picker, progress normalisation, and the writer
+smoke-tests (static plot + gif + html + svg). Animations are checked only for "file got written";
+visual correctness is verified by inspecting the rerun artefacts.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from foundation_model.workflows.inverse_trajectory import (
+    best_seed_by_target_distance,
+    normalize_target_trajectories,
+    plot_trajectory_animation,
+    plot_trajectory_static,
+)
+
+
+# --- best_seed_by_target_distance --------------------------------------------------------------
+
+
+def test_best_seed_picks_closest_joint_distance_to_targets():
+    """Seed 1 is closest to the joint target (QC=1, fe=-2, klat=2); the picker should return 1."""
+    qc = np.array([0.20, 0.95, 0.50])  # seed 1 has highest QC
+    reg = {
+        "formation_energy": np.array([+0.5, -1.9, -1.0]),  # seed 1 hits target -2 best
+        "klat": np.array([0.0, 1.8, 1.2]),  # seed 1 hits target 2 best
+    }
+    reg_targets = {"formation_energy": -2.0, "klat": 2.0}
+    assert best_seed_by_target_distance(qc, reg, reg_targets) == 1
+
+
+def test_best_seed_handles_zero_target_without_div_by_zero():
+    """``target == 0`` would naively divide by zero; the picker uses a min-scale guard."""
+    qc = np.array([0.9, 0.8])
+    reg = {"some_task": np.array([0.1, 0.5])}
+    # Should pick seed 0 (closer to target 0).
+    assert best_seed_by_target_distance(qc, reg, {"some_task": 0.0}) == 0
+
+
+def test_best_seed_empty_qc_raises():
+    with pytest.raises(ValueError, match="empty qc_final"):
+        best_seed_by_target_distance(np.array([]), {}, {})
+
+
+# --- normalize_target_trajectories -------------------------------------------------------------
+
+
+def test_normalize_trajectory_maps_baseline_to_zero_and_target_to_one():
+    """Per (task, seed): a step's value of (target - baseline) + baseline ⇒ progress = 1."""
+    n_steps = 4
+    n_seeds = 2
+    # One reg target only. Baseline = [0.0, 0.5], target = 2.0.
+    reg_targets = {"k": 2.0}
+    seed_reg = {"k": np.array([0.0, 0.5])}
+    # Per-seed trajectory: linear interpolation from baseline → target across 4 steps.
+    traj_k = np.stack(
+        [
+            np.linspace(0.0, 2.0, n_steps),  # seed 0
+            np.linspace(0.5, 2.0, n_steps),  # seed 1
+        ],
+        axis=1,
+    )  # (steps, B)
+    # QC trajectory: flat at the seed baseline so it normalises to 0 progress throughout.
+    seed_qc = np.array([0.1, 0.2])
+    qc_traj = np.tile(seed_qc[None, :], (n_steps, 1))
+
+    progress = normalize_target_trajectories(
+        qc_trajectory=qc_traj,
+        reg_trajectory={"k": traj_k},
+        reg_targets=reg_targets,
+        seed_qc=seed_qc,
+        seed_reg=seed_reg,
+    )
+    # k progress: starts at 0, ends at 1 (per-seed normalised then mean over B).
+    assert progress["k"].shape == (n_steps,)
+    assert progress["k"][0] == pytest.approx(0.0, abs=1e-9)
+    assert progress["k"][-1] == pytest.approx(1.0, abs=1e-9)
+    # QC stays at baseline ⇒ progress = 0 throughout.
+    assert progress["QC"].shape == (n_steps,)
+    assert np.allclose(progress["QC"], 0.0)
+
+
+# --- plot writers ------------------------------------------------------------------------------
+
+
+def _toy_progress() -> dict[str, np.ndarray]:
+    """4-target × 30-step normalised progress, monotone so the picture is interpretable."""
+    n = 30
+    return {
+        "QC": np.clip(np.linspace(0.0, 0.95, n) + 0.02 * np.sin(np.linspace(0, 4 * np.pi, n)), 0, 1.5),
+        "formation_energy": np.linspace(0.0, 1.2, n),
+        "klat": np.linspace(0.0, 0.8, n),
+    }
+
+
+def _toy_weights(n_steps: int = 30, n_components: int = 12) -> np.ndarray:
+    """(steps, n_components) toy weights — start sparse, drift toward a different sparse set."""
+    rng = np.random.default_rng(7)
+    w = np.zeros((n_steps, n_components), dtype=float)
+    # Initial: mass on elements 0..2
+    w[0, :3] = [0.5, 0.3, 0.2]
+    # Final: mass on elements 4, 6, 7
+    end = np.zeros(n_components)
+    end[4], end[6], end[7] = 0.5, 0.3, 0.2
+    for s in range(n_steps):
+        t = s / (n_steps - 1)
+        w[s] = (1 - t) * w[0] + t * end + 0.001 * rng.standard_normal(n_components)
+        w[s] = np.clip(w[s], 0, None)
+        w[s] /= w[s].sum()
+    return w
+
+
+def test_plot_trajectory_static_writes_png(tmp_path):
+    out = tmp_path / "static.png"
+    plot_trajectory_static(_toy_progress(), out, title="toy trajectory")
+    assert out.exists()
+
+
+def test_plot_trajectory_static_with_seed_composition(tmp_path):
+    """``seed_composition`` is rendered as a monospace annotation under the title — verify the
+    plot still writes with the kwarg present (visual correctness is by inspection)."""
+    out = tmp_path / "static_with_seed.png"
+    plot_trajectory_static(
+        _toy_progress(), out, title="toy trajectory", seed_composition="Au65 Ga20 Gd15"
+    )
+    assert out.exists()
+
+
+def test_plot_trajectory_animation_writes_gif(tmp_path):
+    out = tmp_path / "anim.gif"
+    plot_trajectory_animation(
+        _toy_progress(),
+        per_step_weights=_toy_weights(),
+        element_symbols=[f"E{i}" for i in range(12)],
+        out_paths_by_format={"gif": out},
+        title="toy animation",
+        max_frames=10,  # keep test fast
+    )
+    assert out.exists()
+
+
+def test_plot_trajectory_animation_writes_html(tmp_path):
+    out = tmp_path / "anim.html"
+    plot_trajectory_animation(
+        _toy_progress(),
+        per_step_weights=_toy_weights(),
+        element_symbols=[f"E{i}" for i in range(12)],
+        out_paths_by_format={"html": out},
+        title="toy animation",
+        max_frames=10,
+    )
+    assert out.exists()
+
+
+def test_plot_trajectory_animation_writes_smil_svg(tmp_path):
+    out = tmp_path / "anim.svg"
+    plot_trajectory_animation(
+        _toy_progress(),
+        per_step_weights=_toy_weights(),
+        element_symbols=[f"E{i}" for i in range(12)],
+        out_paths_by_format={"svg": out},
+        title="toy animation",
+        max_frames=8,
+    )
+    assert out.exists()
+    body = out.read_text(encoding="utf-8")
+    # The SMIL animation should contain <animate> tags driving the marker x1/x2 + bar widths.
+    assert "<animate" in body
+    # The step counter labels every step exactly once.
+    assert "step 1/" in body
+
+
+def test_plot_trajectory_animation_skips_when_steps_dont_match(tmp_path):
+    """Mismatched per_step_weights vs progress step count ⇒ warning + no file."""
+    out = tmp_path / "should_not_exist.gif"
+    progress = _toy_progress()  # 30 steps
+    plot_trajectory_animation(
+        progress,
+        per_step_weights=_toy_weights(n_steps=15),  # mismatch
+        element_symbols=[f"E{i}" for i in range(12)],
+        out_paths_by_format={"gif": out},
+        title="should skip",
+        max_frames=10,
+    )
+    assert not out.exists()

--- a/src/foundation_model/workflows/plots.py
+++ b/src/foundation_model/workflows/plots.py
@@ -76,8 +76,10 @@ def plot_confusion(
     for t, p in zip(true, pred):
         if 0 <= t < num_classes and 0 <= p < num_classes:
             counts[t, p] += 1
-    if special_material_type:
-        labels = list(MATERIAL_TYPE_DISPLAY_ORDER[:num_classes])
+    # The special material-type ordering only applies to the merged 3-class encoding; for any
+    # other class count fall back to plain integer labels so ticks and labels always match.
+    if special_material_type and num_classes == len(MATERIAL_TYPE_DISPLAY_ORDER):
+        labels = list(MATERIAL_TYPE_DISPLAY_ORDER)
         perm = [MATERIAL_TYPE_CLASSES.index(lbl) for lbl in labels]
     else:
         labels = [str(i) for i in range(num_classes)]

--- a/src/foundation_model/workflows/plots_test.py
+++ b/src/foundation_model/workflows/plots_test.py
@@ -31,6 +31,15 @@ def test_plot_confusion_special_material_type() -> None:
     plots.plt.close(fig)
 
 
+def test_plot_confusion_special_flag_ignored_for_non_three_classes() -> None:
+    # special_material_type must not break when num_classes != 3 (falls back to integer labels).
+    fig = plots.plot_confusion(
+        np.array([0, 1, 4]), np.array([0, 2, 4]), num_classes=5, acc=0.6, title="t", special_material_type=True
+    )
+    assert isinstance(fig, Figure)
+    plots.plt.close(fig)
+
+
 def test_plot_kr_sequences_returns_figure() -> None:
     comps = ["Fe2 O3", "Al2 O3"]
     t_list = [np.array([1.0, 2.0, 3.0]), np.array([1.0, 2.0])]


### PR DESCRIPTION
## Summary

Fourth PR of the `fm` CLI refactor (stacked on #23). Adds the inverse-design engine and the
trajectory helpers.

- **`workflows/inverse.py`** — per-scenario × per-path engine migrated from
  `paper_inverse_comparison` + `paper_inverse_3scenarios` + the demo seed selector. Seeds are
  selected once per run (`top_qc` / `random` / `explicit`, element-system dedup, explicit-append
  budget). **Latent** paths → `optimize_latent` (AE alignment, decode-then-predict surface);
  **composition** paths → `optimize_composition` (seed/random init, `seed_blend`, `allowed_elements`,
  `diversity_scale`, cardinality cap, annealing). `DEFAULT_PATHS` = **11** (3 latent + 8
  composition) with the 48-element `DEFAULT_ALLOY_PALETTE`. Per-scenario outputs: scenario /
  results / summary / targets JSON, comparison / qc-vs-secondary / element-frequency /
  seed-to-optimized figures, trajectory `.npz`; root `seeds.json` + `inverse_design.json` + SUMMARY.
- **`workflows/inverse_trajectory.py`** — straight rename-move of the pure trajectory helpers
  (best-seed / normalize / static plot / animation) + its migrated test.
- **`cli/main.py`** — `fm inverse` (`--checkpoint`/`--scenario`/`--steps`/`--no-trajectory`/
  `--animation-formats`).
- **`plots.py` fix** — the confusion matrix now falls back to integer labels when a classification
  task isn't the merged 3-class `material_type` (the 5-class raw case previously crashed; PR2's
  smoke was regression-only so it went uncaught). Regression test added.
- Smoke configs unified on the qc catalog (2 reg + `material_type` clf) so
  `pretrain → finetune → inverse` chains on one catalog.

## Validation

- `fm pretrain … && fm finetune … && fm inverse --config samples/inverse_smoke.toml --checkpoint
  <finetune ckpt>` runs on CPU and produces the full per-scenario artifact set.
- Full suite → **451 passed, 1 skipped**; ruff/mypy clean on all new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCoVwB3pntFi25YnpoHYwY