### PR TITLE
PR9 — config schema reference + fix predict --seed/--accelerator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,9 @@ flags on every subcommand: `--config` (required), `--output-dir`, `--set section
 (repeatable, value parsed with TOML semantics), `--seed`, `--accelerator`, `--sample`. Each run
 writes `run_provenance.json` (resolved config + package versions + git + argv + seeds) and
 `run.log` into its output dir via `workflows/recording.py::RunRecorder`. Sample configs live in
-`samples/*.toml` (formal + `*_smoke.toml` variants).
+`samples/*.toml` (formal + `*_smoke.toml` variants); the full per-key schema (every section, type,
+default, constraint) is [`docs/configuration.md`](docs/configuration.md) — keep it in sync when you
+add or change a config field.
 
 ## Architecture
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,11 @@
 - **Provenance on every run**: `run_provenance.json` (resolved config + package versions + git +
   argv + seeds) and `run.log`, written by `workflows/recording.py::RunRecorder` — the single
   artifact writer for the training/predict flows.
+- **Config reference + fixes**: added [`docs/configuration.md`](docs/configuration.md), an
+  authoritative per-key schema for all four subcommands. `fm predict` now accepts `--seed` /
+  `--accelerator` (routed to `[predict]`, previously crashed with `unknown key 'training'`) and
+  runs on the chosen device; `--config` help text added; pretrain/finetune command-section fields
+  documented inline.
 - **New package layout**: `workflows/` (task_catalog, recording, `_sections`/`_engine`, pretrain,
   finetune, inverse, inverse_trajectory, plots, predict) + `cli/`; colocated `<module>_test.py`.
 - **Removed**: `src/foundation_model/scripts/` in full (`train.py`/LightningCLI, the

--- a/README.md
+++ b/README.md
@@ -122,8 +122,11 @@ Training callbacks and loggers map to Lightning's built-ins via `[training]` sub
 subset of each): `[training.early_stopping]` → `EarlyStopping` (on by default),
 `[training.checkpoint]` → `ModelCheckpoint`, and `[training.logging]` (`csv` / `tensorboard`) →
 `CSVLogger` / `TensorBoardLogger`. Lightning checkpointing/logging are opt-in; the run recorder
-writes the rehearsal-schema checkpoints + `run.log` regardless. See [`samples/`](samples/) for
-templates and `AGENTS.md` → **Entry Points** for the full convention.
+writes the rehearsal-schema checkpoints + `run.log` regardless.
+
+**[`docs/configuration.md`](docs/configuration.md) is the authoritative schema** — every section,
+key, type, default, constraint, and which subcommands read it. See [`samples/`](samples/) for
+ready-to-copy templates.
 
 ## Features
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,365 @@
+# `fm` configuration reference
+
+Every `fm` subcommand is driven by a single **TOML** file. This document is the authoritative
+schema: every section, every key, its type, default, constraint, and meaning. It is generated from
+and kept in sync with the config dataclasses in `src/foundation_model/workflows/` (`task_catalog.py`,
+`_sections.py`, `pretrain.py`, `finetune.py`, `inverse.py`, `predict.py`).
+
+- Ready-to-copy templates live in [`samples/`](../samples/) (`*.toml` formal, `*_smoke.toml` fast).
+- **Unknown keys are rejected** at load time with a message naming the offending key and the allowed
+  set — so a typo fails fast rather than being silently ignored.
+- Types follow TOML: strings must be quoted, floats need a decimal point (`10.0` is a float, `10`
+  an int — this matters where a field is int-only), arrays are `[...]`, tables are `[section]`,
+  arrays-of-tables are `[[section]]`.
+
+## How a config is loaded
+
+The CLI (`fm <cmd> --config x.toml`) does exactly this: parse the TOML → apply `--set` and
+first-class-flag overrides onto the raw tree → build a validated `@dataclass` → write
+`run_provenance.json` (the fully resolved config) → run. No values are hidden; the provenance file
+records what actually ran.
+
+Override precedence (later wins): **TOML file** → `--set SECTION.KEY=VALUE` → dedicated flags
+(`--seed`, `--accelerator`, `--sample`, and per-command flags). `--checkpoint` / `--output-dir` are
+passed to the builder directly and take precedence over `[…].checkpoint` / `[output].dir`.
+
+## Which sections each subcommand reads
+
+| Section | `pretrain` | `finetune` | `inverse` | `predict` |
+|---|:--:|:--:|:--:|:--:|
+| `[data]` | ✓ | ✓ | ✓ | ✓ |
+| `[descriptor]` | ✓ | ✓ | ✓ | ✓ |
+| `[datasets.*]` | ✓ | ✓ | ✓ | ✓ |
+| `[[tasks]]` | ✓ | ✓ | ✓ | ✓ |
+| `[model]` | ✓ | ✓ | ✓ | ✓ |
+| `[training]` (+ sub-tables) | ✓ | ✓ | — | — |
+| `[output]` | ✓ | ✓ | ✓ | ✓ |
+| command section | `[pretrain]` | `[finetune]` | `[inverse]` | `[predict]` |
+
+`inverse` and `predict` do **not** read `[training]`; their seed/accelerator live in `[inverse]` /
+`[predict]` instead.
+
+---
+
+# Shared sections
+
+## `[data]` — data loading + splitting
+
+| Key | Type | Default | Constraint | Description |
+|---|---|---|---|---|
+| `composition_column` | str | `"composition"` | | Column holding the composition string / formula key. |
+| `val_split` | float | `0.1` | `[0, 1)` | Fraction held out for validation. |
+| `test_split` | float | `0.1` | `[0, 1)`, `val+test < 1` | Fraction held out for test. |
+| `split_random_seed` | int | `42` | | Seed for the random train/val/test split (when no `split` column is present). |
+| `batch_size` | int | `256` | `>= 1` | Training/eval batch size. |
+| `num_workers` | int | `0` | `>= 0` | DataLoader worker processes. |
+
+If a dataset file has a `split` column (`train`/`val`/`test`), it is honored directly and the
+random split is not used.
+
+## `[descriptor]` — how composition descriptors are produced
+
+| Key | Type | Default | Constraint | Description |
+|---|---|---|---|---|
+| `kind` | str | `"kmd"` | `kmd` \| `precomputed` | `kmd` = on-the-fly invertible KMD descriptor (required for the composition inverse-design path); `precomputed` = load a descriptor table. |
+| `n_grids` | int | `8` | `>= 2` (kmd only) | KMD grid resolution; the descriptor width scales with it. |
+| `path` | str (path) | — | required iff `kind = "precomputed"` | File of precomputed per-composition descriptors. |
+
+## `[datasets.<name>]` — one composition-keyed data file (array of named tables)
+
+Define one table per data file; `<name>` is the key each `[[tasks]]` references via its `dataset`
+field. At least one dataset is required.
+
+| Key | Type | Default | Constraint | Description |
+|---|---|---|---|---|
+| `path` | str (path) | — | required; name must end in `.csv` / `.parquet` / `.pd` / `.pd.z` / `.pd.xz` / `.pkl` | The data file (composition-keyed rows). |
+| `preprocessing_path` | str (path) | `None` | | Optional joblib object with a `"dropped_idx"` (the qc dataset drops rows). |
+| `min_elements` | int | `None` | `>= 1` | Keep only compositions with at least this many elements. |
+| `sample` | int | `None` | `>= 1` | Row cap (smoke runs); `--sample N` sets this for every dataset. |
+
+## `[[tasks]]` — supervised tasks (array of tables)
+
+One entry per prediction head. At least one is required; names must be unique.
+
+| Key | Type | Default | Constraint | Description |
+|---|---|---|---|---|
+| `name` | str | — | required, unique | Task/head name; used as the head key and in output filenames. |
+| `kind` | str | — | `regression` \| `kernel_regression` \| `classification` | Head type. (Legacy aliases `reg`/`kr`/`clf` also accepted.) |
+| `dataset` | str | — | must match a `[datasets.<name>]` | Which dataset supplies this task's column(s). |
+| `column` | str | — | required | Target column. |
+| `t_column` | str | `None` | required iff `kind = kernel_regression`; forbidden otherwise | The sequence x-axis column (e.g. energies for DOS, temperatures for ZT). |
+| `num_classes` | int | `None` | required iff `kind = classification`, `>= 2`; forbidden otherwise | Number of classes. |
+| `lr` | float | `None` | | Per-task learning-rate override (else the section LR for its kind). |
+| `replay` | float \| int | `None` | float in `(0,1)` or int `>= 1` | Per-task rehearsal amount (pretrain); see `[pretrain.rehearsal]`. |
+| `hidden_dims` | list[int] | `None` | positive ints; reg/clf only | Override `[model].head_hidden_dims` for this head. |
+| `x_hidden_dims` | list[int] | `None` | positive ints; KR only | Override `[model].kr_x_hidden_dims` (value branch). |
+| `t_hidden_dims` | list[int] | `None` | positive ints; KR only | Override `[model].kr_t_hidden_dims` (coordinate branch). |
+| `n_kernel` | int | `None` | positive int; KR only | Override `[model].n_kernel` for this head. |
+
+### `[[tasks]].scaler` — optional inverse-transform for reporting
+
+A nested table on a task. Used only to inverse-transform predictions to human-readable units.
+
+| Key | Type | Default | Constraint | Description |
+|---|---|---|---|---|
+| `path` | str (path) | — | required | Fitted scaler (joblib). |
+| `key` | str | `None` | | Key inside a dict-of-scalers pickle; `None` = the whole object is the scaler. |
+
+## `[model]` — network architecture
+
+The `*_hidden_dims` lists are the **interior hidden widths**; the input (descriptor width for the
+encoder, `latent_dim` for the heads) is prepended and the output (`1` / `num_classes` / kernel
+projection) appended. Example: `encoder_hidden_dims = [512, 256]` builds
+`descriptor_dim → 512 → 256 → latent_dim`. Any `[[tasks]]` entry may override its own head (see
+above).
+
+| Key | Type | Default | Constraint | Description |
+|---|---|---|---|---|
+| `latent_dim` | int | `128` | positive int | Encoder output width = every head's input width. |
+| `encoder_hidden_dims` | list[int] | `[256]` | positive ints (may be empty) | Encoder hidden layers. Empty = a single `descriptor_dim → latent_dim` layer. |
+| `head_hidden_dims` | list[int] | `[64]` | positive ints, non-empty | Default hidden layers for regression/classification heads. |
+| `kr_x_hidden_dims` | list[int] | `[128, 64]` | positive ints, non-empty | Default KR value-branch hidden layers. |
+| `kr_t_hidden_dims` | list[int] | `[16, 8]` | positive ints, non-empty | Default KR coordinate-branch hidden layers. |
+| `n_kernel` | int | `15` | positive int | Default number of KR Gaussian kernel centers. |
+
+## `[training]` — optimization (pretrain + finetune only)
+
+| Key | Type | Default | Constraint | Description |
+|---|---|---|---|---|
+| `max_epochs` | int | `100` | `>= 1` | Max epochs per training step. |
+| `encoder_lr` | float | `0.005` | | Shared-encoder learning rate. |
+| `head_lr` | float | `0.005` | | Regression/classification head learning rate. |
+| `kr_lr` | float | `0.0005` | | Kernel-regression head learning rate. |
+| `kr_weight_decay` | float | `5e-05` | | Weight decay for KR heads (reg/clf heads use a fixed `1e-5`). |
+| `ae_lr` | float | `0.005` | | AutoEncoder head learning rate (the AE head always trains). |
+| `accelerator` | str | `"auto"` | | Lightning accelerator (`auto` / `cpu` / `gpu` / …). |
+| `devices` | int | `1` | | Number of devices. |
+| `seed` | int | `2025` | | Global seed (`--seed` overrides). |
+
+### `[training.early_stopping]` → Lightning `EarlyStopping` (on by default)
+
+| Key | Type | Default | Constraint | Description |
+|---|---|---|---|---|
+| `enabled` | bool | `true` | | Turn early stopping on/off. |
+| `monitor` | str | `"val_final_loss"` | | Metric to monitor. |
+| `mode` | str | `"min"` | `min` \| `max` | Whether lower or higher is better. |
+| `patience` | int | `8` | `>= 1` | Epochs without improvement before stopping. |
+| `min_delta` | float | `0.0001` | | Minimum change counted as improvement. |
+
+### `[training.checkpoint]` → Lightning `ModelCheckpoint` (opt-in)
+
+Off by default — the run recorder already writes rehearsal-schema checkpoints that
+finetune/inverse/predict consume. Enable to *also* emit Lightning `.ckpt` files.
+
+| Key | Type | Default | Constraint | Description |
+|---|---|---|---|---|
+| `enabled` | bool | `false` | | Emit Lightning `.ckpt` files. |
+| `monitor` | str | `"val_final_loss"` | | Metric to monitor. |
+| `mode` | str | `"min"` | `min` \| `max` | Direction of improvement. |
+| `save_top_k` | int | `1` | | How many best checkpoints to keep. |
+| `save_last` | bool | `false` | | Also save the last-epoch checkpoint. |
+| `filename` | str | `None` | | Optional Lightning filename template. |
+
+### `[training.logging]` → Lightning loggers (opt-in)
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `csv` | bool | `false` | Write a `CSVLogger` metrics table under `<output.dir>/logs/`. |
+| `tensorboard` | bool | `false` | Write a `TensorBoardLogger` under `<output.dir>/logs/`. |
+
+## `[output]` — where the run writes
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `dir` | str (path) | — | Run output directory. Required unless `--output-dir` is passed (which overrides it). Other keys under `[output]` are ignored. |
+
+---
+
+# Command sections
+
+## `[pretrain]` — continual-rehearsal pre-training
+
+| Key | Type | Default | Constraint | Description |
+|---|---|---|---|---|
+| `task_sequence` | list[str] | `[]` → `[[tasks]]` order | tasks must exist | Order tasks are introduced across steps. |
+| `n_runs` | int | `1` | `>= 1` | Independent repeats (different seeds), written to `runs/runNN/`. |
+| `task_order` | str | `"fixed"` | `fixed` \| `random` | `fixed` = `task_sequence` order; `random` = per-run shuffle. |
+
+### `[pretrain.rehearsal]`
+
+| Key | Type | Default | Constraint | Description |
+|---|---|---|---|---|
+| `interval` | int | `1` | `>= 1` | Already-learned tasks rejoin training every Nth step; `1` = always replay. |
+| `default_replay` | float \| int | `0.05` | float in `(0,1)` or int `>= 1` | Replay amount per old task: a fraction of its labels, or an absolute label count. |
+| `per_task` | table (str→num) | `{}` | keys must be tasks; same value rule | Override `default_replay` for named tasks, e.g. `per_task = { density = 0.2 }`. |
+
+## `[finetune]` — frozen-encoder head fine-tuning
+
+| Key | Type | Default | Constraint | Description |
+|---|---|---|---|---|
+| `checkpoint` | str (path) | — | required (or `--checkpoint`) | Checkpoint to fine-tune from. |
+| `tasks` | list[str] | — | required, non-empty | Heads to fine-tune; other heads stay frozen (the AE head always trains). |
+| `epochs` | int | `20` | | Fine-tune epochs (distinct from `[training].max_epochs`). |
+| `freeze_encoder` | bool | `true` | | Freeze the shared encoder + non-target heads (BatchNorm buffers included). |
+| `add_new_tasks` | bool | `true` | | If a target task isn't in the checkpoint, add a fresh head for it. |
+
+## `[predict]` — evaluate / predict with a checkpoint
+
+| Key | Type | Default | Constraint | Description |
+|---|---|---|---|---|
+| `checkpoint` | str (path) | — | required (or `--checkpoint`) | Checkpoint to load. |
+| `tasks` | list[str] | `[]` → all heads | must exist in the checkpoint | Heads to predict; empty = every checkpoint head. |
+| `split` | str | `"test"` | `train` \| `val` \| `test` \| `all` | Which split to predict on. |
+| `compositions` | list[str] | `[]` | | Explicit compositions to predict; **overrides `split`** when given. |
+| `with_metrics` | bool | `true` | | Compute metrics when true targets are available (`--no-metrics` disables). |
+| `seed` | int | `2025` | | RNG seed (`--seed` overrides). |
+| `accelerator` | str | `"auto"` | `auto` \| `cpu` | Device: `auto` uses CUDA if available, else CPU (`--accelerator` overrides). |
+
+## `[inverse]` — inverse design (scenarios × algorithm paths)
+
+| Key | Type | Default | Constraint | Description |
+|---|---|---|---|---|
+| `checkpoint` | str (path) | — | required (or `--checkpoint`) | Trained checkpoint to inverse-design from. |
+| `steps` | int | `300` | | Gradient-optimization steps (`--steps` overrides). |
+| `lr` | float | `0.05` | | Optimizer learning rate. |
+| `class_weight` | float | `5.0` | | Weight of the classification objective vs. the regression targets. |
+| `record_trajectory` | bool | `true` | | Record + emit optimization trajectories (`--no-trajectory` disables). |
+| `per_seed_trajectories` | bool | `false` | | Also emit per-seed trajectory plots (capped at 20). |
+| `animation_formats` | list[str] | `["gif"]` | ⊆ `{gif, html, svg}` | Trajectory animation formats (`--animation-formats` overrides). |
+| `seed` | int | `2025` | | Global RNG seed (`--seed` overrides). |
+| `accelerator` | str | `"auto"` | `auto` \| `cpu` | Device (`--accelerator` overrides). |
+
+`[inverse]` also contains one `[inverse.seeds]` table and the `[[inverse.scenarios]]` /
+`[[inverse.paths]]` arrays below. If `[[inverse.paths]]` is omitted, a built-in set of **11 default
+paths** (3 latent + 8 composition) is used.
+
+### `[inverse.seeds]` — how starting compositions are chosen
+
+| Key | Type | Default | Constraint | Description |
+|---|---|---|---|---|
+| `strategy` | str | `"top_qc"` | `top_qc` \| `random` \| `explicit` | Seed-selection algorithm. |
+| `n` | int | `20` | `>= 1` | Total seed compositions to return. |
+| `split` | str | `"test"` | `train`/`val`/`test`/`all` | Split to draw candidates from. |
+| `explicit` | list[str] | `[]` | required (non-empty) when `strategy = explicit` | Explicit candidate pool. |
+| `explicit_append` | list[str] | `[]` | each must have a computable descriptor | Extra seeds appended to every strategy's output. |
+| `dedup_by_element_system` | bool | `true` | | Keep only one composition per element system (set of element symbols). |
+
+### `[[inverse.scenarios]]` — design objectives (array of tables)
+
+At least one required; names unique.
+
+| Key | Type | Default | Constraint | Description |
+|---|---|---|---|---|
+| `name` | str | — | required, unique | Scenario identifier (→ output subdir). |
+| `reg_tasks` | list[str] | — | required, non-empty, `len == len(reg_targets)` | Regression heads to steer. |
+| `reg_targets` | list[float] | — | required, paired with `reg_tasks` | Desired value per regression task. |
+| `class_task` | str | `"material_type"` | | Classification head defining the objective. |
+| `class_target` | int | `None` | | Target class index; `None` = the default class `[1]`. |
+
+### `[[inverse.paths]]` — algorithm variants (array of tables)
+
+Each path is one optimization recipe. `method` selects the family; the other keys are validated
+against it (a composition-only key on a `latent` path — or `ae_align_scale` on a `composition`
+path — is rejected).
+
+| Key | Type | Default | Applies to | Description |
+|---|---|---|---|---|
+| `name` | str | — | both | Path identifier (→ output filenames). |
+| `method` | str | — | both | `latent` (optimize the latent vector) or `composition` (optimize the recipe). |
+| `ae_align_scale` | float | `0.5` | latent | AE-manifold alignment weight (sweet spot ≈ 0.5). |
+| `init` | str | `"seed"` | composition | `seed` (blend seed weights) or `random` (random starts). |
+| `n_starts` | int | `None` | composition (`init=random`) | Number of random starts. |
+| `seed_blend` | float | `0.95` | composition (`init=seed`) | Fraction of the seed kept; the rest is uniform over the whitelist. |
+| `allowed_elements` | list[str] \| `"all"` | `"all"` | composition | Hard element whitelist. |
+| `diversity_scale` | float | `1.0` | composition | Per-output element-diversity penalty (`1.0` = none). |
+| `max_elements` | int | `None` | composition | Cardinality cap: at most K elements per recipe. |
+| `element_step_scale` | float \| table | `1.0` | composition | Per-element gradient scaling (`0` hard-locks an element to its seed value). |
+| `fixed_amounts` | table (str→float) | `{}` | composition | Pin specific elements to absolute amounts, e.g. `{ Au = 0.65 }`. |
+| `annealing_scale` | float | `0.5` | composition | Softness of the K-hot annealing schedule. |
+| `annealing_schedule` | table | `None` | composition | Advanced override of the annealing schedule. |
+
+For the design intent behind each knob, see
+[docs/inverse_design_algorithms.md](inverse_design_algorithms.md).
+
+---
+
+# CLI flags
+
+Every subcommand shares these (from `common_options`):
+
+| Flag | Applies to | Description |
+|---|---|---|
+| `--config PATH` | all | The TOML config file (**required**). |
+| `--output-dir DIR` | all | Override `[output].dir`. |
+| `--set SECTION.KEY=VALUE` | all | Override one TOML value (repeatable); VALUE is TOML syntax, so quote strings: `--set 'data.composition_column="formula"'`. |
+| `--seed N` | all | Override the run seed (routed to the right section per subcommand). |
+| `--accelerator X` | all | Override the accelerator (`auto` / `cpu`). |
+| `--sample N` | all | Cap rows for every `[datasets.*]` (fast smoke runs). |
+
+Per-subcommand flags:
+
+| Subcommand | Flags |
+|---|---|
+| `pretrain` | `--max-epochs N` (→ `training.max_epochs`) |
+| `finetune` | `--checkpoint PATH`, `--tasks a,b` (→ `finetune.tasks`), `--epochs N` |
+| `inverse` | `--checkpoint PATH`, `--scenario NAME` (repeatable; run only these), `--steps N`, `--no-trajectory`, `--animation-formats gif,html,svg` |
+| `predict` | `--checkpoint PATH`, `--tasks a,b`, `--split train\|val\|test\|all`, `--compositions "Fe2 O3,Al2 O3"` (overrides split), `--no-metrics` |
+
+Run `fm <subcommand> --help` for the exact list.
+
+---
+
+# Minimal examples
+
+Pre-train two regression heads + one classifier, then fine-tune and predict:
+
+```toml
+# pretrain.toml
+[descriptor]
+kind = "kmd"
+n_grids = 12
+
+[datasets.qc]
+path = "data/qc.parquet"
+
+[[tasks]]
+name = "density"
+kind = "regression"
+dataset = "qc"
+column = "density"
+
+[[tasks]]
+name = "material_type"
+kind = "classification"
+dataset = "qc"
+column = "mtype"
+num_classes = 5
+
+[model]
+latent_dim = 128
+encoder_hidden_dims = [256]
+
+[training]
+max_epochs = 100
+[training.early_stopping]
+patience = 8
+[training.logging]
+csv = true
+
+[pretrain]
+task_sequence = ["density", "material_type"]
+[pretrain.rehearsal]
+interval = 1
+default_replay = 0.05
+
+[output]
+dir = "artifacts/pretrain"
+```
+
+```bash
+fm pretrain --config pretrain.toml
+fm finetune --config finetune.toml --checkpoint artifacts/pretrain/runs/run00/training/final_model.pt
+fm predict  --config predict.toml  --checkpoint artifacts/finetune/training/final_model.pt --split test
+```
+
+See [`samples/`](../samples/) for complete formal + smoke configs of all four subcommands.

--- a/src/foundation_model/cli/main.py
+++ b/src/foundation_model/cli/main.py
@@ -88,12 +88,30 @@ def load_raw_config(
 def common_options(func: Callable[..., Any]) -> Callable[..., Any]:
     """Attach the options shared by every subcommand."""
     options = [
-        click.option("--config", "config_path", required=True, type=click.Path(exists=True, dir_okay=False)),
-        click.option("--output-dir", "output_dir", default=None, help="Override the run output directory."),
-        click.option("--set", "overrides", multiple=True, metavar="SECTION.KEY=VALUE", help="Override a TOML value."),
-        click.option("--seed", type=int, default=None, help="Override training.seed."),
-        click.option("--accelerator", default=None, help="Override training.accelerator."),
-        click.option("--sample", type=int, default=None, help="Cap rows for every dataset (smoke runs)."),
+        click.option(
+            "--config",
+            "config_path",
+            required=True,
+            type=click.Path(exists=True, dir_okay=False),
+            help="Path to the run's TOML config file (required).",
+        ),
+        click.option(
+            "--output-dir", "output_dir", default=None, help="Override [output].dir (the run output directory)."
+        ),
+        click.option(
+            "--set",
+            "overrides",
+            multiple=True,
+            metavar="SECTION.KEY=VALUE",
+            help="Override one TOML value (repeatable); VALUE uses TOML syntax, so quote strings: --set data.batch_size=64.",
+        ),
+        click.option(
+            "--seed", type=int, default=None, help="Override the run seed (routed to the subcommand's section)."
+        ),
+        click.option(
+            "--accelerator", default=None, help='Override the accelerator ("auto" | "cpu"), routed per subcommand.'
+        ),
+        click.option("--sample", type=int, default=None, help="Cap rows for every [datasets.*] (fast smoke runs)."),
     ]
     for option in reversed(options):
         func = option(func)
@@ -267,7 +285,15 @@ def _predict_config(
     compositions: str | None,
     no_metrics: bool,
 ) -> PredictConfig:
-    raw = load_raw_config(config_path, overrides, seed=seed, accelerator=accelerator, sample=sample)
+    raw = load_raw_config(
+        config_path,
+        overrides,
+        seed=seed,
+        accelerator=accelerator,
+        sample=sample,
+        seed_key="predict.seed",
+        accelerator_key="predict.accelerator",
+    )
     if tasks is not None:
         _set_dotted(raw, "predict.tasks", [t.strip() for t in tasks.split(",") if t.strip()])
     if split is not None:
@@ -314,7 +340,7 @@ def predict_cmd(
         no_metrics,
     )
     recorder = RunRecorder(cfg.output_dir)
-    recorder.write_provenance(config=cfg, argv=list(sys.argv), seeds={"seed": 2025})
+    recorder.write_provenance(config=cfg, argv=list(sys.argv), seeds={"seed": cfg.seed})
     predict_run(cfg, recorder)
     recorder.close()
 

--- a/src/foundation_model/cli/main_test.py
+++ b/src/foundation_model/cli/main_test.py
@@ -163,3 +163,13 @@ def test_predict_flags(tmp_path) -> None:
     assert cfg.split == "all"
     assert cfg.compositions == ["Fe2 O3", "Al2 O3"]
     assert cfg.with_metrics is False  # --no-metrics
+
+
+def test_predict_seed_and_accelerator_route_to_predict_section(tmp_path) -> None:
+    # regression: --seed / --accelerator used to inject [training] and crash predict's builder.
+    from foundation_model.cli.main import _predict_config
+
+    path = tmp_path / "pred.toml"
+    path.write_text(_PREDICT_CONFIG)
+    cfg = _predict_config(str(path), (), None, 7, "cpu", None, "ck.pt", None, None, None, False)
+    assert cfg.seed == 7 and cfg.accelerator == "cpu"

--- a/src/foundation_model/workflows/finetune.py
+++ b/src/foundation_model/workflows/finetune.py
@@ -48,15 +48,17 @@ _CATALOG_KEYS = {"data", "descriptor", "datasets", "tasks"}
 
 @dataclass(kw_only=True)
 class FinetuneConfig:
+    """``[finetune]`` + shared sections — frozen-encoder head fine-tuning config."""
+
     catalog: TaskCatalogConfig
     model: ModelSectionConfig
     training: TrainingSectionConfig
-    checkpoint: Path
-    tasks: list[str]
+    checkpoint: Path  # checkpoint to fine-tune from (--checkpoint or [finetune].checkpoint)
+    tasks: list[str]  # heads to fine-tune; other heads stay frozen (the AE head always trains)
     output_dir: Path
-    epochs: int = 20
-    freeze_encoder: bool = True
-    add_new_tasks: bool = True
+    epochs: int = 20  # fine-tune epochs (distinct from [training].max_epochs)
+    freeze_encoder: bool = True  # freeze the shared encoder + non-target heads (BatchNorm buffers too)
+    add_new_tasks: bool = True  # if a target task isn't in the checkpoint, add a fresh head for it
 
     def __post_init__(self) -> None:
         self.checkpoint = Path(self.checkpoint)

--- a/src/foundation_model/workflows/inverse.py
+++ b/src/foundation_model/workflows/inverse.py
@@ -47,6 +47,7 @@ _AE_NAME = "__reconstruction__"
 # Default QC class indices for the classification objective when class_target is unset.
 _DEFAULT_QC_CLASSES = [1]
 _ANIMATION_FORMATS = {"gif", "html", "svg"}
+_ACCELERATORS = {"auto", "cpu"}
 _ELEMENT_TOKEN = re.compile(r"[A-Z][a-z]?")
 
 # 48-element feasible alloy palette (copied verbatim from paper_inverse_comparison.py).
@@ -261,6 +262,8 @@ class InverseConfig:
         bad_fmt = [f for f in self.animation_formats if f not in _ANIMATION_FORMATS]
         if bad_fmt:
             raise ValueError(f"animation_formats must be a subset of {sorted(_ANIMATION_FORMATS)}, got {bad_fmt}.")
+        if self.accelerator not in _ACCELERATORS:
+            raise ValueError(f"inverse.accelerator must be one of {sorted(_ACCELERATORS)}, got {self.accelerator!r}.")
         # composition paths require an invertible KMD descriptor
         if self.catalog.descriptor.kind != "kmd" and any(p.method is InverseMethod.COMPOSITION for p in self.paths):
             raise ValueError("composition paths require descriptor.kind == 'kmd' (an invertible KMD descriptor).")

--- a/src/foundation_model/workflows/inverse_test.py
+++ b/src/foundation_model/workflows/inverse_test.py
@@ -275,6 +275,20 @@ def test_seed_and_accelerator_config(data_dir, tmp_path) -> None:
     assert cfg.seed == 7 and cfg.accelerator == "cpu"
 
 
+def test_invalid_accelerator_raises(data_dir, tmp_path) -> None:
+    with pytest.raises(ValueError, match="accelerator must be one of"):
+        build_inverse_config(
+            tomllib.loads(
+                _catalog_toml(data_dir) + '\n[inverse]\naccelerator = "cpuu"\n'
+                "[inverse.seeds]\nn = 2\n"
+                '[[inverse.scenarios]]\nname = "sc1"\nreg_tasks = ["a"]\nreg_targets = [1.0]\nclass_task = "mat"\n'
+                '[[inverse.paths]]\nname = "latent1"\nmethod = "latent"\n'
+                '[output]\ndir = "o"\n'
+            ),
+            checkpoint="ck.pt",
+        )
+
+
 def test_trajectory_static_and_svg_animation_emitted(data_dir, tmp_path) -> None:
     ckpt = tmp_path / "ck.pt"
     _checkpoint(data_dir, ckpt)

--- a/src/foundation_model/workflows/predict.py
+++ b/src/foundation_model/workflows/predict.py
@@ -47,6 +47,8 @@ class PredictConfig:
     split: str = "test"
     compositions: list[str] = field(default_factory=list)  # overrides split when given
     with_metrics: bool = True
+    seed: int = 2025  # seeds torch/numpy for reproducible split resolution
+    accelerator: str = "auto"  # "auto" (cuda if available, else cpu) | "cpu"
 
     def __post_init__(self) -> None:
         self.checkpoint = Path(self.checkpoint)
@@ -69,7 +71,9 @@ def build_predict_config(
     model = build_model_section(raw.get("model", {}))
 
     pred_raw = dict(raw.get("predict", {}))
-    reject_unknown("predict", pred_raw, {"checkpoint", "tasks", "split", "compositions", "with_metrics"})
+    reject_unknown(
+        "predict", pred_raw, {"checkpoint", "tasks", "split", "compositions", "with_metrics", "seed", "accelerator"}
+    )
     resolved_checkpoint = checkpoint if checkpoint is not None else pred_raw.get("checkpoint")
     if resolved_checkpoint is None:
         raise ValueError("checkpoint must be given via --checkpoint or [predict].checkpoint.")
@@ -86,6 +90,8 @@ def build_predict_config(
         split=str(pred_raw.get("split", "test")),
         compositions=list(pred_raw.get("compositions", [])),
         with_metrics=bool(pred_raw.get("with_metrics", True)),
+        seed=int(pred_raw.get("seed", 2025)),
+        accelerator=str(pred_raw.get("accelerator", "auto")),
     )
 
 
@@ -99,16 +105,24 @@ def _task_names_from_state(state_dict: Mapping[str, Any]) -> list[str]:
     return names
 
 
+def _resolve_device(accelerator: str) -> torch.device:
+    """``"cpu"`` forces CPU; ``"auto"`` uses CUDA when available, else CPU."""
+    if accelerator != "cpu" and torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("cpu")
+
+
 def run(cfg: PredictConfig, recorder: RunRecorder | None = None) -> dict[str, Any]:
     """Predict ``cfg.tasks`` (or every checkpoint head) on the resolved set. Returns metrics dict."""
 
     catalog = TaskCatalog(cfg.catalog)
     owns_recorder = recorder is None
     rec = recorder or RunRecorder(cfg.output_dir)
-    seed_everything(2025, workers=True)
+    seed_everything(cfg.seed, workers=True)
 
     try:
         model, ckpt_tasks = _rebuild_model(cfg, catalog)
+        model = model.to(_resolve_device(cfg.accelerator))
         heads = set(model.task_heads)
         requested = cfg.tasks or [t for t in ckpt_tasks if t in heads]
         missing = [t for t in requested if t not in heads]

--- a/src/foundation_model/workflows/predict.py
+++ b/src/foundation_model/workflows/predict.py
@@ -35,6 +35,7 @@ from .task_catalog import TaskCatalog, TaskCatalogConfig, TaskKind, build_task_c
 _PREDICT_ROOT_KEYS = {"data", "descriptor", "datasets", "tasks", "model", "predict", "output"}
 _CATALOG_KEYS = {"data", "descriptor", "datasets", "tasks"}
 _SPLITS = {"train", "val", "test", "all"}
+_ACCELERATORS = {"auto", "cpu"}
 
 
 @dataclass(kw_only=True)
@@ -55,6 +56,8 @@ class PredictConfig:
         self.output_dir = Path(self.output_dir)
         if self.split not in _SPLITS:
             raise ValueError(f"predict.split must be one of {sorted(_SPLITS)}, got {self.split!r}.")
+        if self.accelerator not in _ACCELERATORS:
+            raise ValueError(f"predict.accelerator must be one of {sorted(_ACCELERATORS)}, got {self.accelerator!r}.")
         catalog_tasks = {t.name for t in self.catalog.tasks}
         unknown = [t for t in self.tasks if t not in catalog_tasks]
         if unknown:

--- a/src/foundation_model/workflows/predict_test.py
+++ b/src/foundation_model/workflows/predict_test.py
@@ -128,6 +128,12 @@ def test_seed_and_accelerator_parsed(data_dir) -> None:
     assert cfg.seed == 7 and cfg.accelerator == "cpu"
 
 
+def test_invalid_accelerator_raises(data_dir) -> None:
+    # a typo must fail, not silently fall back to CUDA-if-available.
+    with pytest.raises(ValueError, match="accelerator must be one of"):
+        _predict_cfg(data_dir, "o", "ck.pt", predict_block='accelerator = "cpuu"')
+
+
 def test_predict_unknown_key_rejected(data_dir) -> None:
     with pytest.raises(ValueError, match="unknown key"):
         _predict_cfg(data_dir, "o", "ck.pt", predict_block="bogus = 1")

--- a/src/foundation_model/workflows/predict_test.py
+++ b/src/foundation_model/workflows/predict_test.py
@@ -123,6 +123,16 @@ def test_unknown_task_raises(data_dir) -> None:
         _predict_cfg(data_dir, "o", "ck.pt", predict_block='tasks = ["nope"]')
 
 
+def test_seed_and_accelerator_parsed(data_dir) -> None:
+    cfg = _predict_cfg(data_dir, "o", "ck.pt", predict_block='seed = 7\naccelerator = "cpu"')
+    assert cfg.seed == 7 and cfg.accelerator == "cpu"
+
+
+def test_predict_unknown_key_rejected(data_dir) -> None:
+    with pytest.raises(ValueError, match="unknown key"):
+        _predict_cfg(data_dir, "o", "ck.pt", predict_block="bogus = 1")
+
+
 def test_compositions_override_split(data_dir) -> None:
     cfg = _predict_cfg(data_dir, "o", "ck.pt", predict_block='split = "test"\ncompositions = ["Fe2 O3"]')
     assert cfg.compositions == ["Fe2 O3"]  # documented: compositions win over split

--- a/src/foundation_model/workflows/pretrain.py
+++ b/src/foundation_model/workflows/pretrain.py
@@ -83,9 +83,11 @@ def _validate_replay_amount(value: float | int, *, where: str) -> None:
 class RehearsalConfig:
     """[pretrain.rehearsal] — interval schedule + replay amounts."""
 
-    interval: int = 1
-    default_replay: float | int = 0.05
-    per_task: dict[str, float | int] = field(default_factory=dict)
+    interval: int = 1  # old tasks rejoin training every Nth step (1 = always replay)
+    default_replay: float | int = (
+        0.05  # replay amount per old task: float in (0,1) = fraction of its labels, int >= 1 = count
+    )
+    per_task: dict[str, float | int] = field(default_factory=dict)  # override default_replay for named tasks
 
     def __post_init__(self) -> None:
         if self.interval < 1:
@@ -97,14 +99,16 @@ class RehearsalConfig:
 
 @dataclass(kw_only=True)
 class PretrainConfig:
+    """``[pretrain]`` + shared sections — continual-rehearsal pre-training config."""
+
     catalog: TaskCatalogConfig
     model: ModelSectionConfig
     training: TrainingSectionConfig
     rehearsal: RehearsalConfig
     output_dir: Path
-    task_sequence: list[str] = field(default_factory=list)
-    n_runs: int = 1
-    task_order: TaskOrder = TaskOrder.FIXED
+    task_sequence: list[str] = field(default_factory=list)  # order tasks are introduced; [] = [[tasks]] order
+    n_runs: int = 1  # independent repeats (different seeds) written to runs/runNN/
+    task_order: TaskOrder = TaskOrder.FIXED  # "fixed" (task_sequence order) or "random" (per-run shuffle)
 
     def __post_init__(self) -> None:
         self.output_dir = Path(self.output_dir)


### PR DESCRIPTION
## Summary

Answers "is every CLI parameter documented in detail?" — audited all config fields, wrote an
authoritative schema doc, and fixed the gaps the audit surfaced. Stacked on #28.

### `docs/configuration.md` (new)
A per-key reference for all four subcommands: every section (`[data]`, `[descriptor]`,
`[datasets.*]`, `[[tasks]]` (+ `.scaler`), `[model]`, `[training]` (+ `.early_stopping` /
`.checkpoint` / `.logging`), `[output]`, `[pretrain]` (+ `.rehearsal`), `[finetune]`, `[predict]`,
`[inverse]` (+ `.seeds` / `[[.scenarios]]` / `[[.paths]]`)) with **type, default, constraint, and
description** per key, a which-subcommand-reads-what matrix, precedence rules, the CLI-flag table,
and worked examples. Linked from README + AGENTS.

### Bug fix — `fm predict --seed` / `--accelerator` crashed
Both flags are advertised via `common_options` but routed to a `[training]` section that
`build_predict_config` rejects (`unknown key 'training'`) — the same class as the inverse bug fixed
in PR4, never fixed for predict. Now:
- routed to `[predict].seed` / `[predict].accelerator` (fields + accepted keys added),
- `seed` drives `seed_everything` + provenance,
- `accelerator` resolves the device (`auto` → CUDA-if-available, else CPU) and moves the model —
  predict was previously **CPU-only**.

### Doc/description polish
- `--config` had **no** help text → added; `--seed` / `--accelerator` / `--set` help reworded to be
  accurate now that seed/accelerator route per subcommand.
- The previously-bare `[pretrain]` / `[pretrain.rehearsal]` / `[finetune]` command-section fields
  now have inline descriptions.

## Validation

- New tests: predict `seed`/`accelerator` config parsing + unknown-key rejection, and a CLI-routing
  regression that `--seed`/`--accelerator` land in `[predict]` (not `[training]`).
- Full suite **375 passed**; ruff/mypy clean; the four-command relay chain still runs end-to-end;
  `fm predict --seed 7 --accelerator cpu` runs and records seed 7 in provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCoVwB3pntFi25YnpoHYwY