### PR TITLE
PR8 — configurable model architecture ([model] defaults + per-task overrides)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,12 @@
   `[datasets.*]`/`[[tasks]]`/`[model]`/`[training]` shared sections normalized into validated
   `@dataclass` configs (`workflows/`), unknown keys rejected by name. `--set section.key=value`
   overrides + first-class flags (`--seed`/`--accelerator`/`--sample`/…).
+- **Configurable model architecture**: `[model]` sets depth + per-layer widths via `*_hidden_dims`
+  lists (`encoder_hidden_dims`, `head_hidden_dims`, `kr_x_hidden_dims`, `kr_t_hidden_dims`,
+  `n_kernel`) — the input (descriptor width / `latent_dim`) is prepended and the output appended.
+  Each `[[tasks]]` may override its own head (`hidden_dims` for reg/clf; `x_hidden_dims` /
+  `t_hidden_dims` / `n_kernel` for KR), falling back to the `[model]` defaults. Replaces the fixed
+  single-hidden-layer `encoder_hidden` / `head_hidden_dim` scalars.
 - **Configurable Lightning callbacks/loggers**: `[training.early_stopping]` / `[training.checkpoint]`
   (Lightning `EarlyStopping` / `ModelCheckpoint`) and `[training.logging]` (`CSVLogger` /
   `TensorBoardLogger`) — a flexible subset of each. EarlyStopping is on by default; the Lightning

--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ per-subcommand `build_*_config` builders. Configs share the `[data]` / `[descrip
 (`[pretrain]` / `[finetune]` / `[inverse]` / `[predict]`). Unknown keys are rejected with the
 offending key name.
 
+`[model]` sets the network depth + per-layer widths as `*_hidden_dims` lists — the interior hidden
+widths, with the input (descriptor width for the encoder, `latent_dim` for the heads) prepended and
+the output (1 / `num_classes` / kernel projection) appended. So `encoder_hidden_dims = [512, 256]`
+builds `descriptor_dim → 512 → 256 → latent_dim`. Defaults: `encoder_hidden_dims`, `head_hidden_dims`
+(reg/clf), `kr_x_hidden_dims` / `kr_t_hidden_dims` / `n_kernel` (KR). Any `[[tasks]]` entry may
+override its own head — `hidden_dims` for reg/clf, `x_hidden_dims` / `t_hidden_dims` / `n_kernel` for
+KR — falling back to the `[model]` defaults when unset.
+
 Training callbacks and loggers map to Lightning's built-ins via `[training]` sub-tables (a flexible
 subset of each): `[training.early_stopping]` → `EarlyStopping` (on by default),
 `[training.checkpoint]` → `ModelCheckpoint`, and `[training.logging]` (`csv` / `tensorboard`) →

--- a/samples/finetune.toml
+++ b/samples/finetune.toml
@@ -51,8 +51,8 @@ num_classes = 5
 
 [model]
 latent_dim = 128
-encoder_hidden = 256
-head_hidden_dim = 64
+encoder_hidden_dims = [256]
+head_hidden_dims = [64]
 n_kernel = 15
 
 [training]

--- a/samples/finetune_smoke.toml
+++ b/samples/finetune_smoke.toml
@@ -39,8 +39,8 @@ num_classes = 5
 
 [model]
 latent_dim = 32
-encoder_hidden = 64
-head_hidden_dim = 32
+encoder_hidden_dims = [64]
+head_hidden_dims = [32]
 n_kernel = 8
 
 [training]

--- a/samples/inverse.toml
+++ b/samples/inverse.toml
@@ -52,8 +52,8 @@ num_classes = 5
 
 [model]
 latent_dim = 128
-encoder_hidden = 256
-head_hidden_dim = 64
+encoder_hidden_dims = [256]
+head_hidden_dims = [64]
 n_kernel = 15
 
 [inverse]

--- a/samples/inverse_smoke.toml
+++ b/samples/inverse_smoke.toml
@@ -40,8 +40,8 @@ num_classes = 5
 
 [model]
 latent_dim = 32
-encoder_hidden = 64
-head_hidden_dim = 32
+encoder_hidden_dims = [64]
+head_hidden_dims = [32]
 n_kernel = 8
 
 [inverse]

--- a/samples/predict.toml
+++ b/samples/predict.toml
@@ -51,8 +51,8 @@ num_classes = 5
 
 [model]
 latent_dim = 128
-encoder_hidden = 256
-head_hidden_dim = 64
+encoder_hidden_dims = [256]
+head_hidden_dims = [64]
 n_kernel = 15
 
 [predict]

--- a/samples/predict_smoke.toml
+++ b/samples/predict_smoke.toml
@@ -39,8 +39,8 @@ num_classes = 5
 
 [model]
 latent_dim = 32
-encoder_hidden = 64
-head_hidden_dim = 32
+encoder_hidden_dims = [64]
+head_hidden_dims = [32]
 n_kernel = 8
 
 [predict]

--- a/samples/pretrain.toml
+++ b/samples/pretrain.toml
@@ -40,6 +40,10 @@ kind = "kernel_regression"
 dataset = "qc"
 column = "DOS density (normalized)"
 t_column = "DOS energy"
+# Per-task architecture overrides win over the [model] defaults below (unset → default):
+x_hidden_dims = [256, 128]   # value branch: latent_dim -> 256 -> 128
+t_hidden_dims = [32, 16]     # coordinate branch: t -> 32 -> 16
+n_kernel = 20
 
 [[tasks]]
 name = "power_factor"
@@ -55,11 +59,17 @@ dataset = "qc"
 column = "Material type (label)"
 num_classes = 5
 
+# Model architecture. The *_hidden_dims lists are the HIDDEN layer widths; the input
+# (descriptor width for the encoder, latent_dim for the heads) is prepended automatically and
+# the output (1 / num_classes / kernel projection) is appended. Each [[tasks]] may override its
+# own head via hidden_dims (reg/clf) or x_hidden_dims / t_hidden_dims / n_kernel (KR).
 [model]
 latent_dim = 128
-encoder_hidden = 256
-head_hidden_dim = 64
-n_kernel = 15
+encoder_hidden_dims = [256]      # encoder: descriptor_dim -> 256 -> latent_dim
+head_hidden_dims = [64]          # reg/clf heads: latent_dim -> 64 -> out
+kr_x_hidden_dims = [128, 64]     # KR value branch default: latent_dim -> 128 -> 64
+kr_t_hidden_dims = [16, 8]       # KR coordinate branch default: t -> 16 -> 8
+n_kernel = 15                    # KR kernel centers default
 
 [training]
 max_epochs = 100

--- a/samples/pretrain_smoke.toml
+++ b/samples/pretrain_smoke.toml
@@ -45,8 +45,8 @@ num_classes = 5
 
 [model]
 latent_dim = 32
-encoder_hidden = 64
-head_hidden_dim = 32
+encoder_hidden_dims = [64]
+head_hidden_dims = [32]
 n_kernel = 8
 
 [training]

--- a/src/foundation_model/workflows/_engine.py
+++ b/src/foundation_model/workflows/_engine.py
@@ -37,19 +37,52 @@ AE_NAME = "__reconstruction__"
 _HEAD_WEIGHT_DECAY = 1e-5
 
 
+def build_encoder_config(model: ModelSectionConfig, descriptor_dim: int) -> MLPEncoderConfig:
+    """MLP encoder ``descriptor_dim → *encoder_hidden_dims → latent_dim`` from ``[model]``."""
+    return MLPEncoderConfig(hidden_dims=[descriptor_dim, *model.encoder_hidden_dims, model.latent_dim])
+
+
 def build_empty_model(
     catalog: TaskCatalog, model: ModelSectionConfig, training: TrainingSectionConfig
 ) -> FlexibleMultiTaskModel:
     """Bare model (AE head only). The AE always trains; only ``ae_lr`` is configurable."""
-    encoder_config = MLPEncoderConfig(hidden_dims=[catalog.descriptor_dim, model.encoder_hidden, model.latent_dim])
     built = FlexibleMultiTaskModel(
         task_configs=[],
-        encoder_config=encoder_config,
+        encoder_config=build_encoder_config(model, catalog.descriptor_dim),
         enable_autoencoder=True,
         shared_block_optimizer=OptimizerConfig(lr=training.encoder_lr, weight_decay=1e-2),
     )
     if AE_NAME in built.task_configs_map:
         built.task_configs_map[AE_NAME].optimizer = OptimizerConfig(lr=training.ae_lr)
+    return built
+
+
+def build_model_for_checkpoint(
+    catalog: TaskCatalog, model: ModelSectionConfig, task_names: list[str], *, lr: float = 5e-3
+) -> FlexibleMultiTaskModel:
+    """AE-enabled model with one head per checkpoint task, ready for ``load_state_dict``.
+
+    Shared by ``fm predict`` / ``fm inverse``, which only need the architecture to match the
+    checkpoint (weights are then loaded); ``lr`` is a placeholder as no optimization runs.
+    """
+    built = FlexibleMultiTaskModel(
+        task_configs=[],
+        encoder_config=build_encoder_config(model, catalog.descriptor_dim),
+        enable_autoencoder=True,
+        shared_block_optimizer=OptimizerConfig(lr=lr, weight_decay=1e-2),
+    )
+    for name in task_names:
+        built.add_task(
+            catalog.build_task_config(
+                name,
+                latent_dim=model.latent_dim,
+                head_hidden_dims=model.head_hidden_dims,
+                kr_x_hidden_dims=model.kr_x_hidden_dims,
+                kr_t_hidden_dims=model.kr_t_hidden_dims,
+                n_kernel=model.n_kernel,
+                lr=lr,
+            )
+        )
     return built
 
 
@@ -104,7 +137,9 @@ def build_head_config(
     return catalog.build_task_config(
         name,
         latent_dim=model.latent_dim,
-        head_hidden_dim=model.head_hidden_dim,
+        head_hidden_dims=model.head_hidden_dims,
+        kr_x_hidden_dims=model.kr_x_hidden_dims,
+        kr_t_hidden_dims=model.kr_t_hidden_dims,
         n_kernel=model.n_kernel,
         lr=lr,
         weight_decay=weight_decay,

--- a/src/foundation_model/workflows/_sections.py
+++ b/src/foundation_model/workflows/_sections.py
@@ -19,19 +19,51 @@ def reject_unknown(section: str, raw: Mapping[str, Any], known: set[str]) -> Non
         raise ValueError(f"[{section}]: unknown key(s) {unknown}; allowed keys are {sorted(known)}.")
 
 
+def validate_hidden_dims(where: str, dims: Any, *, allow_empty: bool = False) -> None:
+    """Validate a hidden-layer width list: a (possibly empty) list of positive ints.
+
+    Shared by ``[model]`` (``ModelSectionConfig``) and the per-task ``[[tasks]]`` overrides so both
+    reject e.g. ``[0]``, ``[1.5]``, ``[true]`` or a bare int with the same message.
+    """
+    if not isinstance(dims, list):
+        raise ValueError(f"{where} must be a list of positive ints, got {dims!r}.")
+    if not dims and not allow_empty:
+        raise ValueError(f"{where} must have at least one hidden layer.")
+    for d in dims:
+        if isinstance(d, bool) or not isinstance(d, int) or d < 1:
+            raise ValueError(f"{where} must be a list of positive ints, got {dims!r}.")
+
+
 @dataclass(kw_only=True)
 class ModelSectionConfig:
-    """``[model]`` — architecture dims shared by pretrain and finetune."""
+    """``[model]`` — architecture defaults shared by every subcommand.
+
+    The ``*_hidden_dims`` lists are the *hidden* layer widths; the input dim (descriptor width for
+    the encoder, ``latent_dim`` for the heads) is prepended automatically, and the output dim (1 for
+    regression, ``num_classes`` for classification, the kernel projection for KR) is appended. So
+    ``encoder_hidden_dims = [256]`` builds ``descriptor_dim → 256 → latent_dim``. Each ``[[tasks]]``
+    entry may override its own head's dims (``hidden_dims`` for reg/clf; ``x_hidden_dims`` /
+    ``t_hidden_dims`` / ``n_kernel`` for KR); unset tasks fall back to these defaults.
+    """
 
     latent_dim: int = 128
-    encoder_hidden: int = 256
-    head_hidden_dim: int = 64
+    encoder_hidden_dims: list[int] = field(default_factory=lambda: [256])
+    head_hidden_dims: list[int] = field(default_factory=lambda: [64])
+    kr_x_hidden_dims: list[int] = field(default_factory=lambda: [128, 64])
+    kr_t_hidden_dims: list[int] = field(default_factory=lambda: [16, 8])
     n_kernel: int = 15
 
     def __post_init__(self) -> None:
-        for name in ("latent_dim", "encoder_hidden", "head_hidden_dim", "n_kernel"):
-            if getattr(self, name) < 1:
-                raise ValueError(f"model.{name} must be >= 1, got {getattr(self, name)}.")
+        if self.latent_dim < 1:
+            raise ValueError(f"model.latent_dim must be >= 1, got {self.latent_dim}.")
+        if self.n_kernel < 1:
+            raise ValueError(f"model.n_kernel must be >= 1, got {self.n_kernel}.")
+        # encoder_hidden_dims may be empty (a shallow descriptor_dim → latent_dim encoder); the head
+        # branches need at least one hidden layer.
+        validate_hidden_dims("model.encoder_hidden_dims", self.encoder_hidden_dims, allow_empty=True)
+        validate_hidden_dims("model.head_hidden_dims", self.head_hidden_dims)
+        validate_hidden_dims("model.kr_x_hidden_dims", self.kr_x_hidden_dims)
+        validate_hidden_dims("model.kr_t_hidden_dims", self.kr_t_hidden_dims)
 
 
 @dataclass(kw_only=True)

--- a/src/foundation_model/workflows/_sections.py
+++ b/src/foundation_model/workflows/_sections.py
@@ -19,6 +19,16 @@ def reject_unknown(section: str, raw: Mapping[str, Any], known: set[str]) -> Non
         raise ValueError(f"[{section}]: unknown key(s) {unknown}; allowed keys are {sorted(known)}.")
 
 
+def validate_positive_int(where: str, value: Any) -> None:
+    """Require a positive ``int`` (``bool`` rejected — it is an ``int`` subclass).
+
+    Guards config fields fed to int-only APIs (e.g. ``np.linspace`` kernel counts, layer dims) so a
+    TOML float like ``128.5`` / ``10.0`` fails at config time instead of being silently coerced.
+    """
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{where} must be a positive int, got {value!r}.")
+
+
 def validate_hidden_dims(where: str, dims: Any, *, allow_empty: bool = False) -> None:
     """Validate a hidden-layer width list: a (possibly empty) list of positive ints.
 
@@ -54,10 +64,8 @@ class ModelSectionConfig:
     n_kernel: int = 15
 
     def __post_init__(self) -> None:
-        if self.latent_dim < 1:
-            raise ValueError(f"model.latent_dim must be >= 1, got {self.latent_dim}.")
-        if self.n_kernel < 1:
-            raise ValueError(f"model.n_kernel must be >= 1, got {self.n_kernel}.")
+        validate_positive_int("model.latent_dim", self.latent_dim)
+        validate_positive_int("model.n_kernel", self.n_kernel)
         # encoder_hidden_dims may be empty (a shallow descriptor_dim → latent_dim encoder); the head
         # branches need at least one hidden layer.
         validate_hidden_dims("model.encoder_hidden_dims", self.encoder_hidden_dims, allow_empty=True)

--- a/src/foundation_model/workflows/finetune_test.py
+++ b/src/foundation_model/workflows/finetune_test.py
@@ -22,7 +22,7 @@ from foundation_model.workflows.task_catalog import TaskCatalog, build_task_cata
 _ELEMENTS = ["Fe", "Al", "Cu", "Ni", "Ti", "Zn", "Mg", "Ca", "Na", "Cl", "O", "Si"]
 _FORMULAS = [f"{a}2 {b}3" for i, a in enumerate(_ELEMENTS) for b in _ELEMENTS[i + 1 :]][:24]
 
-_MODEL = ModelSectionConfig(latent_dim=8, encoder_hidden=16, head_hidden_dim=8, n_kernel=4)
+_MODEL = ModelSectionConfig(latent_dim=8, encoder_hidden_dims=[16], head_hidden_dims=[8], n_kernel=4)
 _TRAIN = TrainingSectionConfig(max_epochs=1, early_stopping=EarlyStoppingConfig(patience=2), accelerator="cpu", seed=1)
 
 
@@ -93,8 +93,8 @@ def _finetune_cfg(data_dir, out, *, checkpoint, tasks, add_new_tasks=True, epoch
         + f"""
 [model]
 latent_dim = 8
-encoder_hidden = 16
-head_hidden_dim = 8
+encoder_hidden_dims = [16]
+head_hidden_dims = [8]
 n_kernel = 4
 
 [training]

--- a/src/foundation_model/workflows/inverse.py
+++ b/src/foundation_model/workflows/inverse.py
@@ -33,10 +33,10 @@ import torch  # noqa: E402
 from lightning import seed_everything  # noqa: E402
 from loguru import logger  # noqa: E402
 
-from foundation_model.models.model_config import MLPEncoderConfig, OptimizerConfig  # noqa: E402
 from foundation_model.utils.kmd_plus import DEFAULT_ELEMENTS, formula_to_composition  # noqa: E402
 
 from . import inverse_trajectory  # noqa: E402
+from ._engine import build_model_for_checkpoint  # noqa: E402
 from ._sections import ModelSectionConfig, build_model_section, reject_unknown  # noqa: E402
 from .plots import DISCOVERED_ELEMENT_COLOR, SCATTER_COLOR  # noqa: E402
 from .recording import RunRecorder, load_checkpoint_state  # noqa: E402
@@ -388,8 +388,6 @@ def _element_system(composition: str) -> frozenset[str]:
 
 
 def _rebuild_model(cfg: InverseConfig, catalog: TaskCatalog) -> tuple[Any, list[str]]:
-    from foundation_model.models.flexible_multi_task_model import FlexibleMultiTaskModel
-
     state = load_checkpoint_state(cfg.checkpoint)
     ckpt_tasks = list(state.get("task_sequence") or _task_names_from_state(state["model"]))
     catalog_tasks = {t.name for t in cfg.catalog.tasks}
@@ -397,25 +395,7 @@ def _rebuild_model(cfg: InverseConfig, catalog: TaskCatalog) -> tuple[Any, list[
     if missing:
         raise ValueError(f"checkpoint tasks {missing} are not in the catalog (have {sorted(catalog_tasks)}).")
 
-    encoder_config = MLPEncoderConfig(
-        hidden_dims=[catalog.descriptor_dim, cfg.model.encoder_hidden, cfg.model.latent_dim]
-    )
-    model = FlexibleMultiTaskModel(
-        task_configs=[],
-        encoder_config=encoder_config,
-        enable_autoencoder=True,
-        shared_block_optimizer=OptimizerConfig(lr=5e-3, weight_decay=1e-2),
-    )
-    for name in ckpt_tasks:
-        model.add_task(
-            catalog.build_task_config(
-                name,
-                latent_dim=cfg.model.latent_dim,
-                head_hidden_dim=cfg.model.head_hidden_dim,
-                n_kernel=cfg.model.n_kernel,
-                lr=5e-3,
-            )
-        )
+    model = build_model_for_checkpoint(catalog, cfg.model, ckpt_tasks)
     model.load_state_dict(state["model"], strict=False)
     model.eval()
     return model, ckpt_tasks

--- a/src/foundation_model/workflows/inverse_test.py
+++ b/src/foundation_model/workflows/inverse_test.py
@@ -34,7 +34,7 @@ from foundation_model.workflows.task_catalog import TaskCatalog, build_task_cata
 _ELEMENTS = ["Fe", "Al", "Cu", "Ni", "Ti", "Zn", "Mg", "Ca", "Na", "Cl", "O", "Si", "K", "Mn"]
 _FORMULAS = [f"{a}2 {b}3" for i, a in enumerate(_ELEMENTS) for b in _ELEMENTS[i + 1 :]][:30]
 
-_MODEL = ModelSectionConfig(latent_dim=8, encoder_hidden=16, head_hidden_dim=8, n_kernel=4)
+_MODEL = ModelSectionConfig(latent_dim=8, encoder_hidden_dims=[16], head_hidden_dims=[8], n_kernel=4)
 _TRAIN = TrainingSectionConfig(max_epochs=1, accelerator="cpu", seed=1)
 
 
@@ -139,8 +139,8 @@ def _inverse_cfg(data_dir, out, checkpoint, *, animation: str = "[]") -> Inverse
         + f"""
 [model]
 latent_dim = 8
-encoder_hidden = 16
-head_hidden_dim = 8
+encoder_hidden_dims = [16]
+head_hidden_dims = [8]
 n_kernel = 4
 
 [inverse]

--- a/src/foundation_model/workflows/predict.py
+++ b/src/foundation_model/workflows/predict.py
@@ -26,9 +26,8 @@ from loguru import logger
 from sklearn.metrics import accuracy_score, f1_score, mean_absolute_error, r2_score  # type: ignore[import-untyped]
 
 from foundation_model.data.composition_sources import canonical_key, normalize_composition
-from foundation_model.models.model_config import MLPEncoderConfig, OptimizerConfig
 
-from ._engine import AE_NAME, as_float_array
+from ._engine import AE_NAME, as_float_array, build_model_for_checkpoint
 from ._sections import ModelSectionConfig, build_model_section, reject_unknown
 from .recording import RunRecorder, load_checkpoint_state
 from .task_catalog import TaskCatalog, TaskCatalogConfig, TaskKind, build_task_catalog_config
@@ -142,8 +141,6 @@ def run(cfg: PredictConfig, recorder: RunRecorder | None = None) -> dict[str, An
 
 
 def _rebuild_model(cfg: PredictConfig, catalog: TaskCatalog) -> tuple[Any, list[str]]:
-    from foundation_model.models.flexible_multi_task_model import FlexibleMultiTaskModel
-
     state = load_checkpoint_state(cfg.checkpoint)
     ckpt_tasks = list(state.get("task_sequence") or _task_names_from_state(state["model"]))
     catalog_tasks = {t.name for t in cfg.catalog.tasks}
@@ -151,25 +148,7 @@ def _rebuild_model(cfg: PredictConfig, catalog: TaskCatalog) -> tuple[Any, list[
     if missing:
         raise ValueError(f"checkpoint tasks {missing} are not in the catalog (have {sorted(catalog_tasks)}).")
 
-    encoder_config = MLPEncoderConfig(
-        hidden_dims=[catalog.descriptor_dim, cfg.model.encoder_hidden, cfg.model.latent_dim]
-    )
-    model = FlexibleMultiTaskModel(
-        task_configs=[],
-        encoder_config=encoder_config,
-        enable_autoencoder=True,
-        shared_block_optimizer=OptimizerConfig(lr=5e-3, weight_decay=1e-2),
-    )
-    for name in ckpt_tasks:
-        model.add_task(
-            catalog.build_task_config(
-                name,
-                latent_dim=cfg.model.latent_dim,
-                head_hidden_dim=cfg.model.head_hidden_dim,
-                n_kernel=cfg.model.n_kernel,
-                lr=5e-3,
-            )
-        )
+    model = build_model_for_checkpoint(catalog, cfg.model, ckpt_tasks)
     incompatible = model.load_state_dict(state["model"], strict=False)
     if incompatible.missing_keys:
         logger.info(f"load_state_dict missing keys ({len(incompatible.missing_keys)}): {incompatible.missing_keys[:8]}")

--- a/src/foundation_model/workflows/predict_test.py
+++ b/src/foundation_model/workflows/predict_test.py
@@ -24,7 +24,7 @@ from foundation_model.workflows.task_catalog import TaskCatalog, build_task_cata
 _ELEMENTS = ["Fe", "Al", "Cu", "Ni", "Ti", "Zn", "Mg", "Ca", "Na", "Cl", "O", "Si"]
 _FORMULAS = [f"{a}2 {b}3" for i, a in enumerate(_ELEMENTS) for b in _ELEMENTS[i + 1 :]][:24]
 
-_MODEL = ModelSectionConfig(latent_dim=8, encoder_hidden=16, head_hidden_dim=8, n_kernel=4)
+_MODEL = ModelSectionConfig(latent_dim=8, encoder_hidden_dims=[16], head_hidden_dims=[8], n_kernel=4)
 _TRAIN = TrainingSectionConfig(max_epochs=1, accelerator="cpu", seed=1)
 
 
@@ -88,8 +88,8 @@ def _predict_cfg(data_dir, out, checkpoint, *, predict_block: str, scaler: str =
         + f"""
 [model]
 latent_dim = 8
-encoder_hidden = 16
-head_hidden_dim = 8
+encoder_hidden_dims = [16]
+head_hidden_dims = [8]
 n_kernel = 4
 
 [predict]
@@ -189,8 +189,8 @@ column = "mat"
 num_classes = 3
 [model]
 latent_dim = 8
-encoder_hidden = 16
-head_hidden_dim = 8
+encoder_hidden_dims = [16]
+head_hidden_dims = [8]
 n_kernel = 4
 [predict]
 tasks = ["b"]

--- a/src/foundation_model/workflows/pretrain_test.py
+++ b/src/foundation_model/workflows/pretrain_test.py
@@ -176,8 +176,8 @@ column = "b"
 
 [model]
 latent_dim = 8
-encoder_hidden = 16
-head_hidden_dim = 8
+encoder_hidden_dims = [16]
+head_hidden_dims = [8]
 n_kernel = 4
 
 [training]
@@ -269,8 +269,8 @@ column = "a"
 
 [model]
 latent_dim = 8
-encoder_hidden = 16
-head_hidden_dim = 8
+encoder_hidden_dims = [16]
+head_hidden_dims = [8]
 
 [training]
 max_epochs = 1
@@ -346,8 +346,8 @@ column = "b"
 
 [model]
 latent_dim = 8
-encoder_hidden = 16
-head_hidden_dim = 8
+encoder_hidden_dims = [16]
+head_hidden_dims = [8]
 
 [training]
 max_epochs = 1

--- a/src/foundation_model/workflows/pretrain_test.py
+++ b/src/foundation_model/workflows/pretrain_test.py
@@ -21,6 +21,7 @@ from foundation_model.workflows._sections import (
     EarlyStoppingConfig,
     LoggingConfig,
     TrainingSectionConfig,
+    build_model_section,
     build_training_section,
 )
 from foundation_model.workflows.pretrain import (
@@ -196,6 +197,17 @@ default_replay = 0.5
 
 
 # --- Lightning callbacks / loggers config ------------------------------------------------
+
+
+def test_model_section_rejects_non_int_dims() -> None:
+    # TOML floats (128.5 / 10.0) must fail at config time, not silently coerce downstream.
+    with pytest.raises(ValueError, match="positive int"):
+        build_model_section({"latent_dim": 128.5})
+    with pytest.raises(ValueError, match="positive int"):
+        build_model_section({"n_kernel": 10.0})
+    # hidden-dims lists reject non-positive / non-int entries too.
+    with pytest.raises(ValueError, match="positive ints"):
+        build_model_section({"encoder_hidden_dims": [16, 0]})
 
 
 def test_training_subtables_parse() -> None:

--- a/src/foundation_model/workflows/task_catalog.py
+++ b/src/foundation_model/workflows/task_catalog.py
@@ -50,6 +50,8 @@ from foundation_model.models.model_config import (
 )
 from foundation_model.utils.kmd_plus import DEFAULT_ELEMENTS, KMD, element_features, formula_to_composition
 
+from ._sections import validate_hidden_dims
+
 TaskConfig = RegressionTaskConfig | ClassificationTaskConfig | KernelRegressionTaskConfig
 
 # A composition key element token, e.g. "Fe" / "Cu" in "Fe0.5 Cu0.5".
@@ -155,6 +157,11 @@ class TaskSpec:
     lr: float | None = None  # per-task LR override
     replay: float | int | None = None  # per-task rehearsal override (fraction or count)
     scaler: ScalerSpec | None = None
+    # Per-head architecture overrides (fall back to [model] defaults when None).
+    hidden_dims: list[int] | None = None  # reg/clf hidden widths
+    x_hidden_dims: list[int] | None = None  # kernel_regression value-branch hidden widths
+    t_hidden_dims: list[int] | None = None  # kernel_regression coordinate-branch hidden widths
+    n_kernel: int | None = None  # kernel_regression kernel-center count
 
     def __post_init__(self) -> None:
         self.kind = _coerce_task_kind(self.kind)
@@ -170,6 +177,24 @@ class TaskSpec:
         elif self.num_classes is not None:
             raise ValueError(f"Task '{self.name}': 'num_classes' is only valid for classification.")
         _validate_replay(self.replay, where=f"Task '{self.name}'")
+        self._validate_arch_overrides()
+
+    def _validate_arch_overrides(self) -> None:
+        is_kr = self.kind is TaskKind.KERNEL_REGRESSION
+        if self.hidden_dims is not None:
+            if is_kr:
+                raise ValueError(f"Task '{self.name}': 'hidden_dims' is for reg/clf; use x_hidden_dims/t_hidden_dims.")
+            validate_hidden_dims(f"Task '{self.name}'.hidden_dims", self.hidden_dims)
+        for field_name in ("x_hidden_dims", "t_hidden_dims", "n_kernel"):
+            value = getattr(self, field_name)
+            if value is not None and not is_kr:
+                raise ValueError(f"Task '{self.name}': '{field_name}' is only valid for kernel_regression.")
+        if self.x_hidden_dims is not None:
+            validate_hidden_dims(f"Task '{self.name}'.x_hidden_dims", self.x_hidden_dims)
+        if self.t_hidden_dims is not None:
+            validate_hidden_dims(f"Task '{self.name}'.t_hidden_dims", self.t_hidden_dims)
+        if self.n_kernel is not None and self.n_kernel < 1:
+            raise ValueError(f"Task '{self.name}': n_kernel must be >= 1, got {self.n_kernel}.")
 
 
 @dataclass(kw_only=True)
@@ -516,33 +541,43 @@ class TaskCatalog:
         name: str,
         *,
         latent_dim: int,
-        head_hidden_dim: int,
+        head_hidden_dims: list[int],
+        kr_x_hidden_dims: list[int],
+        kr_t_hidden_dims: list[int],
         n_kernel: int,
         lr: float,
         weight_decay: float = 0.0,
         masking_ratio: float = 1.0,
         init_from_data: bool = True,
     ) -> TaskConfig:
-        """Build the model-side task config for ``name`` (see module docstring for field mapping)."""
+        """Build the model-side task config for ``name``.
+
+        ``head_hidden_dims`` / ``kr_x_hidden_dims`` / ``kr_t_hidden_dims`` / ``n_kernel`` are the
+        ``[model]`` defaults; a task's own ``[[tasks]]`` overrides (``spec.hidden_dims`` etc.) win.
+        Hidden lists are the interior widths — ``latent_dim`` is prepended and the output appended.
+        """
 
         spec = self.task_spec(name)
         head_lr = spec.lr if spec.lr is not None else lr
         optimizer = OptimizerConfig(lr=head_lr, weight_decay=weight_decay)
 
         if spec.kind is TaskKind.REGRESSION:
+            head_hidden = spec.hidden_dims if spec.hidden_dims is not None else head_hidden_dims
             return RegressionTaskConfig(
                 name=name,
                 data_column=spec.column,
-                dims=[latent_dim, head_hidden_dim, 1],
+                dims=[latent_dim, *head_hidden, 1],
                 optimizer=optimizer,
                 task_masking_ratio=masking_ratio,
             )
         if spec.kind is TaskKind.CLASSIFICATION:
             assert spec.num_classes is not None
+            head_hidden = spec.hidden_dims if spec.hidden_dims is not None else head_hidden_dims
             return ClassificationTaskConfig(
                 name=name,
                 data_column=spec.column,
-                dims=[latent_dim, head_hidden_dim, 32],
+                # ClassificationHead appends the num_classes projection after these hidden layers.
+                dims=[latent_dim, *head_hidden],
                 num_classes=spec.num_classes,
                 class_weights=self._class_weights(name),
                 optimizer=optimizer,
@@ -550,17 +585,20 @@ class TaskCatalog:
             )
 
         assert spec.t_column is not None
+        x_hidden = spec.x_hidden_dims if spec.x_hidden_dims is not None else kr_x_hidden_dims
+        t_hidden = spec.t_hidden_dims if spec.t_hidden_dims is not None else kr_t_hidden_dims
+        kernels = spec.n_kernel if spec.n_kernel is not None else n_kernel
         centers: list[float] = []
         sigmas: list[float] = []
         if init_from_data:
-            centers, sigmas = init_kernel_centers_sigmas(self._train_t_values(name), n_kernel)
+            centers, sigmas = init_kernel_centers_sigmas(self._train_t_values(name), kernels)
         return KernelRegressionTaskConfig(
             name=name,
             data_column=spec.column,
             t_column=spec.t_column,
-            x_dim=[latent_dim, 128, 64],
-            t_dim=[16, 8],
-            kernel_num_centers=n_kernel,
+            x_dim=[latent_dim, *x_hidden],
+            t_dim=list(t_hidden),
+            kernel_num_centers=kernels,
             kernel_centers_init=centers or None,
             kernel_sigmas_init=sigmas or None,
             kernel_learnable_centers=True,

--- a/src/foundation_model/workflows/task_catalog.py
+++ b/src/foundation_model/workflows/task_catalog.py
@@ -50,7 +50,7 @@ from foundation_model.models.model_config import (
 )
 from foundation_model.utils.kmd_plus import DEFAULT_ELEMENTS, KMD, element_features, formula_to_composition
 
-from ._sections import validate_hidden_dims
+from ._sections import validate_hidden_dims, validate_positive_int
 
 TaskConfig = RegressionTaskConfig | ClassificationTaskConfig | KernelRegressionTaskConfig
 
@@ -193,8 +193,8 @@ class TaskSpec:
             validate_hidden_dims(f"Task '{self.name}'.x_hidden_dims", self.x_hidden_dims)
         if self.t_hidden_dims is not None:
             validate_hidden_dims(f"Task '{self.name}'.t_hidden_dims", self.t_hidden_dims)
-        if self.n_kernel is not None and self.n_kernel < 1:
-            raise ValueError(f"Task '{self.name}': n_kernel must be >= 1, got {self.n_kernel}.")
+        if self.n_kernel is not None:
+            validate_positive_int(f"Task '{self.name}'.n_kernel", self.n_kernel)
 
 
 @dataclass(kw_only=True)

--- a/src/foundation_model/workflows/task_catalog_test.py
+++ b/src/foundation_model/workflows/task_catalog_test.py
@@ -286,7 +286,7 @@ def catalog_dir(tmp_path):
     return tmp_path
 
 
-def _catalog(catalog_dir, *, extra_tasks: str = "", data_extra: str = "") -> TaskCatalog:
+def _catalog(catalog_dir, *, extra_tasks: str = "", data_extra: str = "", density_extra: str = "") -> TaskCatalog:
     toml = f"""
 [data]
 composition_column = "composition"
@@ -308,6 +308,7 @@ name = "density"
 kind = "regression"
 dataset = "qc"
 column = "density"
+{density_extra}
 
 [[tasks]]
 name = "mat"
@@ -353,26 +354,62 @@ def test_sample_caps_rows(catalog_dir) -> None:
     assert len(frame) == 3
 
 
+def _build_task(cat: TaskCatalog, name: str):
+    """build_task_config with fixed small [model]-style architecture defaults (interior widths)."""
+    return cat.build_task_config(
+        name, latent_dim=8, head_hidden_dims=[4], kr_x_hidden_dims=[16, 8], kr_t_hidden_dims=[8, 4], n_kernel=5, lr=1e-3
+    )
+
+
 def test_build_task_config_per_kind(catalog_dir) -> None:
     cat = _catalog(catalog_dir)
-    reg = cat.build_task_config("density", latent_dim=8, head_hidden_dim=4, n_kernel=5, lr=1e-3)
-    clf = cat.build_task_config("mat", latent_dim=8, head_hidden_dim=4, n_kernel=5, lr=1e-3)
-    kr = cat.build_task_config("dos", latent_dim=8, head_hidden_dim=4, n_kernel=5, lr=1e-3)
+    reg = _build_task(cat, "density")
+    clf = _build_task(cat, "mat")
+    kr = _build_task(cat, "dos")
+    # latent_dim prepended, output appended: reg → [8, 4, 1]; clf hidden stack [8, 4] (+ num_classes)
     assert isinstance(reg, RegressionTaskConfig) and reg.dims == [8, 4, 1]
-    assert isinstance(clf, ClassificationTaskConfig) and clf.num_classes == 3
+    assert isinstance(clf, ClassificationTaskConfig) and clf.num_classes == 3 and clf.dims == [8, 4]
     assert clf.class_weights is not None and len(clf.class_weights) == 3
+    # KR: x branch [latent, *kr_x_hidden_dims]; t branch = kr_t_hidden_dims verbatim
     assert isinstance(kr, KernelRegressionTaskConfig) and kr.kernel_num_centers == 5
+    assert kr.x_dim == [8, 16, 8] and kr.t_dim == [8, 4]
     assert reg.optimizer is not None and reg.optimizer.lr == 1e-3
 
 
 def test_build_task_config_per_task_lr_override(catalog_dir) -> None:
     cat = _catalog(catalog_dir, extra_tasks="lr = 0.02")  # per-task override on the dos task
-    kr = cat.build_task_config("dos", latent_dim=8, head_hidden_dim=4, n_kernel=5, lr=1e-3)
+    kr = _build_task(cat, "dos")
     assert kr.optimizer is not None and kr.optimizer.lr == 0.02
 
 
+def test_build_task_config_per_task_arch_override(catalog_dir) -> None:
+    # dos (KR) overrides its branches + kernel count; density (reg) overrides its hidden stack.
+    cat = _catalog(
+        catalog_dir,
+        extra_tasks="x_hidden_dims = [32, 16]\nt_hidden_dims = [12]\nn_kernel = 9",
+        density_extra="hidden_dims = [6, 3]",
+    )
+    kr = _build_task(cat, "dos")
+    assert isinstance(kr, KernelRegressionTaskConfig)
+    assert kr.x_dim == [8, 32, 16] and kr.t_dim == [12] and kr.kernel_num_centers == 9
+    reg = _build_task(cat, "density")
+    assert isinstance(reg, RegressionTaskConfig) and reg.dims == [8, 6, 3, 1]
+    # mat (clf) untouched → falls back to the [model] default head_hidden_dims
+    clf = _build_task(cat, "mat")
+    assert isinstance(clf, ClassificationTaskConfig) and clf.dims == [8, 4]
+
+
+def test_arch_override_wrong_kind_raises(catalog_dir) -> None:
+    with pytest.raises(ValueError, match="only valid for kernel_regression"):
+        _catalog(catalog_dir, density_extra="x_hidden_dims = [4]")
+    with pytest.raises(ValueError, match="for reg/clf"):
+        _catalog(catalog_dir, extra_tasks="hidden_dims = [4]")  # hidden_dims on the KR dos task
+    with pytest.raises(ValueError, match="positive ints"):
+        _catalog(catalog_dir, density_extra="hidden_dims = [0]")
+
+
 def test_kernel_init_finite(catalog_dir) -> None:
-    kr = _catalog(catalog_dir).build_task_config("dos", latent_dim=8, head_hidden_dim=4, n_kernel=5, lr=1e-3)
+    kr = _build_task(_catalog(catalog_dir), "dos")
     assert isinstance(kr, KernelRegressionTaskConfig)
     assert kr.kernel_centers_init is not None and len(kr.kernel_centers_init) == 5
     assert kr.kernel_sigmas_init is not None

--- a/src/foundation_model/workflows/task_catalog_test.py
+++ b/src/foundation_model/workflows/task_catalog_test.py
@@ -144,6 +144,23 @@ column = "dos"
         _build(toml)
 
 
+def test_task_n_kernel_non_int_raises() -> None:
+    toml = """
+[datasets.qc]
+path = "data/qc.parquet"
+
+[[tasks]]
+name = "dos"
+kind = "kernel_regression"
+dataset = "qc"
+column = "dos"
+t_column = "energy"
+n_kernel = 5.0
+"""
+    with pytest.raises(ValueError, match="positive int"):
+        _build(toml)
+
+
 def test_clf_without_num_classes_raises() -> None:
     toml = """
 [datasets.qc]


### PR DESCRIPTION
## Summary

Follow-up to the `fm` CLI stack (stacked on #27). Makes the network **depth + per-layer widths**
configurable, replacing the fixed single-hidden-layer templates (`encoder_hidden` / `head_hidden_dim`
scalars, plus hardcoded KR `x_dim=[latent,128,64]` / `t_dim=[16,8]` and an undocumented 32-wide clf
layer).

### `[model]` — architecture defaults
`*_hidden_dims` are the **interior** hidden widths; the input (descriptor width for the encoder,
`latent_dim` for the heads) is prepended and the output (`1` / `num_classes` / kernel projection)
appended.

```toml
[model]
latent_dim = 128
encoder_hidden_dims = [256]      # descriptor_dim → 256 → latent_dim
head_hidden_dims = [64]          # reg/clf: latent_dim → 64 → out
kr_x_hidden_dims = [128, 64]     # KR value branch: latent_dim → 128 → 64
kr_t_hidden_dims = [16, 8]       # KR coordinate branch: t → 16 → 8
n_kernel = 15
```

### `[[tasks]]` — per-head overrides (win over `[model]`)
```toml
[[tasks]]
name = "dos_density"
kind = "kernel_regression"
# ...
x_hidden_dims = [256, 128]
t_hidden_dims = [32, 16]
n_kernel = 20

[[tasks]]
name = "density"
kind = "regression"
# ...
hidden_dims = [256, 128]
```

Reg/clf tasks take `hidden_dims`; KR tasks take `x_hidden_dims` / `t_hidden_dims` / `n_kernel`
(kind-matched validation rejects the wrong field). Unset → the `[model]` default.

## Notable

- `_engine.build_encoder_config` + `build_model_for_checkpoint` centralize the encoder build and the
  head-rebuild block that `predict.py` / `inverse.py` previously **duplicated verbatim**.
- Reg and clf heads are now symmetric on `head_hidden_dims` — this drops the previously hardcoded
  32-wide penultimate clf layer (an undocumented magic number).

## Validation

- New tests: per-task arch overrides resolve correctly (reg/clf/KR), wrong-field-for-kind and
  non-positive dims raise, `build_task_config` dim math.
- Full suite → **370 passed**; ruff/mypy clean.
- The CLI smoke chain runs on the restructured configs, and an end-to-end check confirms a
  **heterogeneous** checkpoint (a reg head + two differently-shaped KR heads + a multi-layer encoder)
  trains, saves, and reloads through `fm predict` with no missing keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCoVwB3pntFi25YnpoHYwY