### PR TITLE
PR7 — configurable Lightning callbacks + loggers (early-stop / checkpoint / logging)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,10 @@
   `[datasets.*]`/`[[tasks]]`/`[model]`/`[training]` shared sections normalized into validated
   `@dataclass` configs (`workflows/`), unknown keys rejected by name. `--set section.key=value`
   overrides + first-class flags (`--seed`/`--accelerator`/`--sample`/…).
+- **Configurable Lightning callbacks/loggers**: `[training.early_stopping]` / `[training.checkpoint]`
+  (Lightning `EarlyStopping` / `ModelCheckpoint`) and `[training.logging]` (`CSVLogger` /
+  `TensorBoardLogger`) — a flexible subset of each. EarlyStopping is on by default; the Lightning
+  checkpoint + loggers are opt-in so the `RunRecorder` stays the default checkpoint/log writer.
 - **Provenance on every run**: `run_provenance.json` (resolved config + package versions + git +
   argv + seeds) and `run.log`, written by `workflows/recording.py::RunRecorder` — the single
   artifact writer for the training/predict flows.

--- a/README.md
+++ b/README.md
@@ -108,8 +108,14 @@ All configs are **TOML**, normalized into validated `@dataclass` config objects 
 per-subcommand `build_*_config` builders. Configs share the `[data]` / `[descriptor]` /
 `[datasets.*]` / `[[tasks]]` / `[model]` / `[training]` sections and add one subcommand section
 (`[pretrain]` / `[finetune]` / `[inverse]` / `[predict]`). Unknown keys are rejected with the
-offending key name. See [`samples/`](samples/) for templates and `AGENTS.md` → **Entry Points**
-for the full convention.
+offending key name.
+
+Training callbacks and loggers map to Lightning's built-ins via `[training]` sub-tables (a flexible
+subset of each): `[training.early_stopping]` → `EarlyStopping` (on by default),
+`[training.checkpoint]` → `ModelCheckpoint`, and `[training.logging]` (`csv` / `tensorboard`) →
+`CSVLogger` / `TensorBoardLogger`. Lightning checkpointing/logging are opt-in; the run recorder
+writes the rehearsal-schema checkpoints + `run.log` regardless. See [`samples/`](samples/) for
+templates and `AGENTS.md` → **Entry Points** for the full convention.
 
 ## Features
 

--- a/samples/finetune.toml
+++ b/samples/finetune.toml
@@ -57,12 +57,17 @@ n_kernel = 15
 
 [training]
 max_epochs = 100
-early_stop_patience = 8
 accelerator = "auto"
 devices = 1
 seed = 2025
 head_lr = 5e-3
 ae_lr = 5e-3
+
+[training.early_stopping]
+patience = 8
+
+[training.logging]
+csv = true
 
 [finetune]
 checkpoint = "artifacts/pretrain/training/final_model.pt"

--- a/samples/finetune_smoke.toml
+++ b/samples/finetune_smoke.toml
@@ -45,12 +45,14 @@ n_kernel = 8
 
 [training]
 max_epochs = 100
-early_stop_patience = 3
 accelerator = "cpu"
 devices = 1
 seed = 2025
 head_lr = 5e-3
 ae_lr = 5e-3
+
+[training.early_stopping]
+patience = 3
 
 [finetune]
 checkpoint = "artifacts/pretrain_smoke/runs/run00/training/final_model.pt"

--- a/samples/pretrain.toml
+++ b/samples/pretrain.toml
@@ -63,8 +63,6 @@ n_kernel = 15
 
 [training]
 max_epochs = 100
-early_stop_patience = 8
-early_stop_min_delta = 1e-4
 encoder_lr = 5e-3
 head_lr = 5e-3
 kr_lr = 5e-4
@@ -73,6 +71,28 @@ ae_lr = 5e-3
 accelerator = "auto"
 devices = 1
 seed = 2025
+
+# Lightning EarlyStopping (a subset of its args; enabled by default).
+[training.early_stopping]
+enabled = true
+monitor = "val_final_loss"
+mode = "min"
+patience = 8
+min_delta = 1e-4
+
+# Lightning ModelCheckpoint (off by default — the run recorder already writes checkpoints).
+# Enable to also emit Lightning .ckpt files (per training step, under stepNN_*/lightning/).
+[training.checkpoint]
+enabled = false
+monitor = "val_final_loss"
+mode = "min"
+save_top_k = 1
+save_last = false
+
+# Lightning loggers — write metric curves under <output.dir>/logs/.
+[training.logging]
+csv = true
+tensorboard = false
 
 [pretrain]
 task_sequence = ["density", "dos_density", "power_factor", "formation_energy", "material_type"]

--- a/samples/pretrain_smoke.toml
+++ b/samples/pretrain_smoke.toml
@@ -51,8 +51,6 @@ n_kernel = 8
 
 [training]
 max_epochs = 2
-early_stop_patience = 3
-early_stop_min_delta = 1e-4
 encoder_lr = 5e-3
 head_lr = 5e-3
 kr_lr = 5e-4
@@ -60,6 +58,10 @@ ae_lr = 5e-3
 accelerator = "cpu"
 devices = 1
 seed = 2025
+
+[training.early_stopping]
+patience = 3
+min_delta = 1e-4
 
 [pretrain]
 task_sequence = ["density", "formation_energy", "material_type"]

--- a/src/foundation_model/workflows/_engine.py
+++ b/src/foundation_model/workflows/_engine.py
@@ -17,6 +17,8 @@ from typing import Any
 import numpy as np
 import pandas as pd
 import torch
+from lightning.pytorch.callbacks import Callback, EarlyStopping, ModelCheckpoint
+from lightning.pytorch.loggers import CSVLogger, Logger, TensorBoardLogger
 from sklearn.metrics import accuracy_score, f1_score, mean_absolute_error, r2_score  # type: ignore[import-untyped]
 from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
 
@@ -49,6 +51,39 @@ def build_empty_model(
     if AE_NAME in built.task_configs_map:
         built.task_configs_map[AE_NAME].optimizer = OptimizerConfig(lr=training.ae_lr)
     return built
+
+
+def build_trainer_extras(
+    training: TrainingSectionConfig, *, log_dir: Path, ckpt_dir: Path, run_name: str
+) -> tuple[list[Callback], list[Logger] | bool, bool]:
+    """Build Lightning callbacks + loggers from ``[training]`` config.
+
+    Returns ``(callbacks, logger_arg, enable_checkpointing)`` for ``Trainer(...)``. EarlyStopping is
+    on by default; ModelCheckpoint and the CSV/TensorBoard loggers are opt-in (config-driven) so the
+    default flow keeps the RunRecorder as the sole checkpoint/log writer.
+    """
+    callbacks: list[Callback] = []
+    es = training.early_stopping
+    if es.enabled:
+        callbacks.append(EarlyStopping(monitor=es.monitor, mode=es.mode, patience=es.patience, min_delta=es.min_delta))
+    ckpt = training.checkpoint
+    if ckpt.enabled:
+        callbacks.append(
+            ModelCheckpoint(
+                dirpath=str(ckpt_dir),
+                monitor=ckpt.monitor,
+                mode=ckpt.mode,
+                save_top_k=ckpt.save_top_k,
+                save_last=ckpt.save_last,
+                filename=ckpt.filename,
+            )
+        )
+    loggers: list[Logger] = []
+    if training.logging.csv:
+        loggers.append(CSVLogger(save_dir=str(log_dir), name=run_name))
+    if training.logging.tensorboard:
+        loggers.append(TensorBoardLogger(save_dir=str(log_dir), name=run_name))
+    return callbacks, (loggers or False), ckpt.enabled
 
 
 def build_head_config(

--- a/src/foundation_model/workflows/_sections.py
+++ b/src/foundation_model/workflows/_sections.py
@@ -6,8 +6,10 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
+
+_MODES = {"min", "max"}
 
 
 def reject_unknown(section: str, raw: Mapping[str, Any], known: set[str]) -> None:
@@ -33,12 +35,55 @@ class ModelSectionConfig:
 
 
 @dataclass(kw_only=True)
+class EarlyStoppingConfig:
+    """``[training.early_stopping]`` — a subset of Lightning's ``EarlyStopping``."""
+
+    enabled: bool = True
+    monitor: str = "val_final_loss"
+    mode: str = "min"
+    patience: int = 8
+    min_delta: float = 1e-4
+
+    def __post_init__(self) -> None:
+        if self.mode not in _MODES:
+            raise ValueError(f"training.early_stopping.mode must be 'min' or 'max', got {self.mode!r}.")
+        if self.patience < 1:
+            raise ValueError(f"training.early_stopping.patience must be >= 1, got {self.patience}.")
+
+
+@dataclass(kw_only=True)
+class CheckpointConfig:
+    """``[training.checkpoint]`` — a subset of Lightning's ``ModelCheckpoint``.
+
+    Off by default: the RunRecorder already writes rehearsal-schema checkpoints that the finetune/
+    inverse/predict flows consume. Enable to also emit Lightning ``.ckpt`` files (best/last).
+    """
+
+    enabled: bool = False
+    monitor: str = "val_final_loss"
+    mode: str = "min"
+    save_top_k: int = 1
+    save_last: bool = False
+    filename: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.mode not in _MODES:
+            raise ValueError(f"training.checkpoint.mode must be 'min' or 'max', got {self.mode!r}.")
+
+
+@dataclass(kw_only=True)
+class LoggingConfig:
+    """``[training.logging]`` — enable Lightning's ``CSVLogger`` / ``TensorBoardLogger``."""
+
+    csv: bool = False
+    tensorboard: bool = False
+
+
+@dataclass(kw_only=True)
 class TrainingSectionConfig:
-    """``[training]`` — epochs, early-stop, learning rates, accelerator (pretrain + finetune)."""
+    """``[training]`` — epochs, learning rates, accelerator + Lightning callbacks/loggers."""
 
     max_epochs: int = 100
-    early_stop_patience: int = 8
-    early_stop_min_delta: float = 1e-4
     encoder_lr: float = 5e-3
     head_lr: float = 5e-3
     kr_lr: float = 5e-4
@@ -47,12 +92,13 @@ class TrainingSectionConfig:
     accelerator: str = "auto"
     devices: int = 1
     seed: int = 2025
+    early_stopping: EarlyStoppingConfig = field(default_factory=EarlyStoppingConfig)
+    checkpoint: CheckpointConfig = field(default_factory=CheckpointConfig)
+    logging: LoggingConfig = field(default_factory=LoggingConfig)
 
     def __post_init__(self) -> None:
         if self.max_epochs < 1:
             raise ValueError(f"training.max_epochs must be >= 1, got {self.max_epochs}.")
-        if self.early_stop_patience < 1:
-            raise ValueError(f"training.early_stop_patience must be >= 1, got {self.early_stop_patience}.")
 
 
 def build_model_section(raw: Mapping[str, Any]) -> ModelSectionConfig:
@@ -64,4 +110,17 @@ def build_model_section(raw: Mapping[str, Any]) -> ModelSectionConfig:
 def build_training_section(raw: Mapping[str, Any]) -> TrainingSectionConfig:
     data = dict(raw)
     reject_unknown("training", data, set(TrainingSectionConfig.__dataclass_fields__))
-    return TrainingSectionConfig(**data)
+
+    es_raw = dict(data.pop("early_stopping", {}))
+    reject_unknown("training.early_stopping", es_raw, set(EarlyStoppingConfig.__dataclass_fields__))
+    ckpt_raw = dict(data.pop("checkpoint", {}))
+    reject_unknown("training.checkpoint", ckpt_raw, set(CheckpointConfig.__dataclass_fields__))
+    log_raw = dict(data.pop("logging", {}))
+    reject_unknown("training.logging", log_raw, set(LoggingConfig.__dataclass_fields__))
+
+    return TrainingSectionConfig(
+        **data,
+        early_stopping=EarlyStoppingConfig(**es_raw),
+        checkpoint=CheckpointConfig(**ckpt_raw),
+        logging=LoggingConfig(**log_raw),
+    )

--- a/src/foundation_model/workflows/finetune.py
+++ b/src/foundation_model/workflows/finetune.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import Any
 
 from lightning import Trainer, seed_everything
-from lightning.pytorch.callbacks import Callback, EarlyStopping
+from lightning.pytorch.callbacks import Callback
 from loguru import logger
 
 from ._engine import (
@@ -29,6 +29,7 @@ from ._engine import (
     DropLastTrainCompoundDataModule,
     build_empty_model,
     build_head_config,
+    build_trainer_extras,
     evaluate_task,
 )
 from ._sections import (
@@ -213,22 +214,20 @@ def run(cfg: FinetuneConfig, recorder: RunRecorder | None = None) -> dict[str, A
             for name in cfg.tasks
         }
 
-        callbacks: list[Callback] = [
-            EarlyStopping(
-                monitor="val_final_loss",
-                mode="min",
-                patience=cfg.training.early_stop_patience,
-                min_delta=cfg.training.early_stop_min_delta,
-            )
-        ]
+        callbacks, loggers, enable_ckpt = build_trainer_extras(
+            cfg.training,
+            log_dir=rec.paths.root / "logs",
+            ckpt_dir=rec.paths.training / "finetune" / "lightning",
+            run_name="finetune",
+        )
         if cfg.freeze_encoder:
             callbacks.append(_FrozenEncoderEval())  # keep frozen encoder's BatchNorm buffers fixed
         trainer = Trainer(
             max_epochs=cfg.epochs,
             accelerator=cfg.training.accelerator,
             devices=cfg.training.devices,
-            logger=False,
-            enable_checkpointing=False,
+            logger=loggers,
+            enable_checkpointing=enable_ckpt,
             enable_progress_bar=False,
             callbacks=callbacks,
         )

--- a/src/foundation_model/workflows/finetune_test.py
+++ b/src/foundation_model/workflows/finetune_test.py
@@ -13,7 +13,7 @@ import pytest
 import torch
 
 from foundation_model.workflows._engine import AE_NAME, build_empty_model, build_head_config
-from foundation_model.workflows._sections import ModelSectionConfig, TrainingSectionConfig
+from foundation_model.workflows._sections import EarlyStoppingConfig, ModelSectionConfig, TrainingSectionConfig
 from foundation_model.workflows.finetune import apply_freeze_policy, build_finetune_config
 from foundation_model.workflows.finetune import run as finetune_run
 from foundation_model.workflows.recording import RunRecorder
@@ -23,7 +23,7 @@ _ELEMENTS = ["Fe", "Al", "Cu", "Ni", "Ti", "Zn", "Mg", "Ca", "Na", "Cl", "O", "S
 _FORMULAS = [f"{a}2 {b}3" for i, a in enumerate(_ELEMENTS) for b in _ELEMENTS[i + 1 :]][:24]
 
 _MODEL = ModelSectionConfig(latent_dim=8, encoder_hidden=16, head_hidden_dim=8, n_kernel=4)
-_TRAIN = TrainingSectionConfig(max_epochs=1, early_stop_patience=2, accelerator="cpu", seed=1)
+_TRAIN = TrainingSectionConfig(max_epochs=1, early_stopping=EarlyStoppingConfig(patience=2), accelerator="cpu", seed=1)
 
 
 @pytest.fixture

--- a/src/foundation_model/workflows/pretrain.py
+++ b/src/foundation_model/workflows/pretrain.py
@@ -28,7 +28,6 @@ from typing import Any
 
 import numpy as np
 from lightning import Trainer, seed_everything
-from lightning.pytorch.callbacks import Callback, EarlyStopping
 from loguru import logger
 
 from . import plots
@@ -36,6 +35,7 @@ from ._engine import (
     DropLastTrainCompoundDataModule,
     build_empty_model,
     build_head_config,
+    build_trainer_extras,
     evaluate_task,
 )
 from ._sections import (
@@ -266,20 +266,18 @@ def _run_single(
             batch_size=cfg.catalog.data.batch_size,
             num_workers=cfg.catalog.data.num_workers,
         )
-        callbacks: list[Callback] = [
-            EarlyStopping(
-                monitor="val_final_loss",
-                mode="min",
-                patience=cfg.training.early_stop_patience,
-                min_delta=cfg.training.early_stop_min_delta,
-            )
-        ]
+        callbacks, loggers, enable_ckpt = build_trainer_extras(
+            cfg.training,
+            log_dir=recorder.paths.root / "logs",
+            ckpt_dir=recorder.paths.step_dir(step, task_name) / "lightning",
+            run_name=f"step{step:02d}_{task_name}",
+        )
         trainer = Trainer(
             max_epochs=cfg.training.max_epochs,
             accelerator=cfg.training.accelerator,
             devices=cfg.training.devices,
-            logger=False,
-            enable_checkpointing=False,
+            logger=loggers,
+            enable_checkpointing=enable_ckpt,
             enable_progress_bar=False,
             callbacks=callbacks,
         )

--- a/src/foundation_model/workflows/pretrain_test.py
+++ b/src/foundation_model/workflows/pretrain_test.py
@@ -12,6 +12,17 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from lightning.pytorch.callbacks import EarlyStopping, ModelCheckpoint
+from lightning.pytorch.loggers import CSVLogger, TensorBoardLogger
+
+from foundation_model.workflows._engine import build_trainer_extras
+from foundation_model.workflows._sections import (
+    CheckpointConfig,
+    EarlyStoppingConfig,
+    LoggingConfig,
+    TrainingSectionConfig,
+    build_training_section,
+)
 from foundation_model.workflows.pretrain import (
     active_old_tasks,
     build_pretrain_config,
@@ -182,6 +193,106 @@ interval = 1
 default_replay = 0.5
 """
     return build_pretrain_config(tomllib.loads(toml), output_dir=str(output_dir))
+
+
+# --- Lightning callbacks / loggers config ------------------------------------------------
+
+
+def test_training_subtables_parse() -> None:
+    cfg = build_training_section(
+        tomllib.loads(
+            "max_epochs = 5\n"
+            '[early_stopping]\npatience = 4\nmode = "max"\n'
+            "[checkpoint]\nenabled = true\nsave_top_k = 2\n"
+            "[logging]\ncsv = true\ntensorboard = true\n"
+        )
+    )
+    assert cfg.early_stopping.patience == 4 and cfg.early_stopping.mode == "max"
+    assert cfg.checkpoint.enabled and cfg.checkpoint.save_top_k == 2
+    assert cfg.logging.csv and cfg.logging.tensorboard
+
+
+def test_early_stopping_bad_mode_raises() -> None:
+    with pytest.raises(ValueError, match="mode must be"):
+        build_training_section(tomllib.loads('[early_stopping]\nmode = "up"'))
+
+
+def test_training_subtable_unknown_key_raises() -> None:
+    with pytest.raises(ValueError, match="save_topk"):
+        build_training_section(tomllib.loads("[checkpoint]\nsave_topk = 2"))
+
+
+def test_build_trainer_extras_default(tmp_path) -> None:
+    callbacks, loggers, enable = build_trainer_extras(
+        TrainingSectionConfig(), log_dir=tmp_path, ckpt_dir=tmp_path, run_name="r"
+    )
+    assert any(isinstance(c, EarlyStopping) for c in callbacks)  # on by default
+    assert not any(isinstance(c, ModelCheckpoint) for c in callbacks)  # opt-in
+    assert loggers is False and enable is False
+
+
+def test_build_trainer_extras_all_enabled(tmp_path) -> None:
+    training = TrainingSectionConfig(
+        early_stopping=EarlyStoppingConfig(enabled=False),
+        checkpoint=CheckpointConfig(enabled=True),
+        logging=LoggingConfig(csv=True, tensorboard=True),
+    )
+    callbacks, loggers, enable = build_trainer_extras(
+        training, log_dir=tmp_path, ckpt_dir=tmp_path / "ck", run_name="r"
+    )
+    assert not any(isinstance(c, EarlyStopping) for c in callbacks)
+    assert any(isinstance(c, ModelCheckpoint) for c in callbacks)
+    assert enable is True
+    assert isinstance(loggers, list) and len(loggers) == 2
+    assert any(isinstance(lg, CSVLogger) for lg in loggers)
+    assert any(isinstance(lg, TensorBoardLogger) for lg in loggers)
+
+
+def test_pretrain_lightning_checkpoint_and_csv_logger(smoke_dir, tmp_path) -> None:
+    out = tmp_path / "run"
+    toml = f"""
+[data]
+batch_size = 4
+
+[descriptor]
+kind = "kmd"
+n_grids = 4
+
+[datasets.d1]
+path = "{smoke_dir / "x.parquet"}"
+
+[[tasks]]
+name = "a"
+kind = "regression"
+dataset = "d1"
+column = "a"
+
+[model]
+latent_dim = 8
+encoder_hidden = 16
+head_hidden_dim = 8
+
+[training]
+max_epochs = 1
+accelerator = "cpu"
+seed = 1
+
+[training.checkpoint]
+enabled = true
+
+[training.logging]
+csv = true
+
+[pretrain]
+task_sequence = ["a"]
+"""
+    cfg = build_pretrain_config(tomllib.loads(toml), output_dir=str(out))
+    rec = RunRecorder(out)
+    rec.write_provenance(config=cfg, argv=["fm", "pretrain"], seeds={"seed": 1})
+    pretrain_run(cfg, rec)
+    rec.close()
+    assert (out / "logs").exists()  # CSVLogger wrote metric curves
+    assert list(out.glob("training/step*/lightning/*.ckpt"))  # ModelCheckpoint wrote a .ckpt
 
 
 def test_pretrain_smoke_end_to_end(smoke_dir, tmp_path) -> None:

--- a/src/foundation_model/workflows/recording.py
+++ b/src/foundation_model/workflows/recording.py
@@ -212,6 +212,21 @@ class RunRecorder:
             self._log_sink_id = None
 
 
+def _fold_disabled_heads(state_dict: Mapping[str, Any]) -> dict[str, Any]:
+    """Fold ``disabled_task_heads.<name>.*`` → ``task_heads.<name>.*`` so a checkpoint saved while
+    some heads were disabled (e.g. a mid-fit finetune ``ModelCheckpoint``) still loads every head.
+
+    A head is either active or disabled, never both, so an existing active head is never clobbered
+    (``setdefault``). No-op for checkpoints without disabled heads (pretrain / final RunRecorder).
+    """
+    _PREFIX = "disabled_task_heads."
+    folded: dict[str, Any] = {k: v for k, v in state_dict.items() if not k.startswith(_PREFIX)}
+    for key, value in state_dict.items():
+        if key.startswith(_PREFIX):
+            folded.setdefault("task_heads." + key[len(_PREFIX) :], value)
+    return folded
+
+
 def load_checkpoint_state(path: Path) -> dict[str, Any]:
     """Load a checkpoint and normalize to ``{"model": state_dict, "task_sequence": list|None, ...}``.
 
@@ -220,16 +235,20 @@ def load_checkpoint_state(path: Path) -> dict[str, Any]:
     2. a Lightning checkpoint — ``{"state_dict": ..., "epoch": ..., ...}`` (fm-trainer era,
        ``ModelCheckpoint`` output): the parameters live under ``state_dict``, so unwrap it;
     3. a bare ``state_dict`` (an ``OrderedDict`` of parameter tensors).
+
+    In all cases ``disabled_task_heads.*`` params are folded back onto ``task_heads.*`` so a
+    checkpoint saved with some heads disabled remains fully loadable downstream.
     """
 
     # weights_only=True hardens against arbitrary-code execution from untrusted checkpoints.
     obj = torch.load(Path(path), map_location="cpu", weights_only=True)
     if isinstance(obj, Mapping) and "model" in obj and isinstance(obj["model"], Mapping):
         normalized = dict(obj)
+        normalized["model"] = _fold_disabled_heads(obj["model"])
         normalized.setdefault("task_sequence", None)
         return normalized
     if isinstance(obj, Mapping) and "state_dict" in obj and isinstance(obj["state_dict"], Mapping):
         # Lightning checkpoint: parameters are nested under "state_dict".
-        return {"model": obj["state_dict"], "task_sequence": obj.get("task_sequence")}
+        return {"model": _fold_disabled_heads(obj["state_dict"]), "task_sequence": obj.get("task_sequence")}
     # Bare state_dict (OrderedDict of param tensors).
-    return {"model": obj, "task_sequence": None}
+    return {"model": _fold_disabled_heads(obj), "task_sequence": None}

--- a/src/foundation_model/workflows/recording_test.py
+++ b/src/foundation_model/workflows/recording_test.py
@@ -91,6 +91,22 @@ def test_load_checkpoint_state_normalizes_bare_state_dict(tmp_path) -> None:
     assert "linear.weight" in state["model"]
 
 
+def test_load_checkpoint_state_folds_disabled_heads(tmp_path) -> None:
+    # A checkpoint saved while head 'b' was disabled stores it under disabled_task_heads.*;
+    # load_checkpoint_state must fold it back onto task_heads.* so downstream loads every head.
+    sd = {
+        "encoder.shared.0.weight": torch.zeros(2),
+        "task_heads.a.net.weight": torch.zeros(2),
+        "disabled_task_heads.b.net.weight": torch.ones(2),
+    }
+    ckpt = tmp_path / "disabled.pt"
+    torch.save({"model": sd, "task_sequence": None}, ckpt)
+    keys = set(load_checkpoint_state(ckpt)["model"])
+    assert "task_heads.b.net.weight" in keys  # folded onto task_heads
+    assert "disabled_task_heads.b.net.weight" not in keys
+    assert {"task_heads.a.net.weight", "encoder.shared.0.weight"} <= keys  # others untouched
+
+
 def test_load_checkpoint_state_unwraps_lightning_checkpoint(tmp_path) -> None:
     model = _TinyModel()
     ckpt = tmp_path / "epoch=2.ckpt"


### PR DESCRIPTION
## Summary

Follow-up to the `fm` CLI stack (stacked on #26). Makes early stopping, checkpointing, and logging
config-driven via Lightning's **built-in** callbacks/loggers, replacing the hardcoded `EarlyStopping`
and the custom-only checkpoint/logging.

### Before
- Early stopping: hardcoded `EarlyStopping(monitor="val_final_loss", …)`, only `patience`/`min_delta`
  configurable (`[training].early_stop_*`).
- Checkpointing: `enable_checkpointing=False` — `RunRecorder` only.
- Logging: `logger=False` — loguru `run.log` only.

### After — `[training]` sub-tables (a flexible subset of each Lightning class)
```toml
[training.early_stopping]   # → EarlyStopping (on by default)
enabled = true
monitor = "val_final_loss"
mode = "min"
patience = 8
min_delta = 1e-4

[training.checkpoint]       # → ModelCheckpoint (opt-in; .ckpt under the step/finetune dir)
enabled = false
monitor = "val_final_loss"
mode = "min"
save_top_k = 1
save_last = false

[training.logging]          # → CSVLogger / TensorBoardLogger, under <output.dir>/logs/
csv = true
tensorboard = false
```

Lightning checkpoint/loggers are **opt-in** so `RunRecorder` stays the default writer for the
rehearsal-schema checkpoints the finetune/inverse/predict flows consume. Wired through a shared
`_engine.build_trainer_extras(...)` used by both the pretrain and finetune engines; the flat
`[training].early_stop_*` keys are replaced by `[training.early_stopping]`.

## Validation

- New tests: sub-table parsing + validation (bad `mode`, unknown key), `build_trainer_extras`
  (default vs all-enabled), and a pretrain smoke asserting a `.ckpt` under `stepNN_*/lightning/`
  and a `logs/` dir from the CSV logger.
- Full suite → **367 passed**; ruff/mypy clean; the CLI smoke chain runs on the restructured configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCoVwB3pntFi25YnpoHYwY