### PR TITLE
chore: standardize license headers to 2027 across src

### DIFF
--- a/src/foundation_model/__init__.py
+++ b/src/foundation_model/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2027 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
 import sys
 
 import torch

--- a/src/foundation_model/cli/__init__.py
+++ b/src/foundation_model/cli/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """The unified ``fm`` command-line interface (thin click dispatch → workflow engines)."""

--- a/src/foundation_model/cli/main.py
+++ b/src/foundation_model/cli/main.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """``fm`` — the unified foundation-model CLI.

--- a/src/foundation_model/cli/main_test.py
+++ b/src/foundation_model/cli/main_test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for :mod:`foundation_model.cli.main`."""

--- a/src/foundation_model/data/__init__.py
+++ b/src/foundation_model/data/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2027 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
 from .datamodule import CompoundDataModule
 from .dataset import CompoundDataset
 from .splitter import MultiTaskSplitter

--- a/src/foundation_model/data/composition_sources.py
+++ b/src/foundation_model/data/composition_sources.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/src/foundation_model/data/composition_sources_test.py
+++ b/src/foundation_model/data/composition_sources_test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for composition-keyed data-source helpers (refactor PR2)."""

--- a/src/foundation_model/data/datamodule.py
+++ b/src/foundation_model/data/datamodule.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Dict, List, Mapping, Sequence

--- a/src/foundation_model/data/datamodule_test.py
+++ b/src/foundation_model/data/datamodule_test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for the composition-keyed CompoundDataModule (refactor PR3)."""

--- a/src/foundation_model/data/dataset.py
+++ b/src/foundation_model/data/dataset.py
@@ -1,3 +1,6 @@
+# Copyright 2027 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
 import ast  # For safely evaluating string representations of lists/arrays
 from typing import Dict, List, Mapping, Sequence
 

--- a/src/foundation_model/data/dataset_test.py
+++ b/src/foundation_model/data/dataset_test.py
@@ -1,3 +1,6 @@
+# Copyright 2027 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging  # Add logging import
 
 import numpy as np

--- a/src/foundation_model/data/splitter.py
+++ b/src/foundation_model/data/splitter.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """Composition-level multi-task train/val/test splitter."""

--- a/src/foundation_model/data/splitter_test.py
+++ b/src/foundation_model/data/splitter_test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for the composition-level MultiTaskSplitter (refactor PR4)."""

--- a/src/foundation_model/models/__init__.py
+++ b/src/foundation_model/models/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/src/foundation_model/models/components/__init__.py
+++ b/src/foundation_model/models/components/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/src/foundation_model/models/components/fc_layers.py
+++ b/src/foundation_model/models/components/fc_layers.py
@@ -1,3 +1,6 @@
+# Copyright 2027 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch.nn as nn
 
 

--- a/src/foundation_model/models/components/foundation_encoder.py
+++ b/src/foundation_model/models/components/foundation_encoder.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """Foundation encoder components for multi-task learning models.

--- a/src/foundation_model/models/flexible_multi_task_model.py
+++ b/src/foundation_model/models/flexible_multi_task_model.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/src/foundation_model/models/flexible_multi_task_model_test.py
+++ b/src/foundation_model/models/flexible_multi_task_model_test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/src/foundation_model/models/full_prediction_flow_test.py
+++ b/src/foundation_model/models/full_prediction_flow_test.py
@@ -1,3 +1,6 @@
+# Copyright 2027 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/src/foundation_model/models/model_config.py
+++ b/src/foundation_model/models/model_config.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/src/foundation_model/models/model_config_test.py
+++ b/src/foundation_model/models/model_config_test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for the per-task data-source fields added to BaseTaskConfig (composition refactor PR1)."""

--- a/src/foundation_model/models/task_head/__init__.py
+++ b/src/foundation_model/models/task_head/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/src/foundation_model/models/task_head/autoencoder.py
+++ b/src/foundation_model/models/task_head/autoencoder.py
@@ -1,3 +1,6 @@
+# Copyright 2027 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 AutoEncoder task head for the FlexibleMultiTaskModel.
 """

--- a/src/foundation_model/models/task_head/autoencoder_test.py
+++ b/src/foundation_model/models/task_head/autoencoder_test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/src/foundation_model/models/task_head/base.py
+++ b/src/foundation_model/models/task_head/base.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/src/foundation_model/models/task_head/classification.py
+++ b/src/foundation_model/models/task_head/classification.py
@@ -1,3 +1,6 @@
+# Copyright 2027 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Classification task head for the FlexibleMultiTaskModel.
 """

--- a/src/foundation_model/models/task_head/classification_test.py
+++ b/src/foundation_model/models/task_head/classification_test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/src/foundation_model/models/task_head/kernel_regression.py
+++ b/src/foundation_model/models/task_head/kernel_regression.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/src/foundation_model/models/task_head/regression.py
+++ b/src/foundation_model/models/task_head/regression.py
@@ -1,3 +1,6 @@
+# Copyright 2027 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Regression task head for the FlexibleMultiTaskModel.
 """

--- a/src/foundation_model/utils/__init__.py
+++ b/src/foundation_model/utils/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2027 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+

--- a/src/foundation_model/utils/interpolate.py
+++ b/src/foundation_model/utils/interpolate.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/src/foundation_model/utils/kmd_plus.py
+++ b/src/foundation_model/utils/kmd_plus.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Kernel mean descriptor (KMD) originally authored by Minoru Kusaba

--- a/src/foundation_model/utils/kmd_plus_test.py
+++ b/src/foundation_model/utils/kmd_plus_test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for the kernel mean descriptor utilities."""

--- a/src/foundation_model/utils/plotting.py
+++ b/src/foundation_model/utils/plotting.py
@@ -1,3 +1,6 @@
+# Copyright 2027 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 from typing import Dict, Optional, Tuple
 

--- a/src/foundation_model/utils/training.py
+++ b/src/foundation_model/utils/training.py
@@ -1,3 +1,6 @@
+# Copyright 2027 TsumiNa.
+# SPDX-License-Identifier: Apache-2.0
+
 import lightning as L
 from lightning.pytorch.callbacks import EarlyStopping, ModelCheckpoint
 from lightning.pytorch.loggers import CSVLogger, TensorBoardLogger

--- a/src/foundation_model/workflows/__init__.py
+++ b/src/foundation_model/workflows/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """Workflow engines behind the unified ``fm`` CLI.

--- a/src/foundation_model/workflows/_engine.py
+++ b/src/foundation_model/workflows/_engine.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """Shared engine internals for the training workflows (pretrain / finetune).

--- a/src/foundation_model/workflows/_sections.py
+++ b/src/foundation_model/workflows/_sections.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """Shared config sections used by more than one workflow (``[model]`` / ``[training]``)."""

--- a/src/foundation_model/workflows/finetune.py
+++ b/src/foundation_model/workflows/finetune.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """``fm finetune`` — frozen-encoder fine-tuning of selected task heads.

--- a/src/foundation_model/workflows/finetune_test.py
+++ b/src/foundation_model/workflows/finetune_test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for :mod:`foundation_model.workflows.finetune`."""

--- a/src/foundation_model/workflows/inverse.py
+++ b/src/foundation_model/workflows/inverse.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """``fm inverse`` — scenario × path inverse-design engine.

--- a/src/foundation_model/workflows/inverse_test.py
+++ b/src/foundation_model/workflows/inverse_test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for :mod:`foundation_model.workflows.inverse`."""

--- a/src/foundation_model/workflows/inverse_trajectory.py
+++ b/src/foundation_model/workflows/inverse_trajectory.py
@@ -1,4 +1,4 @@
-# Copyright 2026 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """Per-step trajectory analytics + plots + animations for inverse-design runs.

--- a/src/foundation_model/workflows/inverse_trajectory_test.py
+++ b/src/foundation_model/workflows/inverse_trajectory_test.py
@@ -1,4 +1,4 @@
-# Copyright 2026 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for the pure helpers in :mod:`foundation_model.workflows.inverse_trajectory`.

--- a/src/foundation_model/workflows/plots.py
+++ b/src/foundation_model/workflows/plots.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """Pure plotting helpers for the training workflows.

--- a/src/foundation_model/workflows/plots_test.py
+++ b/src/foundation_model/workflows/plots_test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """Smoke tests for :mod:`foundation_model.workflows.plots` (render without error)."""

--- a/src/foundation_model/workflows/predict.py
+++ b/src/foundation_model/workflows/predict.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """``fm predict`` — evaluate / predict with an arbitrary checkpoint.

--- a/src/foundation_model/workflows/predict_test.py
+++ b/src/foundation_model/workflows/predict_test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for :mod:`foundation_model.workflows.predict`."""

--- a/src/foundation_model/workflows/pretrain.py
+++ b/src/foundation_model/workflows/pretrain.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """``fm pretrain`` — continual-rehearsal pre-training engine with an n-runs sweep.

--- a/src/foundation_model/workflows/pretrain_test.py
+++ b/src/foundation_model/workflows/pretrain_test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for :mod:`foundation_model.workflows.pretrain`."""

--- a/src/foundation_model/workflows/recording.py
+++ b/src/foundation_model/workflows/recording.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """The single artifact writer for the training / predict workflows.

--- a/src/foundation_model/workflows/recording_test.py
+++ b/src/foundation_model/workflows/recording_test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for :mod:`foundation_model.workflows.recording`."""

--- a/src/foundation_model/workflows/task_catalog.py
+++ b/src/foundation_model/workflows/task_catalog.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """TOML-driven task catalog: datasets, tasks, descriptors, scalers and datamodules.

--- a/src/foundation_model/workflows/task_catalog_test.py
+++ b/src/foundation_model/workflows/task_catalog_test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 TsumiNa.
+# Copyright 2027 TsumiNa.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for :mod:`foundation_model.workflows.task_catalog`."""


### PR DESCRIPTION
Standardizes the license header across all Python files under \`src/foundation_model\` to:

\`\`\`
# Copyright 2027 TsumiNa.
# SPDX-License-Identifier: Apache-2.0
\`\`\`

- Bumped outdated headers (2025 / 2026) to 2027 on 43 files.
- Added the missing header to 12 files that previously had none.

No functional code changes; verified all files still compile (\`python -m py_compile\`).