### PR TITLE
PR11 — pretrain warm-start + --resume (kill-restart)

### DIFF
--- a/.github/instructions/rikyu-supercomputer.instructions.md
+++ b/.github/instructions/rikyu-supercomputer.instructions.md
@@ -49,6 +49,23 @@ ssh rikyu-login 'cat > /home/ea0094/jobs/smoke/job.sbatch' < ./job.sbatch
 Note: on `1n1gpu`, `nvidia-smi` may show another user's process on the same physical GB200 —
 GPU memory is large but do not assume the card is exclusively idle; check before large allocations.
 
+## Long pre-training past the walltime (`fm pretrain --resume`)
+
+Partitions cap at **4 days**. A `fm pretrain` run whose `task_sequence` won't finish in one job can
+be re-submitted with **`--resume`**: it warm-starts from the output dir's latest step checkpoint and
+continues at the next task in place (finished runs are skipped). Use the **same** `--output-dir` and
+put it on persistent storage (not per-job `/scratch`, which is deleted at job end). A resubmit-until-
+done pattern: make the sbatch script re-queue itself while `final_model.pt` is absent, e.g.
+
+```bash
+OUT=/home/ea0094/projects/foundation_model/artifacts/pretrain_big
+.venv/bin/fm pretrain --config pretrain.toml --output-dir "$OUT" --resume
+test -f "$OUT/training/final_model.pt" || sbatch "$0"   # (n_runs=1; adjust the path for sweeps)
+```
+
+Resume is per completed task-step (a step killed mid-fit restarts from the previous step's
+checkpoint); optimizer state is not restored, which is fine since each step trains a fresh optimizer.
+
 ## Modules
 
 ```bash

--- a/.github/instructions/rikyu-supercomputer.instructions.md
+++ b/.github/instructions/rikyu-supercomputer.instructions.md
@@ -157,14 +157,34 @@ cd "$PROJ"
 
 # ... optionally stage data into "$USER_SCRATCH_DIR" ...
 
-"$VENV_PY" -m foundation_model.cli.main pretrain --config <toml>   # or: fm pretrain ... (symlink on PATH)
+"$VENV_PY" -m foundation_model.cli.main pretrain --config <toml> --output-dir <persistent-dir>
+# or, with the symlink on PATH:  fm pretrain --config <toml> --output-dir <persistent-dir>
 
 # ... copy results from "$USER_SCRATCH_DIR" back to "$SLURM_SUBMIT_DIR" ...
 ```
 
-## Multi-GPU / multi-node MPI (per docs)
+## GPU selection (`[training].accelerator` / `devices`)
 
-For MPI/NCCL jobs on the multi-GPU partitions, set:
+The `fm` CLI drives a Lightning `Trainer`, so the GPU is chosen by the `[training]` config, not by
+env vars. Both default to **`"auto"`**, so on any GPU job (`--gpus-per-node>=1` + `module load nvhpc`)
+`fm pretrain` / `fm finetune` use the allocated GPU(s) automatically — no config change needed on
+`1n1gpu`. To pin devices on a multi-GPU partition (`1n2gpu` / `1n4gpu`), set `[training].devices`:
+
+```toml
+[training]
+accelerator = "auto"   # or "gpu"
+devices = -1            # all allocated GPUs (single-node DDP); or an int count, or e.g. [0, 1]
+```
+
+Lightning spawns single-node DDP itself (NCCL) — you do **not** launch it under `srun`/`mpirun` or
+set the MPI env below for single-node multi-GPU. `fm predict` / `fm inverse` are single-device
+(`accelerator = "auto" | "cpu"`, no `devices`).
+
+## Multi-node MPI env (generic; the `fm` CLI is single-node)
+
+The `fm` CLI does not expose `num_nodes`, so it targets a **single node**. These env vars are for
+hand-rolled MPI/NCCL jobs on the multi-node partitions (`2n4gpu` / `4n4gpu`), per the rikyu docs —
+not needed for the single-node DDP above:
 
 ```bash
 export OMPI_MCA_pml=ucx
@@ -181,4 +201,3 @@ export CUDA_VISIBLE_DEVICES=${OMPI_COMM_WORLD_LOCAL_RANK:-0}
 
 `pyproject.toml` / `uv.lock` are shared via git (`origin` = `TsumiNa/foundation_model`).
 Commit on one clone, `git pull` on the other, then `uv sync` on each. `.venv` is git-ignored.
-```

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,10 @@
     Supports **warm-start** from a checkpoint (`--checkpoint` / `[pretrain].checkpoint`): loads the
     checkpoint's encoder + heads, treats its tasks as already-learned, and continues the sequence
     with the remaining tasks — i.e. extend a trained model with new tasks. (`fm finetune` already
-    warm-starts, since it loads a checkpoint to fine-tune.)
+    warm-starts, since it loads a checkpoint to fine-tune.) With `--resume` (`[pretrain].resume`),
+    a run killed mid-sequence (e.g. a scheduler job timeout) picks up in place from its output dir's
+    latest step checkpoint on re-submit; finished runs are skipped. Resume granularity is one
+    completed task-step (each step already trains a fresh optimizer, so no optimizer state is kept).
   - `fm finetune` — frozen-encoder fine-tuning of selected heads; the AE head **stays trainable**
     (at `ae_lr`) and `task_log_sigmas` are frozen; non-target heads are disabled for the fit and
     restored before saving so the checkpoint keeps every head.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@
   `build_*_config(toml) → run(cfg, recorder)` dispatch — no business logic in the CLI:
   - `fm pretrain` — continual-rehearsal pre-training with a rehearsal-**interval** replay schedule
     (old tasks join only every Nth step), fraction/count replay amounts, and an `n_runs` sweep.
+    Supports **warm-start** from a checkpoint (`--checkpoint` / `[pretrain].checkpoint`): loads the
+    checkpoint's encoder + heads, treats its tasks as already-learned, and continues the sequence
+    with the remaining tasks — i.e. extend a trained model with new tasks. (`fm finetune` already
+    warm-starts, since it loads a checkpoint to fine-tune.)
   - `fm finetune` — frozen-encoder fine-tuning of selected heads; the AE head **stays trainable**
     (at `ae_lr`) and `task_log_sigmas` are frozen; non-target heads are disabled for the fit and
     restored before saving so the checkpoint keeps every head.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -185,6 +185,7 @@ finetune/inverse/predict consume. Enable to *also* emit Lightning `.ckpt` files.
 | `n_runs` | int | `1` | `>= 1` | Independent repeats (different seeds), written to `runs/runNN/`. |
 | `task_order` | str | `"fixed"` | `fixed` \| `random` | `fixed` = `task_sequence` order; `random` = per-run shuffle. |
 | `checkpoint` | str (path) | `None` | | **Warm-start**: load this checkpoint's encoder + heads as the starting point (`--checkpoint` overrides). Its tasks count as already-learned and are skipped as new steps (they still take part in rehearsal + evaluation); training continues with the `task_sequence` tasks the checkpoint doesn't already contain. Errors if a checkpoint task isn't in the catalog, or if every `task_sequence` task is already in the checkpoint. |
+| `resume` | bool | `false` | | **Kill-restart** (`--resume` sets it): on start, if a run's output dir already holds step checkpoints, warm-start from the latest and continue **in place** at the next task; a run whose `final_model.pt` exists is skipped. For long pre-training that can exceed a scheduler's job time — re-submit the same command and it picks up where it stopped. Resume granularity is one completed task-step; optimizer state is not restored (each step trains a fresh optimizer regardless). |
 
 ### `[pretrain.rehearsal]`
 
@@ -301,7 +302,7 @@ Per-subcommand flags:
 
 | Subcommand | Flags |
 |---|---|
-| `pretrain` | `--max-epochs N` (→ `training.max_epochs`), `--checkpoint PATH` (warm-start / continue a sequence) |
+| `pretrain` | `--max-epochs N` (→ `training.max_epochs`), `--checkpoint PATH` (warm-start / continue a sequence), `--resume` (continue after a kill from the output dir's latest step checkpoint) |
 | `finetune` | `--checkpoint PATH`, `--tasks a,b` (→ `finetune.tasks`), `--epochs N` |
 | `inverse` | `--checkpoint PATH`, `--scenario NAME` (repeatable; run only these), `--steps N`, `--no-trajectory`, `--animation-formats gif,html,svg` |
 | `predict` | `--checkpoint PATH`, `--tasks a,b`, `--split train\|val\|test\|all`, `--compositions "Fe2 O3,Al2 O3"` (overrides split), `--no-metrics` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -184,6 +184,7 @@ finetune/inverse/predict consume. Enable to *also* emit Lightning `.ckpt` files.
 | `task_sequence` | list[str] | `[]` → `[[tasks]]` order | tasks must exist | Order tasks are introduced across steps. |
 | `n_runs` | int | `1` | `>= 1` | Independent repeats (different seeds), written to `runs/runNN/`. |
 | `task_order` | str | `"fixed"` | `fixed` \| `random` | `fixed` = `task_sequence` order; `random` = per-run shuffle. |
+| `checkpoint` | str (path) | `None` | | **Warm-start**: load this checkpoint's encoder + heads as the starting point (`--checkpoint` overrides). Its tasks count as already-learned and are skipped as new steps (they still take part in rehearsal + evaluation); training continues with the `task_sequence` tasks the checkpoint doesn't already contain. Errors if a checkpoint task isn't in the catalog, or if every `task_sequence` task is already in the checkpoint. |
 
 ### `[pretrain.rehearsal]`
 
@@ -300,7 +301,7 @@ Per-subcommand flags:
 
 | Subcommand | Flags |
 |---|---|
-| `pretrain` | `--max-epochs N` (→ `training.max_epochs`) |
+| `pretrain` | `--max-epochs N` (→ `training.max_epochs`), `--checkpoint PATH` (warm-start / continue a sequence) |
 | `finetune` | `--checkpoint PATH`, `--tasks a,b` (→ `finetune.tasks`), `--epochs N` |
 | `inverse` | `--checkpoint PATH`, `--scenario NAME` (repeatable; run only these), `--steps N`, `--no-trajectory`, `--animation-formats gif,html,svg` |
 | `predict` | `--checkpoint PATH`, `--tasks a,b`, `--split train\|val\|test\|all`, `--compositions "Fe2 O3,Al2 O3"` (overrides split), `--no-metrics` |

--- a/src/foundation_model/cli/main.py
+++ b/src/foundation_model/cli/main.py
@@ -132,16 +132,23 @@ def _pretrain_config(
     accelerator: str | None,
     sample: int | None,
     max_epochs: int | None,
+    checkpoint: str | None,
 ) -> PretrainConfig:
     raw = load_raw_config(config_path, overrides, seed=seed, accelerator=accelerator, sample=sample)
     if max_epochs is not None:
         _set_dotted(raw, "training.max_epochs", max_epochs)
-    return build_pretrain_config(raw, output_dir=output_dir)
+    return build_pretrain_config(raw, output_dir=output_dir, checkpoint=checkpoint)
 
 
 @main.command("pretrain")
 @common_options
 @click.option("--max-epochs", type=int, default=None, help="Override training.max_epochs.")
+@click.option(
+    "--checkpoint",
+    default=None,
+    type=click.Path(dir_okay=False),
+    help="Warm-start from this checkpoint (continue the sequence).",
+)
 def pretrain_cmd(
     config_path: str,
     output_dir: str | None,
@@ -150,9 +157,10 @@ def pretrain_cmd(
     accelerator: str | None,
     sample: int | None,
     max_epochs: int | None,
+    checkpoint: str | None,
 ) -> None:
     """Continual-rehearsal pre-training (multi-run sweep)."""
-    cfg = _pretrain_config(config_path, overrides, output_dir, seed, accelerator, sample, max_epochs)
+    cfg = _pretrain_config(config_path, overrides, output_dir, seed, accelerator, sample, max_epochs, checkpoint)
     recorder = RunRecorder(cfg.output_dir)
     recorder.write_provenance(config=cfg, argv=list(sys.argv), seeds={"seed": cfg.training.seed})
     pretrain_run(cfg, recorder)

--- a/src/foundation_model/cli/main.py
+++ b/src/foundation_model/cli/main.py
@@ -133,11 +133,12 @@ def _pretrain_config(
     sample: int | None,
     max_epochs: int | None,
     checkpoint: str | None,
+    resume: bool,
 ) -> PretrainConfig:
     raw = load_raw_config(config_path, overrides, seed=seed, accelerator=accelerator, sample=sample)
     if max_epochs is not None:
         _set_dotted(raw, "training.max_epochs", max_epochs)
-    return build_pretrain_config(raw, output_dir=output_dir, checkpoint=checkpoint)
+    return build_pretrain_config(raw, output_dir=output_dir, checkpoint=checkpoint, resume=resume)
 
 
 @main.command("pretrain")
@@ -149,6 +150,12 @@ def _pretrain_config(
     type=click.Path(dir_okay=False),
     help="Warm-start from this checkpoint (continue the sequence).",
 )
+@click.option(
+    "--resume",
+    is_flag=True,
+    default=False,
+    help="Resume from the latest step checkpoint in the output dir (continue after a kill).",
+)
 def pretrain_cmd(
     config_path: str,
     output_dir: str | None,
@@ -158,9 +165,12 @@ def pretrain_cmd(
     sample: int | None,
     max_epochs: int | None,
     checkpoint: str | None,
+    resume: bool,
 ) -> None:
     """Continual-rehearsal pre-training (multi-run sweep)."""
-    cfg = _pretrain_config(config_path, overrides, output_dir, seed, accelerator, sample, max_epochs, checkpoint)
+    cfg = _pretrain_config(
+        config_path, overrides, output_dir, seed, accelerator, sample, max_epochs, checkpoint, resume
+    )
     recorder = RunRecorder(cfg.output_dir)
     recorder.write_provenance(config=cfg, argv=list(sys.argv), seeds={"seed": cfg.training.seed})
     pretrain_run(cfg, recorder)

--- a/src/foundation_model/cli/main_test.py
+++ b/src/foundation_model/cli/main_test.py
@@ -72,12 +72,14 @@ def _write_config(tmp_path):
 
 
 def test_set_override_applies_to_built_config(tmp_path) -> None:
-    cfg = _pretrain_config(_write_config(tmp_path), ("training.max_epochs=3",), None, None, None, None, None, None)
+    cfg = _pretrain_config(
+        _write_config(tmp_path), ("training.max_epochs=3",), None, None, None, None, None, None, False
+    )
     assert cfg.training.max_epochs == 3
 
 
 def test_max_epochs_flag_overrides(tmp_path) -> None:
-    cfg = _pretrain_config(_write_config(tmp_path), (), None, None, None, None, 5, None)
+    cfg = _pretrain_config(_write_config(tmp_path), (), None, None, None, None, 5, None, False)
     assert cfg.training.max_epochs == 5
 
 
@@ -88,7 +90,7 @@ def test_seed_and_sample_flags_map_into_tree(tmp_path) -> None:
 
 
 def test_output_dir_flag_overrides(tmp_path) -> None:
-    cfg = _pretrain_config(_write_config(tmp_path), (), "/tmp/custom", None, None, None, None, None)
+    cfg = _pretrain_config(_write_config(tmp_path), (), "/tmp/custom", None, None, None, None, None, False)
     assert str(cfg.output_dir) == "/tmp/custom"
 
 

--- a/src/foundation_model/cli/main_test.py
+++ b/src/foundation_model/cli/main_test.py
@@ -72,12 +72,12 @@ def _write_config(tmp_path):
 
 
 def test_set_override_applies_to_built_config(tmp_path) -> None:
-    cfg = _pretrain_config(_write_config(tmp_path), ("training.max_epochs=3",), None, None, None, None, None)
+    cfg = _pretrain_config(_write_config(tmp_path), ("training.max_epochs=3",), None, None, None, None, None, None)
     assert cfg.training.max_epochs == 3
 
 
 def test_max_epochs_flag_overrides(tmp_path) -> None:
-    cfg = _pretrain_config(_write_config(tmp_path), (), None, None, None, None, 5)
+    cfg = _pretrain_config(_write_config(tmp_path), (), None, None, None, None, 5, None)
     assert cfg.training.max_epochs == 5
 
 
@@ -88,7 +88,7 @@ def test_seed_and_sample_flags_map_into_tree(tmp_path) -> None:
 
 
 def test_output_dir_flag_overrides(tmp_path) -> None:
-    cfg = _pretrain_config(_write_config(tmp_path), (), "/tmp/custom", None, None, None, None)
+    cfg = _pretrain_config(_write_config(tmp_path), (), "/tmp/custom", None, None, None, None, None)
     assert str(cfg.output_dir) == "/tmp/custom"
 
 

--- a/src/foundation_model/workflows/_engine.py
+++ b/src/foundation_model/workflows/_engine.py
@@ -11,6 +11,7 @@ use one implementation. Only :class:`RunRecorder` writes files.
 from __future__ import annotations
 
 import ast
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -35,6 +36,20 @@ from .task_catalog import TaskCatalog, TaskConfig, TaskKind
 AE_NAME = "__reconstruction__"
 # Legacy weight decay for regression / classification heads (kernel heads use kr_weight_decay).
 _HEAD_WEIGHT_DECAY = 1e-5
+
+
+def task_names_from_state(state_dict: Mapping[str, Any]) -> list[str]:
+    """Task-head names in a state dict (``task_heads.<name>.*``), in first-seen order, minus the AE.
+
+    Used when a checkpoint carries no ``task_sequence`` list (e.g. a bare/Lightning state dict).
+    """
+    names: list[str] = []
+    for key in state_dict:
+        if key.startswith("task_heads."):
+            name = key.split(".", 2)[1]
+            if name != AE_NAME and name not in names:
+                names.append(name)
+    return names
 
 
 def build_encoder_config(model: ModelSectionConfig, descriptor_dim: int) -> MLPEncoderConfig:

--- a/src/foundation_model/workflows/_engine.py
+++ b/src/foundation_model/workflows/_engine.py
@@ -52,6 +52,18 @@ def task_names_from_state(state_dict: Mapping[str, Any]) -> list[str]:
     return names
 
 
+def checkpoint_task_order(state: Mapping[str, Any]) -> list[str]:
+    """Every task head present in a loaded checkpoint, ordered by its ``task_sequence`` when given.
+
+    The state dict is the ground truth for which heads *exist*; ``task_sequence`` only records order
+    — and a pretrain **step** checkpoint stores just that step's active subset — so heads that are in
+    the weights but missing from ``task_sequence`` are appended rather than silently dropped.
+    """
+    in_state = task_names_from_state(state["model"])
+    ordered = [t for t in (state.get("task_sequence") or []) if t in in_state]
+    return ordered + [h for h in in_state if h not in ordered]
+
+
 def build_encoder_config(model: ModelSectionConfig, descriptor_dim: int) -> MLPEncoderConfig:
     """MLP encoder ``descriptor_dim → *encoder_hidden_dims → latent_dim`` from ``[model]``."""
     return MLPEncoderConfig(hidden_dims=[descriptor_dim, *model.encoder_hidden_dims, model.latent_dim])

--- a/src/foundation_model/workflows/inverse.py
+++ b/src/foundation_model/workflows/inverse.py
@@ -36,14 +36,12 @@ from loguru import logger  # noqa: E402
 from foundation_model.utils.kmd_plus import DEFAULT_ELEMENTS, formula_to_composition  # noqa: E402
 
 from . import inverse_trajectory  # noqa: E402
-from ._engine import build_model_for_checkpoint  # noqa: E402
+from ._engine import build_model_for_checkpoint, task_names_from_state  # noqa: E402
 from ._sections import ModelSectionConfig, build_model_section, reject_unknown  # noqa: E402
 from .plots import DISCOVERED_ELEMENT_COLOR, SCATTER_COLOR  # noqa: E402
 from .recording import RunRecorder, load_checkpoint_state  # noqa: E402
 from .task_catalog import TaskCatalog, TaskCatalogConfig, build_task_catalog_config  # noqa: E402
 
-# Reserved AE head name.
-_AE_NAME = "__reconstruction__"
 # Default QC class indices for the classification objective when class_target is unset.
 _DEFAULT_QC_CLASSES = [1]
 _ANIMATION_FORMATS = {"gif", "html", "svg"}
@@ -392,7 +390,7 @@ def _element_system(composition: str) -> frozenset[str]:
 
 def _rebuild_model(cfg: InverseConfig, catalog: TaskCatalog) -> tuple[Any, list[str]]:
     state = load_checkpoint_state(cfg.checkpoint)
-    ckpt_tasks = list(state.get("task_sequence") or _task_names_from_state(state["model"]))
+    ckpt_tasks = list(state.get("task_sequence") or task_names_from_state(state["model"]))
     catalog_tasks = {t.name for t in cfg.catalog.tasks}
     missing = [t for t in ckpt_tasks if t not in catalog_tasks]
     if missing:
@@ -402,16 +400,6 @@ def _rebuild_model(cfg: InverseConfig, catalog: TaskCatalog) -> tuple[Any, list[
     model.load_state_dict(state["model"], strict=False)
     model.eval()
     return model, ckpt_tasks
-
-
-def _task_names_from_state(state_dict: Mapping[str, Any]) -> list[str]:
-    names: list[str] = []
-    for key in state_dict:
-        if key.startswith("task_heads."):
-            name = key.split(".", 2)[1]
-            if name != _AE_NAME and name not in names:
-                names.append(name)
-    return names
 
 
 def _dedup_by_system(candidates: Sequence[str], n: int, *, enabled: bool) -> list[str]:

--- a/src/foundation_model/workflows/inverse.py
+++ b/src/foundation_model/workflows/inverse.py
@@ -36,7 +36,7 @@ from loguru import logger  # noqa: E402
 from foundation_model.utils.kmd_plus import DEFAULT_ELEMENTS, formula_to_composition  # noqa: E402
 
 from . import inverse_trajectory  # noqa: E402
-from ._engine import build_model_for_checkpoint, task_names_from_state  # noqa: E402
+from ._engine import build_model_for_checkpoint, checkpoint_task_order  # noqa: E402
 from ._sections import ModelSectionConfig, build_model_section, reject_unknown  # noqa: E402
 from .plots import DISCOVERED_ELEMENT_COLOR, SCATTER_COLOR  # noqa: E402
 from .recording import RunRecorder, load_checkpoint_state  # noqa: E402
@@ -390,7 +390,7 @@ def _element_system(composition: str) -> frozenset[str]:
 
 def _rebuild_model(cfg: InverseConfig, catalog: TaskCatalog) -> tuple[Any, list[str]]:
     state = load_checkpoint_state(cfg.checkpoint)
-    ckpt_tasks = list(state.get("task_sequence") or task_names_from_state(state["model"]))
+    ckpt_tasks = checkpoint_task_order(state)
     catalog_tasks = {t.name for t in cfg.catalog.tasks}
     missing = [t for t in ckpt_tasks if t not in catalog_tasks]
     if missing:

--- a/src/foundation_model/workflows/predict.py
+++ b/src/foundation_model/workflows/predict.py
@@ -27,7 +27,7 @@ from sklearn.metrics import accuracy_score, f1_score, mean_absolute_error, r2_sc
 
 from foundation_model.data.composition_sources import canonical_key, normalize_composition
 
-from ._engine import as_float_array, build_model_for_checkpoint, task_names_from_state
+from ._engine import as_float_array, build_model_for_checkpoint, checkpoint_task_order
 from ._sections import ModelSectionConfig, build_model_section, reject_unknown
 from .recording import RunRecorder, load_checkpoint_state
 from .task_catalog import TaskCatalog, TaskCatalogConfig, TaskKind, build_task_catalog_config
@@ -149,7 +149,7 @@ def run(cfg: PredictConfig, recorder: RunRecorder | None = None) -> dict[str, An
 
 def _rebuild_model(cfg: PredictConfig, catalog: TaskCatalog) -> tuple[Any, list[str]]:
     state = load_checkpoint_state(cfg.checkpoint)
-    ckpt_tasks = list(state.get("task_sequence") or task_names_from_state(state["model"]))
+    ckpt_tasks = checkpoint_task_order(state)
     catalog_tasks = {t.name for t in cfg.catalog.tasks}
     missing = [t for t in ckpt_tasks if t not in catalog_tasks]
     if missing:

--- a/src/foundation_model/workflows/predict.py
+++ b/src/foundation_model/workflows/predict.py
@@ -27,7 +27,7 @@ from sklearn.metrics import accuracy_score, f1_score, mean_absolute_error, r2_sc
 
 from foundation_model.data.composition_sources import canonical_key, normalize_composition
 
-from ._engine import AE_NAME, as_float_array, build_model_for_checkpoint
+from ._engine import as_float_array, build_model_for_checkpoint, task_names_from_state
 from ._sections import ModelSectionConfig, build_model_section, reject_unknown
 from .recording import RunRecorder, load_checkpoint_state
 from .task_catalog import TaskCatalog, TaskCatalogConfig, TaskKind, build_task_catalog_config
@@ -98,16 +98,6 @@ def build_predict_config(
     )
 
 
-def _task_names_from_state(state_dict: Mapping[str, Any]) -> list[str]:
-    names: list[str] = []
-    for key in state_dict:
-        if key.startswith("task_heads."):
-            name = key.split(".", 2)[1]
-            if name != AE_NAME and name not in names:
-                names.append(name)
-    return names
-
-
 def _resolve_device(accelerator: str) -> torch.device:
     """``"cpu"`` forces CPU; ``"auto"`` uses CUDA when available, else CPU."""
     if accelerator != "cpu" and torch.cuda.is_available():
@@ -159,7 +149,7 @@ def run(cfg: PredictConfig, recorder: RunRecorder | None = None) -> dict[str, An
 
 def _rebuild_model(cfg: PredictConfig, catalog: TaskCatalog) -> tuple[Any, list[str]]:
     state = load_checkpoint_state(cfg.checkpoint)
-    ckpt_tasks = list(state.get("task_sequence") or _task_names_from_state(state["model"]))
+    ckpt_tasks = list(state.get("task_sequence") or task_names_from_state(state["model"]))
     catalog_tasks = {t.name for t in cfg.catalog.tasks}
     missing = [t for t in ckpt_tasks if t not in catalog_tasks]
     if missing:

--- a/src/foundation_model/workflows/pretrain.py
+++ b/src/foundation_model/workflows/pretrain.py
@@ -37,6 +37,7 @@ from ._engine import (
     build_head_config,
     build_trainer_extras,
     evaluate_task,
+    task_names_from_state,
 )
 from ._sections import (
     ModelSectionConfig,
@@ -45,7 +46,7 @@ from ._sections import (
     build_training_section,
     reject_unknown,
 )
-from .recording import RunRecorder
+from .recording import RunRecorder, load_checkpoint_state
 from .task_catalog import TaskCatalog, TaskCatalogConfig, TaskKind, build_task_catalog_config
 
 # Stable qualitative palette so each task keeps one colour across the forgetting figure.
@@ -109,9 +110,14 @@ class PretrainConfig:
     task_sequence: list[str] = field(default_factory=list)  # order tasks are introduced; [] = [[tasks]] order
     n_runs: int = 1  # independent repeats (different seeds) written to runs/runNN/
     task_order: TaskOrder = TaskOrder.FIXED  # "fixed" (task_sequence order) or "random" (per-run shuffle)
+    # Warm-start: load encoder + heads from this checkpoint, treat its tasks as already learned, and
+    # continue the sequence with the task_sequence tasks it doesn't already contain. None = from scratch.
+    checkpoint: Path | None = None
 
     def __post_init__(self) -> None:
         self.output_dir = Path(self.output_dir)
+        if self.checkpoint is not None:
+            self.checkpoint = Path(self.checkpoint)
         if not isinstance(self.task_order, TaskOrder):
             self.task_order = TaskOrder(str(self.task_order))
         if self.n_runs < 1:
@@ -130,7 +136,9 @@ class PretrainConfig:
 # --- builder ------------------------------------------------------------------------------
 
 
-def build_pretrain_config(raw: Mapping[str, Any], *, output_dir: str | Path | None = None) -> PretrainConfig:
+def build_pretrain_config(
+    raw: Mapping[str, Any], *, output_dir: str | Path | None = None, checkpoint: str | Path | None = None
+) -> PretrainConfig:
     """Normalize a parsed-TOML tree into a :class:`PretrainConfig`."""
 
     reject_unknown("<root>", raw, _PRETRAIN_ROOT_KEYS)
@@ -139,7 +147,7 @@ def build_pretrain_config(raw: Mapping[str, Any], *, output_dir: str | Path | No
     training = build_training_section(raw.get("training", {}))
 
     pretrain_raw = dict(raw.get("pretrain", {}))
-    reject_unknown("pretrain", pretrain_raw, {"task_sequence", "n_runs", "task_order", "rehearsal"})
+    reject_unknown("pretrain", pretrain_raw, {"task_sequence", "n_runs", "task_order", "rehearsal", "checkpoint"})
     rehearsal_raw = dict(pretrain_raw.get("rehearsal", {}))
     reject_unknown("pretrain.rehearsal", rehearsal_raw, {"interval", "default_replay", "per_task"})
     rehearsal = RehearsalConfig(
@@ -151,6 +159,7 @@ def build_pretrain_config(raw: Mapping[str, Any], *, output_dir: str | Path | No
     resolved_output = output_dir if output_dir is not None else raw.get("output", {}).get("dir")
     if resolved_output is None:
         raise ValueError("output directory must be given via --output-dir or [output].dir.")
+    resolved_checkpoint = checkpoint if checkpoint is not None else pretrain_raw.get("checkpoint")
 
     return PretrainConfig(
         catalog=catalog,
@@ -161,6 +170,7 @@ def build_pretrain_config(raw: Mapping[str, Any], *, output_dir: str | Path | No
         task_sequence=list(pretrain_raw.get("task_sequence", [])),
         n_runs=int(pretrain_raw.get("n_runs", 1)),
         task_order=TaskOrder(str(pretrain_raw.get("task_order", "fixed"))),
+        checkpoint=Path(resolved_checkpoint) if resolved_checkpoint is not None else None,
     )
 
 
@@ -230,6 +240,29 @@ def _run_task_order(cfg: PretrainConfig, seed: int) -> list[str]:
     return list(cfg.task_sequence)
 
 
+def _warm_start(cfg: PretrainConfig, catalog: TaskCatalog) -> tuple[Any, list[str], dict[str, Any]]:
+    """Build the run's start model. With ``cfg.checkpoint`` set, load its encoder + heads (warm-start)
+    and return those tasks as already-learned; otherwise an empty (AE-only) model."""
+    model = build_empty_model(catalog, cfg.model, cfg.training)
+    if cfg.checkpoint is None:
+        return model, [], {}
+    state = load_checkpoint_state(cfg.checkpoint)
+    preloaded = list(state.get("task_sequence") or task_names_from_state(state["model"]))
+    catalog_tasks = {t.name for t in cfg.catalog.tasks}
+    missing = [t for t in preloaded if t not in catalog_tasks]
+    if missing:
+        raise ValueError(f"pretrain.checkpoint tasks {missing} are not in the catalog (have {sorted(catalog_tasks)}).")
+    built: dict[str, Any] = {}
+    for name in preloaded:
+        built[name] = build_head_config(catalog, cfg.model, cfg.training, name, init_from_data=False)
+        model.add_task(built[name])
+    incompatible = model.load_state_dict(state["model"], strict=False)
+    if incompatible.missing_keys:
+        logger.info(f"warm-start: {len(incompatible.missing_keys)} missing key(s) e.g. {incompatible.missing_keys[:6]}")
+    logger.info(f"warm-started from {cfg.checkpoint} with heads {preloaded}")
+    return model, preloaded, built
+
+
 def _run_single(
     cfg: PretrainConfig,
     catalog: TaskCatalog,
@@ -239,20 +272,26 @@ def _run_single(
     seed: int,
 ) -> list[dict[str, Any]]:
     seed_everything(seed, workers=True)
-    model = build_empty_model(catalog, cfg.model, cfg.training)
+    model, preloaded, built = _warm_start(cfg, catalog)
 
-    task_colors = {name: _TASK_PALETTE[i % len(_TASK_PALETTE)] for i, name in enumerate(task_order)}
-    clf_tasks = frozenset(n for n in task_order if catalog.task_spec(n).kind is TaskKind.CLASSIFICATION)
-    metric_history: dict[str, list[tuple[int, float]]] = {name: [] for name in task_order}
+    # New tasks = task_order entries not already loaded from the checkpoint; preloaded tasks are
+    # already trained and only participate as rehearsal/eval targets.
+    new_tasks = [t for t in task_order if t not in preloaded]
+    if not new_tasks:
+        raise ValueError("nothing to train: every task in task_sequence is already in pretrain.checkpoint.")
+    full_order = [*preloaded, *new_tasks]
+
+    task_colors = {name: _TASK_PALETTE[i % len(_TASK_PALETTE)] for i, name in enumerate(full_order)}
+    clf_tasks = frozenset(n for n in full_order if catalog.task_spec(n).kind is TaskKind.CLASSIFICATION)
+    metric_history: dict[str, list[tuple[int, float]]] = {name: [] for name in full_order}
     records: list[dict[str, Any]] = []
-    built: dict[str, Any] = {}
 
-    for step, task_name in enumerate(task_order, start=1):
-        logger.info(f"--- step {step}/{len(task_order)}: add '{task_name}' ---")
+    for step, task_name in enumerate(new_tasks, start=1):
+        logger.info(f"--- step {step}/{len(new_tasks)}: add '{task_name}' ---")
         built[task_name] = build_head_config(catalog, cfg.model, cfg.training, task_name, masking_ratio=1.0)
         model.add_task(built[task_name])
 
-        learned = list(task_order[: step - 1])
+        learned = [*preloaded, *new_tasks[: step - 1]]
         participating = active_old_tasks(step, learned, cfg.rehearsal.interval)
         active = [task_name, *participating]
         for name in participating:
@@ -294,7 +333,7 @@ def _run_single(
 
         step_dir = recorder.paths.step_dir(step, task_name)
         step_metrics: dict[str, dict[str, float]] = {}
-        for name in task_order[:step]:  # evaluate ALL learned heads, regardless of interval
+        for name in [*preloaded, *new_tasks[:step]]:  # ALL learned heads (preloaded + new-so-far)
             metric = evaluate_task(
                 model, catalog, name, recorder, step_dir, is_new=(name == task_name), test_keys=test_keys
             )
@@ -311,7 +350,7 @@ def _run_single(
     plots.plt.close(fig)
     recorder.write_records()
     recorder.write_metrics_table()
-    recorder.save_final_model(model, list(task_order), _task_spec_dump(catalog, task_order))
+    recorder.save_final_model(model, list(full_order), _task_spec_dump(catalog, full_order))
     return records
 
 

--- a/src/foundation_model/workflows/pretrain.py
+++ b/src/foundation_model/workflows/pretrain.py
@@ -36,8 +36,8 @@ from ._engine import (
     build_empty_model,
     build_head_config,
     build_trainer_extras,
+    checkpoint_task_order,
     evaluate_task,
-    task_names_from_state,
 )
 from ._sections import (
     ModelSectionConfig,
@@ -113,6 +113,11 @@ class PretrainConfig:
     # Warm-start: load encoder + heads from this checkpoint, treat its tasks as already learned, and
     # continue the sequence with the task_sequence tasks it doesn't already contain. None = from scratch.
     checkpoint: Path | None = None
+    # Resume: on (re)start, if a run's output dir already holds step checkpoints, warm-start from the
+    # latest and continue in place — so a job killed mid-sequence picks up at the next task. Completed
+    # runs (final_model.pt present) are skipped. Optimizer state is NOT restored (each step trains a
+    # fresh optimizer anyway); the resume granularity is one completed task-step.
+    resume: bool = False
 
     def __post_init__(self) -> None:
         self.output_dir = Path(self.output_dir)
@@ -137,7 +142,11 @@ class PretrainConfig:
 
 
 def build_pretrain_config(
-    raw: Mapping[str, Any], *, output_dir: str | Path | None = None, checkpoint: str | Path | None = None
+    raw: Mapping[str, Any],
+    *,
+    output_dir: str | Path | None = None,
+    checkpoint: str | Path | None = None,
+    resume: bool = False,
 ) -> PretrainConfig:
     """Normalize a parsed-TOML tree into a :class:`PretrainConfig`."""
 
@@ -147,7 +156,9 @@ def build_pretrain_config(
     training = build_training_section(raw.get("training", {}))
 
     pretrain_raw = dict(raw.get("pretrain", {}))
-    reject_unknown("pretrain", pretrain_raw, {"task_sequence", "n_runs", "task_order", "rehearsal", "checkpoint"})
+    reject_unknown(
+        "pretrain", pretrain_raw, {"task_sequence", "n_runs", "task_order", "rehearsal", "checkpoint", "resume"}
+    )
     rehearsal_raw = dict(pretrain_raw.get("rehearsal", {}))
     reject_unknown("pretrain.rehearsal", rehearsal_raw, {"interval", "default_replay", "per_task"})
     rehearsal = RehearsalConfig(
@@ -171,6 +182,7 @@ def build_pretrain_config(
         n_runs=int(pretrain_raw.get("n_runs", 1)),
         task_order=TaskOrder(str(pretrain_raw.get("task_order", "fixed"))),
         checkpoint=Path(resolved_checkpoint) if resolved_checkpoint is not None else None,
+        resume=resume or bool(pretrain_raw.get("resume", False)),
     )
 
 
@@ -216,8 +228,29 @@ def run(cfg: PretrainConfig, recorder: RunRecorder | None = None) -> dict[str, A
                 run_recorder = root_recorder
             else:
                 run_recorder = RunRecorder(cfg.output_dir / "runs" / f"run{run_idx:02d}")
+
+            # Resume: prefer a run's own latest step checkpoint (continue in place after a kill);
+            # fall back to the explicit warm-start checkpoint. A finished run is skipped.
+            source = cfg.checkpoint
+            if cfg.resume:
+                training_dir = run_recorder.paths.training
+                if (training_dir / "final_model.pt").exists():
+                    logger.info(f"=== pretrain run {run_idx + 1}/{cfg.n_runs}: already complete, skipping (resume) ===")
+                    continue
+                source = _latest_step_checkpoint(training_dir) or cfg.checkpoint
+                if source is not None:
+                    logger.info(f"resuming run {run_idx + 1}/{cfg.n_runs} from {source}")
+
             logger.info(f"=== pretrain run {run_idx + 1}/{cfg.n_runs} (seed={run_seed}) order={order} ===")
-            records = _run_single(cfg, catalog, run_recorder, task_order=order, seed=run_seed)
+            records = _run_single(
+                cfg,
+                catalog,
+                run_recorder,
+                task_order=order,
+                seed=run_seed,
+                warm_start_source=source,
+                is_resume=cfg.resume,
+            )
             for rec in records:
                 aggregate.append({"run": run_idx, **rec})
             if run_recorder is not root_recorder:
@@ -240,14 +273,24 @@ def _run_task_order(cfg: PretrainConfig, seed: int) -> list[str]:
     return list(cfg.task_sequence)
 
 
-def _warm_start(cfg: PretrainConfig, catalog: TaskCatalog) -> tuple[Any, list[str], dict[str, Any]]:
-    """Build the run's start model. With ``cfg.checkpoint`` set, load its encoder + heads (warm-start)
-    and return those tasks as already-learned; otherwise an empty (AE-only) model."""
+def _latest_step_checkpoint(training_dir: Path) -> Path | None:
+    """The highest-numbered ``stepNN_*/checkpoint.pt`` under a run's training dir (for --resume)."""
+    if not training_dir.exists():
+        return None
+    candidates = sorted(training_dir.glob("step*/checkpoint.pt"), key=lambda p: p.parent.name)
+    return candidates[-1] if candidates else None
+
+
+def _warm_start(
+    cfg: PretrainConfig, catalog: TaskCatalog, source: Path | None
+) -> tuple[Any, list[str], dict[str, Any]]:
+    """Build the run's start model. With ``source`` set, load its encoder + heads (warm-start) and
+    return those tasks as already-learned; otherwise an empty (AE-only) model."""
     model = build_empty_model(catalog, cfg.model, cfg.training)
-    if cfg.checkpoint is None:
+    if source is None:
         return model, [], {}
-    state = load_checkpoint_state(cfg.checkpoint)
-    preloaded = list(state.get("task_sequence") or task_names_from_state(state["model"]))
+    state = load_checkpoint_state(source)
+    preloaded = checkpoint_task_order(state)
     catalog_tasks = {t.name for t in cfg.catalog.tasks}
     missing = [t for t in preloaded if t not in catalog_tasks]
     if missing:
@@ -259,7 +302,7 @@ def _warm_start(cfg: PretrainConfig, catalog: TaskCatalog) -> tuple[Any, list[st
     incompatible = model.load_state_dict(state["model"], strict=False)
     if incompatible.missing_keys:
         logger.info(f"warm-start: {len(incompatible.missing_keys)} missing key(s) e.g. {incompatible.missing_keys[:6]}")
-    logger.info(f"warm-started from {cfg.checkpoint} with heads {preloaded}")
+    logger.info(f"warm-started from {source} with heads {preloaded}")
     return model, preloaded, built
 
 
@@ -270,14 +313,20 @@ def _run_single(
     *,
     task_order: Sequence[str],
     seed: int,
+    warm_start_source: Path | None = None,
+    is_resume: bool = False,
 ) -> list[dict[str, Any]]:
     seed_everything(seed, workers=True)
-    model, preloaded, built = _warm_start(cfg, catalog)
+    model, preloaded, built = _warm_start(cfg, catalog, warm_start_source)
 
     # New tasks = task_order entries not already loaded from the checkpoint; preloaded tasks are
     # already trained and only participate as rehearsal/eval targets.
     new_tasks = [t for t in task_order if t not in preloaded]
     if not new_tasks:
+        if is_resume:  # killed after the last step but before final_model was written — just finalize
+            recorder.save_final_model(model, list(preloaded), _task_spec_dump(catalog, preloaded))
+            logger.info("resume: every task already trained; wrote final_model.")
+            return []
         raise ValueError("nothing to train: every task in task_sequence is already in pretrain.checkpoint.")
     full_order = [*preloaded, *new_tasks]
 
@@ -286,12 +335,16 @@ def _run_single(
     metric_history: dict[str, list[tuple[int, float]]] = {name: [] for name in full_order}
     records: list[dict[str, Any]] = []
 
-    for step, task_name in enumerate(new_tasks, start=1):
-        logger.info(f"--- step {step}/{len(new_tasks)}: add '{task_name}' ---")
+    # Global step numbering continues past the preloaded tasks so the rehearsal-interval schedule
+    # picks up where the checkpoint left off (step == 1 for a from-scratch run, offset == 0).
+    offset = len(preloaded)
+    for i, task_name in enumerate(new_tasks):
+        step = offset + i + 1
+        logger.info(f"--- step {step}: add '{task_name}' (new {i + 1}/{len(new_tasks)}) ---")
         built[task_name] = build_head_config(catalog, cfg.model, cfg.training, task_name, masking_ratio=1.0)
         model.add_task(built[task_name])
 
-        learned = [*preloaded, *new_tasks[: step - 1]]
+        learned = [*preloaded, *new_tasks[:i]]
         participating = active_old_tasks(step, learned, cfg.rehearsal.interval)
         active = [task_name, *participating]
         for name in participating:
@@ -333,7 +386,7 @@ def _run_single(
 
         step_dir = recorder.paths.step_dir(step, task_name)
         step_metrics: dict[str, dict[str, float]] = {}
-        for name in [*preloaded, *new_tasks[:step]]:  # ALL learned heads (preloaded + new-so-far)
+        for name in [*preloaded, *new_tasks[: i + 1]]:  # ALL learned heads (preloaded + new-so-far)
             metric = evaluate_task(
                 model, catalog, name, recorder, step_dir, is_new=(name == task_name), test_keys=test_keys
             )

--- a/src/foundation_model/workflows/pretrain_test.py
+++ b/src/foundation_model/workflows/pretrain_test.py
@@ -200,6 +200,26 @@ default_replay = 0.5
 # --- warm-start from a checkpoint --------------------------------------------------------
 
 
+def test_checkpoint_task_order_includes_all_heads_in_state() -> None:
+    from foundation_model.workflows._engine import checkpoint_task_order
+
+    # A step checkpoint stores task_sequence as the active subset, but the weights carry every
+    # learned head; checkpoint_task_order must return all of them (AE excluded), ordered by the
+    # sequence first, then any heads the sequence omitted.
+    state = {
+        "model": {
+            "task_heads.a.w": 0,
+            "task_heads.b.w": 0,
+            "task_heads.c.w": 0,
+            "task_heads.__reconstruction__.w": 0,
+        },
+        "task_sequence": ["c"],
+    }
+    assert checkpoint_task_order(state) == ["c", "a", "b"]
+    # no task_sequence → fall back to state order
+    assert checkpoint_task_order({"model": state["model"], "task_sequence": None}) == ["a", "b", "c"]
+
+
 def _ws_toml(smoke_dir, sequence: list[str]) -> str:
     return f"""
 [data]
@@ -267,11 +287,13 @@ def test_warm_start_continues_sequence(smoke_dir, tmp_path) -> None:
     assert final["task_sequence"] == ["a", "b"]
     heads = {k.split(".", 2)[1] for k in final["model"] if k.startswith("task_heads.")}
     assert {"a", "b"} <= heads
-    # 'a' was not re-introduced as a training step; only step01_b exists.
-    assert (out2 / "training" / "step01_b").exists()
-    assert not (out2 / "training" / "step01_a").exists()
-    # 'a' head is evaluated in step 1 (already learned)
-    assert (out2 / "training" / "step01_b" / "a_metrics.json").exists()
+    # 'a' was not re-introduced as a training step; global step numbering continues past it, so the
+    # new task 'b' is step 2 (not step 1) and no step for 'a' is written this run.
+    assert (out2 / "training" / "step02_b").exists()
+    assert not (out2 / "training" / "step01_b").exists()
+    assert not list((out2 / "training").glob("step*_a"))
+    # 'a' head is still evaluated at the new step (already learned)
+    assert (out2 / "training" / "step02_b" / "a_metrics.json").exists()
 
 
 def test_warm_start_checkpoint_task_not_in_catalog_raises(smoke_dir, tmp_path) -> None:
@@ -316,6 +338,38 @@ dir = "o"
     raw = tomllib.loads(toml)
     assert str(build_pretrain_config(raw).checkpoint) == "from_toml.pt"
     assert str(build_pretrain_config(raw, checkpoint="from_cli.pt").checkpoint) == "from_cli.pt"  # CLI wins
+
+
+def test_resume_config_from_flag_and_toml(smoke_dir) -> None:
+    base = tomllib.loads(_ws_toml(smoke_dir, ["a"]))
+    assert build_pretrain_config(base, output_dir="o").resume is False
+    assert build_pretrain_config(base, output_dir="o", resume=True).resume is True  # --resume flag
+    base["pretrain"]["resume"] = True
+    assert build_pretrain_config(base, output_dir="o").resume is True  # [pretrain].resume
+
+
+def test_resume_continues_after_simulated_kill(smoke_dir, tmp_path) -> None:
+    out = tmp_path / "run"
+    # 1. train [a] fully, then delete final_model.pt to simulate a kill right after step 1.
+    _run_pretrain(build_pretrain_config(tomllib.loads(_ws_toml(smoke_dir, ["a"])), output_dir=str(out)), out)
+    assert (out / "training" / "step01_a" / "checkpoint.pt").exists()
+    (out / "training" / "final_model.pt").unlink()
+
+    # 2. re-run the full sequence [a, b] with --resume → picks up from the step-1 checkpoint.
+    cfg = build_pretrain_config(tomllib.loads(_ws_toml(smoke_dir, ["a", "b"])), output_dir=str(out), resume=True)
+    _run_pretrain(cfg, out)
+    final = torch.load(out / "training" / "final_model.pt", weights_only=True)
+    assert final["task_sequence"] == ["a", "b"]
+    assert (out / "training" / "step02_b").exists()  # continued at the next step, in place
+
+
+def test_resume_skips_completed_run(smoke_dir, tmp_path) -> None:
+    out = tmp_path / "run"
+    _run_pretrain(build_pretrain_config(tomllib.loads(_ws_toml(smoke_dir, ["a", "b"])), output_dir=str(out)), out)
+    steps_before = sorted(p.name for p in (out / "training").glob("step*"))
+    cfg = build_pretrain_config(tomllib.loads(_ws_toml(smoke_dir, ["a", "b"])), output_dir=str(out), resume=True)
+    _run_pretrain(cfg, out)  # final_model.pt present → run skipped, nothing re-trained
+    assert sorted(p.name for p in (out / "training").glob("step*")) == steps_before
 
 
 # --- Lightning callbacks / loggers config ------------------------------------------------

--- a/src/foundation_model/workflows/pretrain_test.py
+++ b/src/foundation_model/workflows/pretrain_test.py
@@ -11,6 +11,7 @@ import tomllib
 import numpy as np
 import pandas as pd
 import pytest
+import torch
 
 from lightning.pytorch.callbacks import EarlyStopping, ModelCheckpoint
 from lightning.pytorch.loggers import CSVLogger, TensorBoardLogger
@@ -194,6 +195,127 @@ interval = 1
 default_replay = 0.5
 """
     return build_pretrain_config(tomllib.loads(toml), output_dir=str(output_dir))
+
+
+# --- warm-start from a checkpoint --------------------------------------------------------
+
+
+def _ws_toml(smoke_dir, sequence: list[str]) -> str:
+    return f"""
+[data]
+batch_size = 4
+
+[descriptor]
+kind = "kmd"
+n_grids = 4
+
+[datasets.d1]
+path = "{smoke_dir / "x.parquet"}"
+
+[[tasks]]
+name = "a"
+kind = "regression"
+dataset = "d1"
+column = "a"
+
+[[tasks]]
+name = "b"
+kind = "regression"
+dataset = "d1"
+column = "b"
+
+[model]
+latent_dim = 8
+encoder_hidden_dims = [16]
+head_hidden_dims = [8]
+
+[training]
+max_epochs = 1
+accelerator = "cpu"
+seed = 1
+
+[pretrain]
+task_sequence = {sequence!r}
+[pretrain.rehearsal]
+interval = 1
+default_replay = 0.5
+"""
+
+
+def _run_pretrain(cfg, out) -> None:
+    rec = RunRecorder(out)
+    rec.write_provenance(config=cfg, argv=["fm", "pretrain"], seeds={"seed": 1})
+    pretrain_run(cfg, rec)
+    rec.close()
+
+
+def test_warm_start_continues_sequence(smoke_dir, tmp_path) -> None:
+    # 1. pre-train task 'a' only → checkpoint.
+    out1 = tmp_path / "run1"
+    _run_pretrain(build_pretrain_config(tomllib.loads(_ws_toml(smoke_dir, ["a"])), output_dir=str(out1)), out1)
+    ckpt = out1 / "training" / "final_model.pt"
+
+    # 2. warm-start with sequence [a, b] → only 'b' is a new step; the model keeps both heads.
+    out2 = tmp_path / "run2"
+    cfg2 = build_pretrain_config(
+        tomllib.loads(_ws_toml(smoke_dir, ["a", "b"])), output_dir=str(out2), checkpoint=str(ckpt)
+    )
+    assert cfg2.checkpoint is not None
+    _run_pretrain(cfg2, out2)
+
+    final = torch.load(out2 / "training" / "final_model.pt", weights_only=True)
+    assert final["task_sequence"] == ["a", "b"]
+    heads = {k.split(".", 2)[1] for k in final["model"] if k.startswith("task_heads.")}
+    assert {"a", "b"} <= heads
+    # 'a' was not re-introduced as a training step; only step01_b exists.
+    assert (out2 / "training" / "step01_b").exists()
+    assert not (out2 / "training" / "step01_a").exists()
+    # 'a' head is evaluated in step 1 (already learned)
+    assert (out2 / "training" / "step01_b" / "a_metrics.json").exists()
+
+
+def test_warm_start_checkpoint_task_not_in_catalog_raises(smoke_dir, tmp_path) -> None:
+    ckpt = tmp_path / "bad.pt"
+    torch.save({"model": {"task_heads.zzz.net.weight": torch.zeros(2)}, "task_sequence": ["zzz"]}, ckpt)
+    cfg = build_pretrain_config(
+        tomllib.loads(_ws_toml(smoke_dir, ["a", "b"])), output_dir=str(tmp_path / "o"), checkpoint=str(ckpt)
+    )
+    with pytest.raises(ValueError, match="not in the catalog"):
+        _run_pretrain(cfg, tmp_path / "o")
+
+
+def test_warm_start_nothing_to_train_raises(smoke_dir, tmp_path) -> None:
+    out1 = tmp_path / "run1"
+    _run_pretrain(build_pretrain_config(tomllib.loads(_ws_toml(smoke_dir, ["a", "b"])), output_dir=str(out1)), out1)
+    ckpt = out1 / "training" / "final_model.pt"
+    cfg = build_pretrain_config(
+        tomllib.loads(_ws_toml(smoke_dir, ["a", "b"])), output_dir=str(tmp_path / "o"), checkpoint=str(ckpt)
+    )
+    with pytest.raises(ValueError, match="nothing to train"):
+        _run_pretrain(cfg, tmp_path / "o")
+
+
+def test_checkpoint_from_toml_and_cli_precedence(smoke_dir) -> None:
+    toml = f"""
+[descriptor]
+kind = "kmd"
+n_grids = 4
+[datasets.d1]
+path = "{smoke_dir / "x.parquet"}"
+[[tasks]]
+name = "a"
+kind = "regression"
+dataset = "d1"
+column = "a"
+[pretrain]
+task_sequence = ["a"]
+checkpoint = "from_toml.pt"
+[output]
+dir = "o"
+"""
+    raw = tomllib.loads(toml)
+    assert str(build_pretrain_config(raw).checkpoint) == "from_toml.pt"
+    assert str(build_pretrain_config(raw, checkpoint="from_cli.pt").checkpoint) == "from_cli.pt"  # CLI wins
 
 
 # --- Lightning callbacks / loggers config ------------------------------------------------


### PR DESCRIPTION
## Summary

`fm pretrain` can now **warm-start from a checkpoint** and continue the continual-rehearsal
sequence — i.e. take a trained model and extend it with new tasks. (`fm finetune` already
warm-starts, since it loads a checkpoint to fine-tune; this closes the gap for pretrain.)

### How it works
Add an optional `checkpoint` (`--checkpoint` flag or `[pretrain].checkpoint`, flag wins). When set:
- load the checkpoint's encoder + heads (`load_state_dict(strict=False)`),
- treat the checkpoint's tasks as **already-learned** — they participate in rehearsal + are
  evaluated each step, but are **not** re-introduced as training steps,
- run the remaining `task_sequence` tasks (those not already in the checkpoint) as new steps,
- save a final model whose `task_sequence` is `preloaded + new`.

Errors clearly if a checkpoint task isn't in the catalog, or if every `task_sequence` task is
already present ("nothing to train").

```bash
fm pretrain --config c.toml --set 'pretrain.task_sequence=["density"]' --output-dir A
fm pretrain --config c.toml --set 'pretrain.task_sequence=["density","formation_energy"]' \
    --checkpoint A/.../final_model.pt --output-dir B      # trains only formation_energy
```

### Also
Consolidated the **triplicated** `_task_names_from_state` (predict + inverse both had a private
copy) into `_engine.task_names_from_state`, now shared by pretrain warm-start + predict + inverse.

## Validation

- New tests: warm-start continues the sequence (only the new step runs; both heads saved;
  preloaded task evaluated), checkpoint-task-not-in-catalog raises, all-tasks-present raises,
  and `--checkpoint` / `[pretrain].checkpoint` precedence.
- Full suite **390 passed**; ruff/mypy clean; verified end-to-end via the CLI (a
  density → +formation_energy warm-start trains only the new step and carries both heads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCoVwB3pntFi25YnpoHYwY