### PR TITLE
PR5 — fm predict: arbitrary-checkpoint evaluation & prediction

### DIFF
--- a/samples/predict_smoke.toml
+++ b/samples/predict_smoke.toml
@@ -1,0 +1,53 @@
+# Smoke-test config for `fm predict` — evaluate a smoke checkpoint on the test split.
+#
+# Catalog + model dims match samples/pretrain_smoke.toml.
+#
+#   fm predict --config samples/predict_smoke.toml \
+#       --checkpoint artifacts/finetune_smoke/training/final_model.pt
+
+[data]
+composition_column = "composition"
+batch_size = 64
+
+[descriptor]
+kind = "kmd"
+n_grids = 8
+
+[datasets.qc]
+path = "data/qc_ac_te_mp_dos_reformat_20250615_enforce_quaternary_test.pd.parquet"
+preprocessing_path = "data/preprocessing_objects_20250615.pkl.z"
+sample = 300
+
+[[tasks]]
+name = "density"
+kind = "regression"
+dataset = "qc"
+column = "Density (normalized)"
+
+[[tasks]]
+name = "formation_energy"
+kind = "regression"
+dataset = "qc"
+column = "Formation energy per atom (normalized)"
+
+[[tasks]]
+name = "material_type"
+kind = "classification"
+dataset = "qc"
+column = "Material type (label)"
+num_classes = 5
+
+[model]
+latent_dim = 32
+encoder_hidden = 64
+head_hidden_dim = 32
+n_kernel = 8
+
+[predict]
+checkpoint = "artifacts/finetune_smoke/training/final_model.pt"
+tasks = []          # empty → every head in the checkpoint
+split = "test"
+with_metrics = true
+
+[output]
+dir = "artifacts/predict_smoke"

--- a/src/foundation_model/cli/main.py
+++ b/src/foundation_model/cli/main.py
@@ -22,6 +22,8 @@ from foundation_model.workflows.finetune import FinetuneConfig, build_finetune_c
 from foundation_model.workflows.finetune import run as finetune_run
 from foundation_model.workflows.inverse import InverseConfig, build_inverse_config
 from foundation_model.workflows.inverse import run as inverse_run
+from foundation_model.workflows.predict import PredictConfig, build_predict_config
+from foundation_model.workflows.predict import run as predict_run
 from foundation_model.workflows.pretrain import PretrainConfig, build_pretrain_config
 from foundation_model.workflows.pretrain import run as pretrain_run
 from foundation_model.workflows.recording import RunRecorder
@@ -249,6 +251,71 @@ def inverse_cmd(
     recorder = RunRecorder(cfg.output_dir)
     recorder.write_provenance(config=cfg, argv=list(sys.argv), seeds={"seed": 2025})
     inverse_run(cfg, recorder, only_scenarios=list(scenarios) or None)
+    recorder.close()
+
+
+def _predict_config(
+    config_path: str,
+    overrides: Sequence[str],
+    output_dir: str | None,
+    seed: int | None,
+    accelerator: str | None,
+    sample: int | None,
+    checkpoint: str | None,
+    tasks: str | None,
+    split: str | None,
+    compositions: str | None,
+    no_metrics: bool,
+) -> PredictConfig:
+    raw = load_raw_config(config_path, overrides, seed=seed, accelerator=accelerator, sample=sample)
+    if tasks is not None:
+        _set_dotted(raw, "predict.tasks", [t.strip() for t in tasks.split(",") if t.strip()])
+    if split is not None:
+        _set_dotted(raw, "predict.split", split)
+    if compositions is not None:
+        _set_dotted(raw, "predict.compositions", [c.strip() for c in compositions.split(",") if c.strip()])
+    if no_metrics:
+        _set_dotted(raw, "predict.with_metrics", False)
+    return build_predict_config(raw, output_dir=output_dir, checkpoint=checkpoint)
+
+
+@main.command("predict")
+@common_options
+@click.option("--checkpoint", default=None, type=click.Path(dir_okay=False), help="Checkpoint to predict with.")
+@click.option("--tasks", default=None, help="Comma-separated heads to predict (default: all checkpoint heads).")
+@click.option("--split", default=None, help="train | val | test | all.")
+@click.option("--compositions", default=None, help="Comma-separated compositions (overrides split).")
+@click.option("--no-metrics", is_flag=True, default=False, help="Skip metric computation.")
+def predict_cmd(
+    config_path: str,
+    output_dir: str | None,
+    overrides: tuple[str, ...],
+    seed: int | None,
+    accelerator: str | None,
+    sample: int | None,
+    checkpoint: str | None,
+    tasks: str | None,
+    split: str | None,
+    compositions: str | None,
+    no_metrics: bool,
+) -> None:
+    """Evaluate / predict with an arbitrary checkpoint."""
+    cfg = _predict_config(
+        config_path,
+        overrides,
+        output_dir,
+        seed,
+        accelerator,
+        sample,
+        checkpoint,
+        tasks,
+        split,
+        compositions,
+        no_metrics,
+    )
+    recorder = RunRecorder(cfg.output_dir)
+    recorder.write_provenance(config=cfg, argv=list(sys.argv), seeds={"seed": 2025})
+    predict_run(cfg, recorder)
     recorder.close()
 
 

--- a/src/foundation_model/cli/main_test.py
+++ b/src/foundation_model/cli/main_test.py
@@ -130,3 +130,36 @@ def test_finetune_tasks_and_checkpoint_flags(tmp_path) -> None:
     assert cfg.tasks == ["a", "b"]  # --tasks overrides finetune.tasks
     assert str(cfg.checkpoint) == "override.pt"  # --checkpoint wins
     assert cfg.epochs == 7
+
+
+_PREDICT_CONFIG = """
+[descriptor]
+kind = "kmd"
+
+[datasets.d1]
+path = "data/x.parquet"
+
+[[tasks]]
+name = "a"
+kind = "regression"
+dataset = "d1"
+column = "a"
+
+[predict]
+split = "test"
+
+[output]
+dir = "out"
+"""
+
+
+def test_predict_flags(tmp_path) -> None:
+    from foundation_model.cli.main import _predict_config
+
+    path = tmp_path / "pred.toml"
+    path.write_text(_PREDICT_CONFIG)
+    cfg = _predict_config(str(path), (), None, None, None, None, "ck.pt", "a", "all", "Fe2 O3,Al2 O3", True)
+    assert cfg.tasks == ["a"]
+    assert cfg.split == "all"
+    assert cfg.compositions == ["Fe2 O3", "Al2 O3"]
+    assert cfg.with_metrics is False  # --no-metrics

--- a/src/foundation_model/workflows/predict.py
+++ b/src/foundation_model/workflows/predict.py
@@ -1,0 +1,325 @@
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``fm predict`` — evaluate / predict with an arbitrary checkpoint.
+
+Rebuilds the checkpoint's model from the :class:`TaskCatalog`, loads its weights with
+``strict=False`` (preserving the fm-trainer ``strict=False`` semantics), resolves a prediction
+set (a split or an explicit composition list), and writes per-head prediction parquets — plus
+metrics when true targets are available. Single-device only; the legacy distributed prediction
+gather is not migrated.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import torch
+from lightning import seed_everything
+from loguru import logger
+from sklearn.metrics import accuracy_score, f1_score, mean_absolute_error, r2_score  # type: ignore[import-untyped]
+
+from foundation_model.data.composition_sources import canonical_key, normalize_composition
+from foundation_model.models.model_config import MLPEncoderConfig, OptimizerConfig
+
+from ._engine import AE_NAME, as_float_array
+from ._sections import ModelSectionConfig, build_model_section, reject_unknown
+from .recording import RunRecorder, load_checkpoint_state
+from .task_catalog import TaskCatalog, TaskCatalogConfig, TaskKind, build_task_catalog_config
+
+_PREDICT_ROOT_KEYS = {"data", "descriptor", "datasets", "tasks", "model", "predict", "output"}
+_CATALOG_KEYS = {"data", "descriptor", "datasets", "tasks"}
+_SPLITS = {"train", "val", "test", "all"}
+
+
+@dataclass(kw_only=True)
+class PredictConfig:
+    catalog: TaskCatalogConfig
+    model: ModelSectionConfig
+    checkpoint: Path
+    output_dir: Path
+    tasks: list[str] = field(default_factory=list)  # empty → every head in the checkpoint
+    split: str = "test"
+    compositions: list[str] = field(default_factory=list)  # overrides split when given
+    with_metrics: bool = True
+
+    def __post_init__(self) -> None:
+        self.checkpoint = Path(self.checkpoint)
+        self.output_dir = Path(self.output_dir)
+        if self.split not in _SPLITS:
+            raise ValueError(f"predict.split must be one of {sorted(_SPLITS)}, got {self.split!r}.")
+        catalog_tasks = {t.name for t in self.catalog.tasks}
+        unknown = [t for t in self.tasks if t not in catalog_tasks]
+        if unknown:
+            raise ValueError(f"predict.tasks references unknown task(s): {unknown}.")
+
+
+def build_predict_config(
+    raw: Mapping[str, Any], *, output_dir: str | Path | None = None, checkpoint: str | Path | None = None
+) -> PredictConfig:
+    """Normalize a parsed-TOML tree into a :class:`PredictConfig`."""
+
+    reject_unknown("<root>", raw, _PREDICT_ROOT_KEYS)
+    catalog = build_task_catalog_config({k: raw[k] for k in _CATALOG_KEYS if k in raw})
+    model = build_model_section(raw.get("model", {}))
+
+    pred_raw = dict(raw.get("predict", {}))
+    reject_unknown("predict", pred_raw, {"checkpoint", "tasks", "split", "compositions", "with_metrics"})
+    resolved_checkpoint = checkpoint if checkpoint is not None else pred_raw.get("checkpoint")
+    if resolved_checkpoint is None:
+        raise ValueError("checkpoint must be given via --checkpoint or [predict].checkpoint.")
+    resolved_output = output_dir if output_dir is not None else raw.get("output", {}).get("dir")
+    if resolved_output is None:
+        raise ValueError("output directory must be given via --output-dir or [output].dir.")
+
+    return PredictConfig(
+        catalog=catalog,
+        model=model,
+        checkpoint=Path(resolved_checkpoint),
+        output_dir=Path(resolved_output),
+        tasks=list(pred_raw.get("tasks", [])),
+        split=str(pred_raw.get("split", "test")),
+        compositions=list(pred_raw.get("compositions", [])),
+        with_metrics=bool(pred_raw.get("with_metrics", True)),
+    )
+
+
+def _task_names_from_state(state_dict: Mapping[str, Any]) -> list[str]:
+    names: list[str] = []
+    for key in state_dict:
+        if key.startswith("task_heads."):
+            name = key.split(".", 2)[1]
+            if name != AE_NAME and name not in names:
+                names.append(name)
+    return names
+
+
+def run(cfg: PredictConfig, recorder: RunRecorder | None = None) -> dict[str, Any]:
+    """Predict ``cfg.tasks`` (or every checkpoint head) on the resolved set. Returns metrics dict."""
+
+    catalog = TaskCatalog(cfg.catalog)
+    owns_recorder = recorder is None
+    rec = recorder or RunRecorder(cfg.output_dir)
+    seed_everything(2025, workers=True)
+
+    try:
+        model, ckpt_tasks = _rebuild_model(cfg, catalog)
+        heads = set(model.task_heads)
+        requested = cfg.tasks or [t for t in ckpt_tasks if t in heads]
+        missing = [t for t in requested if t not in heads]
+        if missing:
+            raise ValueError(f"requested task(s) {missing} not in the checkpoint (available: {sorted(heads)}).")
+
+        comps = _resolve_compositions(cfg, catalog, requested)
+        if not comps:
+            raise RuntimeError("no compositions resolved for prediction.")
+        logger.info(f"Predicting {requested} on {len(comps)} compositions.")
+
+        device = next(model.parameters()).device
+        pred_dir = rec.paths.root / "predict"
+        pred_dir.mkdir(parents=True, exist_ok=True)
+        metrics: dict[str, dict[str, float]] = {}
+        for task in requested:
+            metric = _predict_task(model, catalog, task, comps, device, rec, pred_dir)
+            if metric:
+                metrics[task] = metric
+
+        if metrics:
+            rec.append_record({"split": cfg.split, "metrics": metrics})
+            (pred_dir / "metrics.json").write_text(json.dumps(metrics, indent=2), encoding="utf-8")
+            rows = [{"task": t, **m} for t, m in metrics.items()]
+            pd.DataFrame(rows).to_csv(pred_dir / "metrics_table.csv", index=False)
+        return {"metrics": metrics, "n_compositions": len(comps)}
+    finally:
+        if owns_recorder:
+            rec.close()
+
+
+def _rebuild_model(cfg: PredictConfig, catalog: TaskCatalog) -> tuple[Any, list[str]]:
+    from foundation_model.models.flexible_multi_task_model import FlexibleMultiTaskModel
+
+    state = load_checkpoint_state(cfg.checkpoint)
+    ckpt_tasks = list(state.get("task_sequence") or _task_names_from_state(state["model"]))
+    catalog_tasks = {t.name for t in cfg.catalog.tasks}
+    missing = [t for t in ckpt_tasks if t not in catalog_tasks]
+    if missing:
+        raise ValueError(f"checkpoint tasks {missing} are not in the catalog (have {sorted(catalog_tasks)}).")
+
+    encoder_config = MLPEncoderConfig(
+        hidden_dims=[catalog.descriptor_dim, cfg.model.encoder_hidden, cfg.model.latent_dim]
+    )
+    model = FlexibleMultiTaskModel(
+        task_configs=[],
+        encoder_config=encoder_config,
+        enable_autoencoder=True,
+        shared_block_optimizer=OptimizerConfig(lr=5e-3, weight_decay=1e-2),
+    )
+    for name in ckpt_tasks:
+        model.add_task(
+            catalog.build_task_config(
+                name,
+                latent_dim=cfg.model.latent_dim,
+                head_hidden_dim=cfg.model.head_hidden_dim,
+                n_kernel=cfg.model.n_kernel,
+                lr=5e-3,
+            )
+        )
+    incompatible = model.load_state_dict(state["model"], strict=False)
+    if incompatible.missing_keys:
+        logger.info(f"load_state_dict missing keys ({len(incompatible.missing_keys)}): {incompatible.missing_keys[:8]}")
+    if incompatible.unexpected_keys:
+        logger.info(
+            f"load_state_dict unexpected keys ({len(incompatible.unexpected_keys)}): {incompatible.unexpected_keys[:8]}"
+        )
+    model.eval()
+    return model, ckpt_tasks
+
+
+def _resolve_compositions(cfg: PredictConfig, catalog: TaskCatalog, tasks: Sequence[str]) -> list[str]:
+    """Explicit compositions win; otherwise the union of the requested tasks' rows on the split."""
+
+    if cfg.compositions:
+        # Normalize to canonical keys (matching the catalog frames), preserving order + dropping dups.
+        seen: dict[str, None] = {}
+        for comp in cfg.compositions:
+            seen.setdefault(canonical_key(comp, normalize_composition), None)
+        return list(seen)
+
+    frames = catalog.task_frames(tasks)
+    universe: dict[str, None] = {}
+    for name in tasks:
+        frame = frames[name]
+        if cfg.split == "all" or "split" not in frame.columns:
+            index = frame.index
+        else:
+            index = frame.index[frame["split"] == cfg.split]
+        for key in index:
+            universe.setdefault(str(key), None)
+    return list(universe)
+
+
+def _predict_task(
+    model: Any,
+    catalog: TaskCatalog,
+    name: str,
+    comps: list[str],
+    device: torch.device,
+    rec: RunRecorder,
+    pred_dir: Path,
+) -> dict[str, float]:
+    """Predict one head on ``comps``; write parquet (+ metrics when true targets exist)."""
+
+    spec = catalog.task_spec(name)
+    frame = catalog.task_frames([name])[name]
+    head = model.task_heads[name]
+    descriptor_fn = catalog.descriptor_fn()
+
+    if spec.kind is TaskKind.KERNEL_REGRESSION:
+        return _predict_kr(model, catalog, name, comps, device, rec, pred_dir)
+
+    desc = descriptor_fn(comps)
+    kept = [c for c in comps if c in desc.index]
+    if not kept:
+        logger.warning(f"task '{name}': no descriptors available for the prediction set.")
+        return {}
+    x = torch.tensor(desc.loc[kept].values, dtype=torch.float32, device=device)
+    with torch.no_grad():
+        h = torch.tanh(model.encoder(x))
+        if spec.kind is TaskKind.REGRESSION:
+            pred = catalog.inverse_transform(name, head(h).squeeze(-1).cpu().numpy())
+        else:  # classification
+            pred = head(h).argmax(dim=-1).cpu().numpy()
+
+    true = _true_values(frame, spec.column, kept, kind=spec.kind, catalog=catalog, name=name)
+    out = pd.DataFrame({"composition": kept, "pred": pred, "true": true})
+    out.to_parquet(pred_dir / f"{name}_pred.parquet")
+    return _metrics(spec.kind, true, pred)
+
+
+def _predict_kr(
+    model: Any,
+    catalog: TaskCatalog,
+    name: str,
+    comps: list[str],
+    device: torch.device,
+    rec: RunRecorder,
+    pred_dir: Path,
+) -> dict[str, float]:
+    spec = catalog.task_spec(name)
+    assert spec.t_column is not None
+    frame = catalog.task_frames([name])[name]
+    head = model.task_heads[name]
+    available = set(catalog.descriptor_fn()(comps).index)
+    keep: list[str] = []
+    t_list: list[np.ndarray] = []
+    true_parts: list[np.ndarray] = []
+    for comp in comps:
+        if comp not in available or comp not in frame.index:
+            continue
+        y = as_float_array(frame.at[comp, spec.column]) if pd.notna(frame.at[comp, spec.column]) else np.array([])
+        t = as_float_array(frame.at[comp, spec.t_column]) if pd.notna(frame.at[comp, spec.t_column]) else np.array([])
+        if t.size == 0:
+            continue
+        keep.append(comp)
+        t_list.append(t)
+        true_parts.append(y if y.size == t.size else np.full(t.size, np.nan))
+    if not keep:
+        logger.warning(f"task '{name}': no compositions with a t-grid to predict.")
+        return {}
+    desc = catalog.descriptor_fn()(keep)
+    x = torch.tensor(desc.loc[keep].values, dtype=torch.float32, device=device)
+    with torch.no_grad():
+        h = torch.tanh(model.encoder(x))
+        t_tensors = [torch.tensor(t, dtype=torch.float32, device=device) for t in t_list]
+        expanded_h, expanded_t = model._expand_for_kernel_regression(h, t_tensors)
+        pred = catalog.inverse_transform(name, head(expanded_h, t=expanded_t).squeeze(-1).cpu().numpy())
+    rows: list[dict[str, Any]] = []
+    offset = 0
+    for comp, t_arr, y_true in zip(keep, t_list, true_parts):
+        n = int(t_arr.size)
+        for k in range(n):
+            rows.append(
+                {"composition": comp, "t": float(t_arr[k]), "pred": float(pred[offset + k]), "true": float(y_true[k])}
+            )
+        offset += n
+    long = pd.DataFrame(rows)
+    long.to_parquet(pred_dir / f"{name}_pred.parquet")
+    mask = ~long["true"].isna()
+    if mask.sum() >= 2:
+        return {
+            "r2": float(r2_score(long.loc[mask, "true"], long.loc[mask, "pred"])),
+            "mae": float(mean_absolute_error(long.loc[mask, "true"], long.loc[mask, "pred"])),
+            "points": int(mask.sum()),
+        }
+    return {}
+
+
+def _true_values(
+    frame: pd.DataFrame, column: str, comps: list[str], *, kind: TaskKind, catalog: TaskCatalog, name: str
+) -> np.ndarray:
+    raw = np.array([frame.at[c, column] if c in frame.index else np.nan for c in comps], dtype=float)
+    if kind is TaskKind.REGRESSION:
+        return catalog.inverse_transform(name, raw)
+    return raw
+
+
+def _metrics(kind: TaskKind, true: np.ndarray, pred: np.ndarray) -> dict[str, float]:
+    mask = ~np.isnan(np.asarray(true, dtype=float))
+    if mask.sum() < 1:
+        return {}
+    t, p = np.asarray(true)[mask], np.asarray(pred)[mask]
+    if kind is TaskKind.REGRESSION:
+        if mask.sum() < 2:
+            return {"samples": int(mask.sum())}
+        return {"r2": float(r2_score(t, p)), "mae": float(mean_absolute_error(t, p)), "samples": int(mask.sum())}
+    return {
+        "accuracy": float(accuracy_score(t.astype(int), p.astype(int))),
+        "macro_f1": float(f1_score(t.astype(int), p.astype(int), average="macro", zero_division=0)),
+        "samples": int(mask.sum()),
+    }

--- a/src/foundation_model/workflows/predict.py
+++ b/src/foundation_model/workflows/predict.py
@@ -126,7 +126,7 @@ def run(cfg: PredictConfig, recorder: RunRecorder | None = None) -> dict[str, An
         pred_dir.mkdir(parents=True, exist_ok=True)
         metrics: dict[str, dict[str, float]] = {}
         for task in requested:
-            metric = _predict_task(model, catalog, task, comps, device, rec, pred_dir)
+            metric = _predict_task(model, catalog, task, comps, device, pred_dir, with_metrics=cfg.with_metrics)
             if metric:
                 metrics[task] = metric
 
@@ -182,7 +182,7 @@ def _rebuild_model(cfg: PredictConfig, catalog: TaskCatalog) -> tuple[Any, list[
 
 
 def _resolve_compositions(cfg: PredictConfig, catalog: TaskCatalog, tasks: Sequence[str]) -> list[str]:
-    """Explicit compositions win; otherwise the union of the requested tasks' rows on the split."""
+    """Explicit compositions win (request order); otherwise resolve the split via the datamodule."""
 
     if cfg.compositions:
         # Normalize to canonical keys (matching the catalog frames), preserving order + dropping dups.
@@ -191,17 +191,12 @@ def _resolve_compositions(cfg: PredictConfig, catalog: TaskCatalog, tasks: Seque
             seen.setdefault(canonical_key(comp, normalize_composition), None)
         return list(seen)
 
-    frames = catalog.task_frames(tasks)
-    universe: dict[str, None] = {}
-    for name in tasks:
-        frame = frames[name]
-        if cfg.split == "all" or "split" not in frame.columns:
-            index = frame.index
-        else:
-            index = frame.index[frame["split"] == cfg.split]
-        for key in index:
-            universe.setdefault(str(key), None)
-    return list(universe)
+    # Split-based: go through CompoundDataModule so the composition-level split overlay applies —
+    # including the [data].val_split/test_split random fallback when a task frame has no explicit
+    # 'split' column (otherwise every row would leak into the requested split).
+    datamodule = catalog.build_datamodule(tasks, predict_idx=cfg.split)
+    datamodule.setup("predict")
+    return list(datamodule.predict_compositions)
 
 
 def _predict_task(
@@ -210,20 +205,20 @@ def _predict_task(
     name: str,
     comps: list[str],
     device: torch.device,
-    rec: RunRecorder,
     pred_dir: Path,
+    *,
+    with_metrics: bool,
 ) -> dict[str, float]:
-    """Predict one head on ``comps``; write parquet (+ metrics when true targets exist)."""
+    """Predict one head on ``comps``; write parquet (+ metrics when enabled and targets exist)."""
 
     spec = catalog.task_spec(name)
     frame = catalog.task_frames([name])[name]
     head = model.task_heads[name]
-    descriptor_fn = catalog.descriptor_fn()
 
     if spec.kind is TaskKind.KERNEL_REGRESSION:
-        return _predict_kr(model, catalog, name, comps, device, rec, pred_dir)
+        return _predict_kr(model, catalog, name, comps, device, pred_dir, with_metrics=with_metrics)
 
-    desc = descriptor_fn(comps)
+    desc = catalog.descriptor_fn()(comps)
     kept = [c for c in comps if c in desc.index]
     if not kept:
         logger.warning(f"task '{name}': no descriptors available for the prediction set.")
@@ -237,9 +232,8 @@ def _predict_task(
             pred = head(h).argmax(dim=-1).cpu().numpy()
 
     true = _true_values(frame, spec.column, kept, kind=spec.kind, catalog=catalog, name=name)
-    out = pd.DataFrame({"composition": kept, "pred": pred, "true": true})
-    out.to_parquet(pred_dir / f"{name}_pred.parquet")
-    return _metrics(spec.kind, true, pred)
+    pd.DataFrame({"composition": kept, "pred": pred, "true": true}).to_parquet(pred_dir / f"{name}_pred.parquet")
+    return _metrics(spec.kind, true, pred) if with_metrics else {}
 
 
 def _predict_kr(
@@ -248,14 +242,16 @@ def _predict_kr(
     name: str,
     comps: list[str],
     device: torch.device,
-    rec: RunRecorder,
     pred_dir: Path,
+    *,
+    with_metrics: bool,
 ) -> dict[str, float]:
     spec = catalog.task_spec(name)
     assert spec.t_column is not None
     frame = catalog.task_frames([name])[name]
     head = model.task_heads[name]
-    available = set(catalog.descriptor_fn()(comps).index)
+    desc = catalog.descriptor_fn()(comps)  # compute descriptors once and reuse for filtering + tensor
+    available = set(desc.index)
     keep: list[str] = []
     t_list: list[np.ndarray] = []
     true_parts: list[np.ndarray] = []
@@ -268,11 +264,11 @@ def _predict_kr(
             continue
         keep.append(comp)
         t_list.append(t)
-        true_parts.append(y if y.size == t.size else np.full(t.size, np.nan))
+        # Inverse-transform the true sequence too, so it matches the (inverse-transformed) preds.
+        true_parts.append(catalog.inverse_transform(name, y) if y.size == t.size else np.full(t.size, np.nan))
     if not keep:
         logger.warning(f"task '{name}': no compositions with a t-grid to predict.")
         return {}
-    desc = catalog.descriptor_fn()(keep)
     x = torch.tensor(desc.loc[keep].values, dtype=torch.float32, device=device)
     with torch.no_grad():
         h = torch.tanh(model.encoder(x))
@@ -291,7 +287,7 @@ def _predict_kr(
     long = pd.DataFrame(rows)
     long.to_parquet(pred_dir / f"{name}_pred.parquet")
     mask = ~long["true"].isna()
-    if mask.sum() >= 2:
+    if with_metrics and mask.sum() >= 2:
         return {
             "r2": float(r2_score(long.loc[mask, "true"], long.loc[mask, "pred"])),
             "mae": float(mean_absolute_error(long.loc[mask, "true"], long.loc[mask, "pred"])),

--- a/src/foundation_model/workflows/predict_test.py
+++ b/src/foundation_model/workflows/predict_test.py
@@ -1,0 +1,230 @@
+# Copyright 2025 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for :mod:`foundation_model.workflows.predict`."""
+
+from __future__ import annotations
+
+import tomllib
+
+import joblib  # type: ignore[import-untyped]
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+from sklearn.preprocessing import StandardScaler  # type: ignore[import-untyped]
+
+from foundation_model.workflows._engine import build_empty_model, build_head_config
+from foundation_model.workflows._sections import ModelSectionConfig, TrainingSectionConfig
+from foundation_model.workflows.predict import PredictConfig, build_predict_config
+from foundation_model.workflows.predict import run as predict_run
+from foundation_model.workflows.recording import RunRecorder
+from foundation_model.workflows.task_catalog import TaskCatalog, build_task_catalog_config
+
+_ELEMENTS = ["Fe", "Al", "Cu", "Ni", "Ti", "Zn", "Mg", "Ca", "Na", "Cl", "O", "Si"]
+_FORMULAS = [f"{a}2 {b}3" for i, a in enumerate(_ELEMENTS) for b in _ELEMENTS[i + 1 :]][:24]
+
+_MODEL = ModelSectionConfig(latent_dim=8, encoder_hidden=16, head_hidden_dim=8, n_kernel=4)
+_TRAIN = TrainingSectionConfig(max_epochs=1, accelerator="cpu", seed=1)
+
+
+@pytest.fixture
+def data_dir(tmp_path):
+    rng = np.random.default_rng(0)
+    a = rng.normal(size=len(_FORMULAS))
+    a[3] = np.nan  # one masked regression target
+    df = pd.DataFrame(
+        {
+            "composition": _FORMULAS,
+            "a": a,
+            "mat": rng.integers(0, 3, size=len(_FORMULAS)),
+            "split": (["train", "val", "test"] * len(_FORMULAS))[: len(_FORMULAS)],
+        }
+    )
+    df.to_parquet(tmp_path / "x.parquet")
+    return tmp_path
+
+
+def _catalog_toml(data_dir, *, scaler: str = "") -> str:
+    return f"""
+[descriptor]
+kind = "kmd"
+n_grids = 4
+
+[datasets.d1]
+path = "{data_dir / "x.parquet"}"
+
+[[tasks]]
+name = "a"
+kind = "regression"
+dataset = "d1"
+column = "a"
+{scaler}
+
+[[tasks]]
+name = "mat"
+kind = "classification"
+dataset = "d1"
+column = "mat"
+num_classes = 3
+"""
+
+
+def _catalog(data_dir) -> TaskCatalog:
+    return TaskCatalog(build_task_catalog_config(tomllib.loads(_catalog_toml(data_dir))))
+
+
+def _checkpoint(data_dir, path) -> None:
+    cat = _catalog(data_dir)
+    model = build_empty_model(cat, _MODEL, _TRAIN)
+    for name in ["a", "mat"]:
+        model.add_task(build_head_config(cat, _MODEL, _TRAIN, name))
+    torch.save({"model": model.state_dict(), "task_sequence": ["a", "mat"]}, path)
+
+
+def _predict_cfg(data_dir, out, checkpoint, *, predict_block: str, scaler: str = "") -> PredictConfig:
+    toml = (
+        _catalog_toml(data_dir, scaler=scaler)
+        + f"""
+[model]
+latent_dim = 8
+encoder_hidden = 16
+head_hidden_dim = 8
+n_kernel = 4
+
+[predict]
+{predict_block}
+
+[output]
+dir = "o"
+"""
+    )
+    return build_predict_config(tomllib.loads(toml), output_dir=str(out), checkpoint=str(checkpoint))
+
+
+def _run(cfg, out) -> dict:
+    rec = RunRecorder(out)
+    rec.write_provenance(config=cfg, argv=["fm", "predict"], seeds={"seed": 2025})
+    result = predict_run(cfg, rec)
+    rec.close()
+    return result
+
+
+# --- config validation -------------------------------------------------------------------
+
+
+def test_invalid_split_raises(data_dir) -> None:
+    with pytest.raises(ValueError, match="split must be one of"):
+        _predict_cfg(data_dir, "o", "ck.pt", predict_block='split = "bogus"')
+
+
+def test_unknown_task_raises(data_dir) -> None:
+    with pytest.raises(ValueError, match="unknown task"):
+        _predict_cfg(data_dir, "o", "ck.pt", predict_block='tasks = ["nope"]')
+
+
+def test_compositions_override_split(data_dir) -> None:
+    cfg = _predict_cfg(data_dir, "o", "ck.pt", predict_block='split = "test"\ncompositions = ["Fe2 O3"]')
+    assert cfg.compositions == ["Fe2 O3"]  # documented: compositions win over split
+
+
+# --- engine ------------------------------------------------------------------------------
+
+
+def test_predict_smoke_split_test(data_dir, tmp_path) -> None:
+    ckpt = tmp_path / "ck.pt"
+    _checkpoint(data_dir, ckpt)
+    out = tmp_path / "pred"
+    cfg = _predict_cfg(data_dir, out, ckpt, predict_block='split = "test"')
+    result = _run(cfg, out)
+
+    assert (out / "run_provenance.json").exists()
+    for task in ("a", "mat"):
+        assert (out / "predict" / f"{task}_pred.parquet").exists()
+    reg = pd.read_parquet(out / "predict" / "a_pred.parquet")
+    assert {"composition", "pred", "true"} <= set(reg.columns)
+    assert np.isfinite(reg["pred"]).all()
+    if "a" in result["metrics"]:
+        assert np.isfinite(result["metrics"]["a"]["mae"])
+
+
+def test_explicit_compositions_in_order(data_dir, tmp_path) -> None:
+    ckpt = tmp_path / "ck.pt"
+    _checkpoint(data_dir, ckpt)
+    out = tmp_path / "pred"
+    wanted = ["Fe2 O3", "Al2 O3", "Cu2 Ni3"]
+    cfg = _predict_cfg(data_dir, out, ckpt, predict_block=f'tasks = ["a"]\ncompositions = {wanted!r}')
+    _run(cfg, out)
+    reg = pd.read_parquet(out / "predict" / "a_pred.parquet")
+    assert list(reg["composition"]) == wanted  # exactly those rows, in order
+
+
+def test_head_absent_from_checkpoint_errors(data_dir, tmp_path) -> None:
+    ckpt = tmp_path / "ck.pt"
+    _checkpoint(data_dir, ckpt)  # heads a, mat only
+    out = tmp_path / "pred"
+    # Catalog holds every checkpoint task (a, mat) plus an extra head 'b' that the checkpoint
+    # lacks; requesting 'b' must error listing the available heads.
+    toml = f"""
+[descriptor]
+kind = "kmd"
+n_grids = 4
+[datasets.d1]
+path = "{data_dir / "x.parquet"}"
+[[tasks]]
+name = "a"
+kind = "regression"
+dataset = "d1"
+column = "a"
+[[tasks]]
+name = "b"
+kind = "regression"
+dataset = "d1"
+column = "a"
+[[tasks]]
+name = "mat"
+kind = "classification"
+dataset = "d1"
+column = "mat"
+num_classes = 3
+[model]
+latent_dim = 8
+encoder_hidden = 16
+head_hidden_dim = 8
+n_kernel = 4
+[predict]
+tasks = ["b"]
+[output]
+dir = "o"
+"""
+    cfg = build_predict_config(tomllib.loads(toml), output_dir=str(out), checkpoint=str(ckpt))
+    with pytest.raises(ValueError, match="not in the checkpoint"):
+        _run(cfg, out)
+
+
+def test_masked_nan_target_in_parquet_excluded_from_metrics(data_dir, tmp_path) -> None:
+    ckpt = tmp_path / "ck.pt"
+    _checkpoint(data_dir, ckpt)
+    out = tmp_path / "pred"
+    cfg = _predict_cfg(data_dir, out, ckpt, predict_block='tasks = ["a"]\nsplit = "all"')
+    result = _run(cfg, out)
+    reg = pd.read_parquet(out / "predict" / "a_pred.parquet")
+    assert reg["true"].isna().any()  # the masked row is present with true=NaN
+    if "a" in result["metrics"]:
+        # metric sample count excludes the NaN row
+        assert result["metrics"]["a"]["samples"] == int(reg["true"].notna().sum())
+
+
+def test_scaler_inverse_transform_applied(data_dir, tmp_path) -> None:
+    ckpt = tmp_path / "ck.pt"
+    _checkpoint(data_dir, ckpt)
+    scaler = StandardScaler().fit(np.array([[100.0], [150.0], [200.0], [250.0]]))  # physical-scale scaler
+    scaler_path = tmp_path / "scalers.z"
+    joblib.dump({"a": scaler}, scaler_path)
+    scaler_block = f'scaler = {{ path = "{scaler_path}", key = "a" }}'
+    out = tmp_path / "pred"
+    cfg = _predict_cfg(data_dir, out, ckpt, predict_block='tasks = ["a"]\nsplit = "all"', scaler=scaler_block)
+    _run(cfg, out)
+    reg = pd.read_parquet(out / "predict" / "a_pred.parquet")
+    # inverse-transformed predictions land on the physical (~100-250) scale, not the model's ~[-1,1].
+    assert np.nanmedian(np.abs(reg["pred"])) > 10.0

--- a/src/foundation_model/workflows/predict_test.py
+++ b/src/foundation_model/workflows/predict_test.py
@@ -215,6 +215,18 @@ def test_masked_nan_target_in_parquet_excluded_from_metrics(data_dir, tmp_path) 
         assert result["metrics"]["a"]["samples"] == int(reg["true"].notna().sum())
 
 
+def test_no_metrics_skips_metric_artifacts(data_dir, tmp_path) -> None:
+    ckpt = tmp_path / "ck.pt"
+    _checkpoint(data_dir, ckpt)
+    out = tmp_path / "pred"
+    cfg = _predict_cfg(data_dir, out, ckpt, predict_block='tasks = ["a"]\nsplit = "all"\nwith_metrics = false')
+    result = _run(cfg, out)
+    assert (out / "predict" / "a_pred.parquet").exists()  # predictions still written
+    assert not (out / "predict" / "metrics.json").exists()  # ...but no metrics artifacts
+    assert not (out / "predict" / "metrics_table.csv").exists()
+    assert result["metrics"] == {}
+
+
 def test_scaler_inverse_transform_applied(data_dir, tmp_path) -> None:
     ckpt = tmp_path / "ck.pt"
     _checkpoint(data_dir, ckpt)


### PR DESCRIPTION
## Summary

Fifth PR of the `fm` CLI refactor (stacked on #24). Replaces `fm-trainer`'s
`validate`/`test`/`predict`.

- **`workflows/predict.py`** — rebuild the checkpoint's model from the `TaskCatalog`, load with
  `strict=False` (fm-trainer semantics; missing/unexpected keys logged), resolve a prediction set
  (a split or an explicit composition list — **compositions win** when both given), batch-predict
  every requested head (or all checkpoint heads), and write `<task>_pred.parquet`
  (composition/pred/true[/t]) with per-task scaler inverse-transform. `with_metrics` → masked
  metrics (NaN/missing targets kept in the parquet, excluded from the metric) + `metrics_table.csv`.
  Single-device; the legacy distributed gather is intentionally not migrated.
- **`cli/main.py`** — `fm predict` (`--checkpoint`/`--tasks`/`--split`/`--compositions`/
  `--no-metrics`). This completes the four-subcommand CLI.

## Validation

- `fm pretrain → finetune → inverse → predict` all run on CPU on one coherent qc catalog.
- Tests: invalid split, unknown task, compositions-win, explicit-order, absent-head error, masked
  NaN excluded from metrics, scaler round-trip.
- Full suite → **460 passed, 1 skipped**; ruff/mypy clean on all new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCoVwB3pntFi25YnpoHYwY