### PR TITLE
docs(utils): document KMD descriptor API and migration

### DIFF
--- a/docs/kmd_descriptor_guide.md
+++ b/docs/kmd_descriptor_guide.md
@@ -1,0 +1,446 @@
+# KMD 描述符计算与迁移指南
+
+本文说明如何使用 `kmd_plus.py` 将材料组成转换为 Kernel Mean Descriptor（KMD），以及把该模块迁移到其他代码库时需要携带的文件、依赖和约定。
+
+## 1. KMD 在做什么
+
+设系统有 $C$ 个可选组分，每个组分有 $F$ 个特征。组分特征矩阵为
+
+$$
+X \in \mathbb{R}^{C \times F},
+$$
+
+一个样品的混合权重为
+
+$$
+w \in \mathbb{R}^{C}, \qquad w_c \ge 0, \qquad \sum_{c=1}^{C} w_c = 1.
+$$
+
+`KMD` 在初始化时根据 $X$ 构造并缓存核矩阵 $K$，之后通过一次矩阵乘法计算描述符：
+
+$$
+z = wK.
+$$
+
+批量输入时，权重矩阵 $W$ 的形状为 `(n_samples, n_components)`，输出为 `W @ K`。因此，同一个 `KMD` 实例应复用于所有样品，避免重复构造核矩阵。
+
+## 2. 两种核构造方法
+
+### 2.1 `method="1d"`：逐特征网格 KMD
+
+这是本项目计算元素组成描述符时使用的方法。
+
+对于每个组分特征，代码在该特征的最小值和最大值之间建立 `n_grids` 个等距网格点，再计算组分到各网格点的高斯核响应。所有特征的响应最后按列拼接。
+
+- 核矩阵形状：`(n_components, n_features * n_grids)`
+- 描述符形状：`(n_samples, n_features * n_grids)`
+- `n_grids` 必须为不小于 2 的整数
+- `scale=True` 时，每个特征先做 min-max 归一化
+- `sigma="auto"` 时，每个特征使用自身网格间距确定核宽度
+
+若元素特征表有 58 个特征，配置为：
+
+```toml
+[descriptor]
+kind = "kmd"
+n_grids = 8
+```
+
+则描述符维度为：
+
+$$
+58 \times 8 = 464.
+$$
+
+`n_grids` 越大，描述符越细致、维度和计算开销也越高。训练、预测和逆向设计必须使用相同的组分特征表、组分顺序、`n_grids`、`sigma` 和 `scale`。
+
+### 2.2 `method="md"`：多维特征空间 KMD
+
+该方法直接计算组分之间在完整特征空间中的高斯核。
+
+- 核矩阵形状：`(n_components, n_components)`
+- 描述符形状：`(n_samples, n_components)`
+- `n_grids` 不参与计算
+- `scale=True` 时，每个特征按样本标准差（`ddof=1`）标准化
+- `sigma="auto"` 时，核尺度来自各组分最近邻平方距离的中位数
+
+`md` 更紧凑，但输出维度随组分数量变化；`1d` 的输出维度由特征数和网格数决定。本项目的元素组成路径固定使用 `1d`。
+
+## 3. 最小可运行示例
+
+下面的示例不依赖本项目的训练框架，只需要 `kmd_plus.py` 及其数值计算依赖。
+
+```python
+import numpy as np
+
+from kmd_plus import KMD
+
+# 4 个组分，每个组分有 3 个固定特征。
+component_features = np.array(
+    [
+        [0.2, 1.0, 3.0],
+        [0.8, 1.5, 2.0],
+        [1.4, 0.5, 1.0],
+        [2.0, 2.0, 0.0],
+    ],
+    dtype=float,
+)
+
+# 两个样品；列顺序必须与 component_features 的行顺序完全一致。
+weights = np.array(
+    [
+        [0.5, 0.5, 0.0, 0.0],
+        [0.0, 0.2, 0.3, 0.5],
+    ],
+    dtype=float,
+)
+
+kmd = KMD(
+    component_features,
+    method="1d",
+    n_grids=8,
+    sigma="auto",
+    scale=True,
+)
+
+descriptors = kmd.transform(weights)
+# 等价写法：descriptors = kmd(weights)
+
+print(descriptors.shape)  # (2, 3 * 8) == (2, 24)
+```
+
+`transform` 本身不会检查权重是否非负或每行和是否为 1。调用方应在进入 KMD 前完成校验或归一化：
+
+```python
+if np.any(weights < 0):
+    raise ValueError("KMD weights must be non-negative.")
+
+row_sums = weights.sum(axis=1, keepdims=True)
+if np.any(row_sums == 0):
+    raise ValueError("Every sample must contain at least one component.")
+
+weights = weights / row_sums
+descriptors = kmd.transform(weights)
+```
+
+## 4. 从化学式计算元素 KMD
+
+模块自带 `element_features.csv`，其行索引是从 H 到 Pu 的 94 个元素，列是 58 个元素级特征。`formula_to_composition` 会把化学式转换为与元素表行顺序一致的原子分数向量。
+
+```python
+import numpy as np
+
+from kmd_plus import KMD, element_features, formula_to_composition
+
+kmd = KMD(
+    element_features.values,
+    method="1d",
+    n_grids=8,
+    sigma="auto",
+    scale=True,
+)
+
+formulas = ["SiO2", "Al2O3", "LiFePO4"]
+weights = np.stack([formula_to_composition(formula) for formula in formulas])
+descriptors = kmd.transform(weights)
+
+print(weights.shape)      # (3, 94)
+print(descriptors.shape)  # (3, 464)
+```
+
+`formula_to_composition` 也接受元素数量字典和 pymatgen `Composition`：
+
+```python
+from pymatgen.core import Composition
+
+from kmd_plus import formula_to_composition
+
+from_string = formula_to_composition("SiO2")
+from_dict = formula_to_composition({"Si": 1.0, "O": 2.0})
+from_object = formula_to_composition(Composition("SiO2"))
+```
+
+注意：传入自定义 `elements` 时，其顺序必须与 `component_features` 的行顺序一致，并且必须覆盖待处理化学式中的全部元素。函数不会为不在 `elements` 中的元素增加列，也不会对遗漏元素后的向量重新归一化。
+
+### 4.1 本项目的实际生产调用链
+
+在 `foundation_model` 中，`component_features` 不是从训练任务的数据集读取的，而是来自与 `kmd_plus.py` 同目录的内置文件：
+
+```text
+src/foundation_model/utils/element_features.csv
+```
+
+模块导入时以第一列作为元素索引读取该文件：
+
+```python
+_ELEMENT_FEATURES_PATH = os.path.join(os.path.dirname(__file__), "element_features.csv")
+element_features = pd.read_csv(_ELEMENT_FEATURES_PATH, index_col=0)
+DEFAULT_ELEMENTS = list(element_features.index)
+```
+
+当前文件的形状为 `(94, 58)`：
+
+- 94 行对应从 `H` 到 `Pu` 的元素；
+- 58 列对应元素级物理和化学特征，例如 `atomic_number`、`atomic_radius`、`atomic_weight`、`boiling_point` 和 `bulk_modulus`；
+- `element_features.index` 同时定义了 `formula_to_composition` 输出向量的默认元素顺序。
+
+当配置指定 KMD 时：
+
+```toml
+[descriptor]
+kind = "kmd"
+n_grids = 8
+```
+
+`TaskCatalog` 的实际构造代码等价于：
+
+```python
+kmd = KMD(
+    element_features.values,
+    method="1d",
+    n_grids=8,
+    sigma="auto",
+    scale=True,
+)
+```
+
+这里传入的 `component_features` 就是 `element_features.values`，形状为 `(94, 58)`。转换为 NumPy 数组后虽然不再携带 DataFrame 的行标签，但行顺序保持不变。
+
+每条任务数据只需要提供化学式，例如 `"SiO2"`。描述符计算过程为：
+
+```python
+formula = "SiO2"
+
+# DEFAULT_ELEMENTS 来自 element_features.index，所以 weight 的第 j 列与
+# element_features.values 的第 j 行表示同一个元素。
+weight = formula_to_composition(formula)[None, :]
+descriptor = kmd.transform(weight)
+
+assert weight.shape == (1, 94)
+assert descriptor.shape == (1, 464)
+assert np.isclose(weight.sum(), 1.0)
+```
+
+矩阵关系如下：
+
+```text
+element_features.csv
+    │  pd.read_csv(..., index_col=0)
+    ▼
+element_features.values                  shape: (94, 58)
+    │  KMD(method="1d", n_grids=8)
+    ▼
+KMD kernel K                             shape: (94, 58 × 8) = (94, 464)
+
+"SiO2"
+    │  formula_to_composition()
+    ▼
+weight                                   shape: (1, 94)
+    │  weight @ K
+    ▼
+descriptor                               shape: (1, 464)
+```
+
+因此，训练任务的数据文件负责提供 composition 字符串和预测目标，不负责提供 `component_features`。如果配置改为 `kind = "precomputed"`，`TaskCatalog` 不会创建 KMD，而是从配置指定的预计算描述符文件读取输入。
+
+## 5. 可微分的 PyTorch 计算
+
+梯度优化组成时，使用 `transform_torch`，不要先把 tensor 转成 NumPy。核矩阵被视为常量，梯度会通过矩阵乘法回传到权重。
+
+```python
+import torch
+
+from kmd_plus import KMD, element_features
+
+kmd = KMD(element_features.values, method="1d", n_grids=8)
+
+logits = torch.zeros(
+    1,
+    len(element_features),
+    dtype=torch.float32,
+    requires_grad=True,
+)
+weights = torch.softmax(logits, dim=1)
+descriptors = kmd.transform_torch(weights)
+
+loss = descriptors.square().mean()
+loss.backward()
+
+assert logits.grad is not None
+```
+
+`transform_torch` 默认让核矩阵跟随输入权重的 `device` 和 `dtype`，并按 `(device, dtype)` 缓存只读副本，适合在优化循环中重复调用。
+
+若外部代码需要读取核矩阵，可使用 `kernel_torch()`。每次调用都会返回独立 clone，调用方的原地修改不会影响 KMD 内部状态：
+
+```python
+kernel = kmd.kernel_torch(device="cpu", dtype=torch.float64)
+```
+
+PyTorch 只在调用这两个方法时才需要安装；纯 NumPy 的 `transform` 和 `inverse` 不导入 PyTorch。
+
+## 6. 从描述符恢复混合权重
+
+`inverse` 为每个样品求解带单纯形约束的二次规划：
+
+$$
+\underset{w}{\operatorname{minimize}}\; \frac{1}{2}w^T(KK^T)w - (Kz)^Tw,
+\qquad w \ge 0,\quad \mathbf{1}^T w = 1.
+$$
+
+```python
+descriptors = kmd.transform(weights)
+recovered_weights = kmd.inverse(descriptors)
+
+np.testing.assert_allclose(recovered_weights.sum(axis=1), 1.0)
+np.testing.assert_allclose(recovered_weights, weights, atol=1e-4)
+```
+
+逆变换要求 $KK^T$ 正定。重复的组分特征、过于相似的核响应或过低的描述符维度都可能使核不可逆。代码会在这种情况下抛出 `ValueError`：
+
+- `method="1d"`：优先尝试增加 `n_grids`
+- `method="md"`：优先尝试减小显式 `sigma`
+- 两种方法：检查是否存在重复组分行或常量特征列
+
+`inverse` 固定使用 `qpsolvers` 的 `quadprog` 后端，因此即使只在少数路径中调用逆变换，也必须安装 `quadprog`。
+
+## 7. `sigma` 和 `scale` 的含义
+
+显式指定正数 `sigma` 时，两种方法都使用标准高斯形式：
+
+$$
+k(d)=\exp\left(-\frac{d^2}{2\sigma^2}\right).
+$$
+
+`sigma="auto"` 的规则则由方法决定：
+
+- `md`：$\gamma$ 为最近邻平方距离中位数的倒数，核为 $\exp(-\gamma d^2)$
+- `1d`：每个特征的 $\gamma$ 为网格间距平方的倒数
+
+实践建议：
+
+1. 首次使用优先保留 `sigma="auto"` 和 `scale=True`。
+2. 训练和推理必须复用完全相同的参数。
+3. `scale=True` 时，`md` 的每个特征必须有非零标准差，`1d` 的每个特征必须有非零极差。
+4. 若特征中存在常量列，应在构造 KMD 前删除该列，或在确认数值尺度合理后使用 `scale=False`。
+
+## 8. 迁移到其他代码库
+
+### 8.1 必须复制的文件
+
+```text
+your_package/
+├── kmd_plus.py
+└── element_features.csv  # 使用内置元素描述符时必须与 .py 文件同目录
+```
+
+`kmd_plus.py` 通过 `os.path.dirname(__file__)` 查找 `element_features.csv`。如果新项目不需要内置元素特征，可以改为由调用方传入 `component_features`，并移除模块级 CSV 加载及相关默认元素常量。
+
+复制代码时应保留源文件顶部的版权和 SPDX 许可证声明，并遵守仓库许可证要求。
+
+### 8.2 Python 依赖
+
+纯 NumPy 正向计算需要：
+
+```text
+numpy
+pandas
+scipy
+pymatgen
+```
+
+逆变换额外需要：
+
+```text
+qpsolvers
+quadprog
+```
+
+可微分计算额外需要：
+
+```text
+torch
+```
+
+完整安装示例：
+
+```bash
+python -m pip install numpy pandas scipy pymatgen qpsolvers quadprog torch
+```
+
+若目标平台不提供 `quadprog` wheel，而新项目只做正向计算，可删除 `inverse` 相关代码及 `qpsolvers` 导入；不要仅捕获导入错误后保留一个不可用的 `inverse` 接口。
+
+### 8.3 迁移后最小验收
+
+至少验证以下行为：
+
+```python
+import numpy as np
+
+from your_package.kmd_plus import KMD, element_features, formula_to_composition
+
+kmd = KMD(element_features.values, method="1d", n_grids=8)
+weights = np.stack(
+    [
+        formula_to_composition("SiO2"),
+        formula_to_composition("Al2O3"),
+    ]
+)
+descriptors = kmd.transform(weights)
+
+assert weights.shape == (2, len(element_features))
+assert descriptors.shape == (2, element_features.shape[1] * 8)
+assert np.isfinite(descriptors).all()
+assert np.allclose(weights.sum(axis=1), 1.0)
+```
+
+如果新项目会使用逆变换，再加入 round-trip 检查；如果会做组成优化，再加入 `transform_torch(...).backward()` 检查。
+
+## 9. 常见问题
+
+### 描述符维度与模型输入维度不一致
+
+检查 `component_features.shape[1]` 和 `n_grids`。对于 `1d`：
+
+```text
+descriptor_dim = n_features * n_grids
+```
+
+改变元素特征列数或 `n_grids` 后，旧模型的输入层通常不能直接复用。
+
+### 不同机器上同一化学式得到不同结果
+
+核矩阵不仅取决于化学式，还取决于完整的组分特征表及其行列顺序。确认两端使用同一份 CSV、相同的预处理参数和相同的元素顺序。
+
+### 输出出现 NaN 或无穷值
+
+最常见原因是 `scale=True` 时存在常量特征列，导致标准化或 min-max 归一化除以零。先检查：
+
+```python
+feature_range = np.ptp(component_features, axis=0)
+constant_columns = np.flatnonzero(feature_range == 0)
+```
+
+### `inverse` 报告 KMD 不可逆
+
+检查重复组分、增加 `1d` 的 `n_grids`，或调整 `md` 的 `sigma`。正向描述符仍可能可计算，但不可逆意味着无法唯一恢复原始组成。
+
+### 自定义组分体系如何使用
+
+不必使用元素。只要 `component_features` 的每一行代表一个组分，权重矩阵的每一列与该行对应，KMD 同样适用于聚合物单体、溶剂、合金端元或其他混合体系。
+
+## 10. 补充：统计描述符
+
+模块还提供 `stats_descriptor(weights, component_features)`，可按顺序拼接加权均值、加权方差、存在组分的最大值和最小值。它不是 KMD，也不使用预计算核矩阵，但可作为简单基线：
+
+```python
+from kmd_plus import stats_descriptor
+
+summary = stats_descriptor(
+    weights,
+    component_features,
+    stats=("mean", "var", "max", "min"),
+)
+```
+
+默认输出维度为 `n_features * 4`。`max` 和 `min` 只统计权重非零的组分，并要求每个样品至少包含一个非零权重。

--- a/src/foundation_model/utils/kmd_plus.py
+++ b/src/foundation_model/utils/kmd_plus.py
@@ -5,16 +5,44 @@
 # (ISM, kusaba@ism.ac.jp). Refactored into a stateful class with a
 # precomputed kernel basis.
 
-"""Kernel mean descriptor (KMD) and summary-statistics descriptors for mixtures.
+"""Kernel mean and summary-statistics descriptors for mixture compositions.
 
-A :class:`KMD` instance is built once around a fixed ``component_features``
-matrix and the chosen kernel hyper-parameters. It precomputes the kernel basis
-shared by both directions, so:
+The module represents a mixture by two aligned arrays:
 
-* :meth:`KMD.transform` (also available via ``__call__``) maps mixing weights to
-  descriptors (materials → descriptors), and
-* :meth:`KMD.inverse` recovers the weights from descriptors by quadratic
-  programming (descriptors → materials).
+``component_features``
+        A fixed matrix of shape ``(n_components, n_features)``. Row ``j`` contains
+        the features of component ``j``. Components may be chemical elements,
+        monomers, solvents, alloy endmembers, or any other constituents.
+``weight``
+        A sample matrix of shape ``(n_samples, n_components)``. Column ``j`` is the
+        amount of the same component represented by row ``j`` of
+        ``component_features``. KMD conventionally expects non-negative rows that
+        sum to one, although :meth:`KMD.transform` deliberately does not enforce or
+        normalize this constraint.
+
+A :class:`KMD` instance converts the fixed component feature matrix into a
+kernel basis ``K`` once, then reuses it for every sample. The forward operation
+is simply ``weight @ K``. :meth:`KMD.inverse` solves the corresponding
+non-negative, sum-to-one quadratic program, and :meth:`KMD.transform_torch`
+provides the same forward operation with gradients through ``weight``.
+
+The bundled :data:`element_features` table contains 58 features for 94 elements
+(``H`` through ``Pu``). Together with :func:`formula_to_composition`, it
+provides an element-composition descriptor out of the box.
+
+Examples
+--------
+Create an 8-dimensional descriptor from two constituent features and four grid
+points per feature:
+
+>>> component_features = np.array([[0.0, 1.0], [1.0, 0.5], [2.0, 2.0]])
+>>> weight = np.array([[0.25, 0.75, 0.0], [0.0, 0.4, 0.6]])
+>>> kmd = KMD(component_features, method="1d", n_grids=4)
+>>> kmd.transform(weight).shape
+(2, 8)
+
+For the complete migration checklist and element-based examples, see
+``docs/kmd_descriptor_guide.md``.
 """
 
 from __future__ import annotations
@@ -45,21 +73,52 @@ def formula_to_composition(
     formula: str | dict[str, float] | Composition,
     elements: Sequence[str] | None = None,
 ) -> npt.NDArray[np.float64]:
-    """Convert a formula to a composition vector over ``elements``.
+    """Convert one chemical formula to an element-aligned atomic-fraction vector.
+
+    The output index is defined exclusively by ``elements``. Entry ``j`` is the
+    atomic fraction of ``elements[j]`` in the full composition. Consequently,
+    the vector can be used as one row of ``weight`` only when ``elements`` has
+    the same order as the rows of the KMD ``component_features`` matrix.
 
     Parameters
     ----------
     formula:
-        Chemical formula (e.g. ``"SiO2"``), a dict of element fractions, or a
-        :class:`~pymatgen.core.composition.Composition`.
+        Chemical formula such as ``"SiO2"``; a mapping from element symbol to
+        amount, such as ``{"Si": 1, "O": 2}``; or an existing
+        :class:`~pymatgen.core.composition.Composition`. Mapping values need not
+        be normalized because pymatgen computes atomic fractions.
     elements:
-        Element symbols defining the vector layout. Defaults to the elements of
-        the bundled ``element_features.csv``.
+        Ordered element symbols defining the output layout. The default is
+        :data:`DEFAULT_ELEMENTS`, which matches the row order of the bundled
+        :data:`element_features` table (94 elements from ``H`` through ``Pu``).
 
     Returns
     -------
-    numpy.ndarray of shape ``(len(elements),)``
-        Atomic fractions aligned to ``elements``.
+    numpy.ndarray
+        One-dimensional ``float64`` array of shape ``(len(elements),)``.
+        Entries for absent elements are zero.
+
+    Raises
+    ------
+    TypeError
+        If ``formula`` is not a string, dictionary, or pymatgen
+        :class:`~pymatgen.core.composition.Composition`.
+    ValueError
+        If pymatgen cannot parse the formula or its amounts.
+
+    Notes
+    -----
+    Elements omitted from ``elements`` are not represented, and the remaining
+    entries are not renormalized. Therefore, the result sums to one only when
+    ``elements`` covers every element present in ``formula``.
+
+    Examples
+    --------
+    >>> vector = formula_to_composition("SiO2", elements=["O", "Si", "Al"])
+    >>> np.allclose(vector, [2 / 3, 1 / 3, 0.0])
+    True
+    >>> bool(np.isclose(formula_to_composition({"Li": 1, "Fe": 1, "P": 1, "O": 4}).sum(), 1.0))
+    True
     """
     if elements is None:
         elements = DEFAULT_ELEMENTS
@@ -77,29 +136,76 @@ def formula_to_composition(
 
 
 class KMD:
-    """Kernel mean descriptor for mixture systems.
+    """Precomputed kernel mean descriptor for fixed mixture components.
 
-    The kernel basis is derived once from ``component_features`` at construction
-    time and reused for both :meth:`transform` and :meth:`inverse`.
+    Construction fixes the component vocabulary, component row order, feature
+    columns, scaling rule, and kernel hyperparameters. The resulting kernel is
+    reused by :meth:`transform`, :meth:`inverse`, and :meth:`transform_torch`.
+    Create one instance per descriptor definition and reuse it across batches.
 
     Parameters
     ----------
     component_features:
-        Features for each constituent, shape ``(n_components, n_features)``.
+        Two-dimensional numeric array-like of shape
+        ``(n_components, n_features)``. Each row describes one constituent and
+        each column is one constituent-level feature. Row ``j`` must correspond
+        to column ``j`` of every ``weight`` passed to :meth:`transform`. At least
+        two rows are required. Values are converted to ``float64``.
+
+        With ``scale=True``, every feature column must vary across components:
+        ``method="md"`` requires a non-zero sample standard deviation and
+        ``method="1d"`` requires a non-zero min-max range. Constant columns can
+        otherwise produce non-finite kernels.
     method:
-        ``"md"`` builds the descriptor on the multidimensional feature space;
-        ``"1d"`` builds a per-feature descriptor on a discretized grid and
-        concatenates the results.
+        Kernel construction strategy. ``"md"`` computes an RBF kernel between
+        components in the full feature space, producing ``n_components``
+        descriptor columns. ``"1d"`` computes a separate RBF response over an
+        equally spaced grid for each feature and concatenates the blocks,
+        producing ``n_features * n_grids`` descriptor columns.
     n_grids:
-        Number of equally spaced grid points per feature. Required for
-        ``method="1d"`` and ignored for ``"md"``.
+        Number of equally spaced grid points per feature. Required and at least
+        2 for ``method="1d"``; ignored for ``method="md"``. Increasing it
+        raises descriptor resolution, memory use, and output width linearly.
     sigma:
-        Kernel width. With ``"auto"`` it is the inverse median nearest-neighbour
-        distance for ``"md"`` and the inverse grid width for ``"1d"``. A float
-        sets the width manually as ``exp(-d^2 / (2 * sigma^2))``.
+        Positive RBF width or ``"auto"``. A numeric value uses
+        ``exp(-d**2 / (2 * sigma**2))``. For ``method="md"``, ``"auto"`` sets
+        the RBF coefficient to the inverse median nearest-neighbour squared
+        distance. For ``method="1d"``, it uses the inverse squared grid spacing
+        independently for each feature.
     scale:
-        Whether to rescale ``component_features`` before building the kernel
-        (standardization for ``"md"``, min-max normalization for ``"1d"``).
+        Whether to rescale feature columns before kernel construction.
+        ``method="md"`` applies z-score scaling with sample standard deviation
+        (``ddof=1``); ``method="1d"`` applies min-max scaling. Scaling parameters
+        are derived from ``component_features`` and are not exposed separately.
+
+    Raises
+    ------
+    ValueError
+        If ``method`` is unknown, ``n_grids`` is invalid for ``"1d"``, ``sigma``
+        is non-positive, fewer than two components are supplied, or automatic
+        multidimensional scaling is undefined for duplicate components.
+
+    Notes
+    -----
+    Descriptor compatibility requires the exact same component row order,
+    feature columns, feature values, ``method``, ``n_grids``, ``sigma``, and
+    ``scale`` at training and inference time. This class stores the resulting
+    kernel, not a public copy of the scaled component feature matrix.
+
+    Examples
+    --------
+    Build and reuse a one-dimensional-grid KMD:
+
+    >>> features = np.array([[0.0, 1.0], [1.0, 0.5], [2.0, 2.0]])
+    >>> weights = np.array([[0.2, 0.3, 0.5]])
+    >>> descriptor = KMD(features, method="1d", n_grids=4)
+    >>> descriptor(weights).shape
+    (1, 8)
+
+    The multidimensional method instead returns one value per component:
+
+    >>> KMD(features, method="md").transform(weights).shape
+    (1, 3)
     """
 
     def __init__(
@@ -131,31 +237,59 @@ class KMD:
         self._gram: npt.NDArray[np.float64] | None = None
 
     def transform(self, weight: npt.ArrayLike) -> npt.NDArray[np.float64]:
-        """Map mixing weights to kernel mean descriptors (materials → descriptors).
+        """Map a batch of component weights to kernel mean descriptors.
 
-        Parameters
-        ----------
-        weight:
-            Mixing ratios, shape ``(n_samples, n_components)``.
+            Parameters
+            ----------
+            weight:
+                Two-dimensional numeric array-like of shape
+                ``(n_samples, n_components)``. Column ``j`` weights row ``j`` of the
+                ``component_features`` passed at construction. Values are converted
+                to ``float64`` before multiplication.
 
-        Returns
-        -------
-        numpy.ndarray
-            Descriptors of shape ``(n_samples, n_components)`` for ``"md"`` and
-            ``(n_samples, n_features * n_grids)`` for ``"1d"``.
+                KMD mixtures conventionally use non-negative rows summing to one,
+                but this method intentionally performs no sign, finiteness, or
+                normalization checks. Normalize and validate upstream when those
+                constraints are required.
+
+            Returns
+            -------
+            numpy.ndarray
+                ``float64`` descriptor matrix. Its shape is
+                ``(n_samples, n_components)`` for ``method="md"`` and
+                ``(n_samples, n_features * n_grids)`` for ``method="1d"``.
+
+        Raises
+        ------
+        ValueError
+            If the final dimension of ``weight`` does not equal ``n_components`` or
+            the input is otherwise incompatible with matrix multiplication.
+
+        Examples
+        --------
+        >>> features = np.array([[0.0, 1.0], [1.0, 0.5], [2.0, 2.0]])
+        >>> kmd = KMD(features, method="1d", n_grids=3)
+        >>> weights = np.array([[1.0, 0.0, 0.0], [0.25, 0.25, 0.5]])
+        >>> kmd.transform(weights).shape
+        (2, 6)
         """
         return np.asarray(weight, dtype=float) @ self._kernel
 
     def __call__(self, weight: npt.ArrayLike) -> npt.NDArray[np.float64]:
-        """Alias for :meth:`transform`."""
+        """Call :meth:`transform` with ``weight``.
+
+        This alias has the same inputs, outputs, and constraints as
+        :meth:`transform` and allows a configured :class:`KMD` instance to be
+        used as a descriptor callable.
+        """
         return self.transform(weight)
 
     def _internal_kernel_torch(self, *, device=None, dtype=None):  # type: ignore[no-untyped-def]
-        """Cached torch kernel for **internal** read-only use (no clone, no exposure).
+        """Return the cached internal torch kernel for one device and dtype.
 
-        Keyed by ``(device, dtype)`` so repeated calls in a gradient loop avoid the deep-copy
-        cost of :meth:`kernel_torch`. The cached tensor must never be returned to callers — they
-        could mutate it in place and break :meth:`transform` / :meth:`inverse`.
+        The returned tensor is internal mutable state and must never be exposed
+        to callers. Public code should use :meth:`kernel_torch`, which clones
+        this value, or :meth:`transform_torch`, which only reads it.
         """
         import torch
 
@@ -173,63 +307,129 @@ class KMD:
         return cached
 
     def kernel_torch(self, *, device=None, dtype=None):  # type: ignore[no-untyped-def]
-        """Return the precomputed kernel as a fresh ``torch.Tensor`` (safe to mutate).
+        """Copy the precomputed kernel into an independently owned torch tensor.
 
-        Each call returns an independently-allocated tensor (no memory sharing with the numpy
-        kernel, the internal cache, or any previous return), so in-place mutations on the result
-        cannot affect :meth:`transform` / :meth:`inverse` — :class:`KMD` itself stays 100%
-        numpy-only and backwards-compatible. For hot loops that just need a read-only view, use
-        :meth:`transform_torch` (which reuses an internal cache).
-
-        Parameters
-        ----------
-        device, dtype:
-            Optional torch device / dtype overrides for the returned tensor.
-        """
-        return self._internal_kernel_torch(device=device, dtype=dtype).clone()
-
-    def transform_torch(self, weight, *, device=None, dtype=None):  # type: ignore[no-untyped-def]
-        """Differentiable torch counterpart of :meth:`transform`.
-
-        :meth:`transform` is a single matrix multiplication ``weight @ K`` with ``K`` constant —
-        so the only step needed for end-to-end gradient flow into composition weights (e.g. for
-        gradient-based inverse design in composition space) is doing that matmul in torch.
-
-        Uses the internal kernel cache (matmul reads, never mutates), so repeated calls inside
-        an optimisation loop are constant-time after the first.
+        Every call returns a clone that shares no storage with the NumPy kernel,
+        the internal torch cache, or earlier return values. In-place mutation of
+        the result is therefore safe. For repeated forward operations, prefer
+        :meth:`transform_torch` to avoid cloning on every iteration.
 
         Parameters
         ----------
-        weight : torch.Tensor
-            Mixing ratios, shape ``(n_samples, n_components)``. Any ``device`` / ``dtype``.
-            Gradients flow through this argument.
-        device, dtype : optional
-            Overrides for the kernel view; defaults to ``weight``'s device/dtype.
+        device:
+            Optional device accepted by :meth:`torch.Tensor.to`, for example
+            ``"cpu"``, ``"cuda"``, or a :class:`torch.device`. Defaults to CPU
+            when the cache has not already established another explicit device.
+        dtype:
+            Optional torch dtype such as :data:`torch.float32`. Without an
+            override, the kernel retains its NumPy-derived ``float64`` dtype.
 
         Returns
         -------
         torch.Tensor
-            Descriptors, same shape as :meth:`transform` would produce.
+            Kernel of shape ``(n_components, n_descriptor_dims)``. The second
+            dimension is ``n_components`` for ``"md"`` and
+            ``n_features * n_grids`` for ``"1d"``.
+
+        Notes
+        -----
+        PyTorch is imported lazily, so it is required only when a torch-specific
+        method is called.
+        """
+        return self._internal_kernel_torch(device=device, dtype=dtype).clone()
+
+    def transform_torch(self, weight, *, device=None, dtype=None):  # type: ignore[no-untyped-def]
+        """Differentiably map a batch of torch component weights to descriptors.
+
+        This is the torch equivalent of :meth:`transform`: it computes
+        ``weight @ K`` while treating ``K`` as constant. Autograd therefore
+        propagates gradients to ``weight`` but not to the component features or
+        KMD hyperparameters. A kernel copy is cached per ``(device, dtype)``.
+
+        Parameters
+        ----------
+        weight:
+            :class:`torch.Tensor` of shape
+            ``(n_samples, n_components)``. Column ``j`` weights row ``j`` of
+            the construction-time ``component_features``. Gradients flow through
+            this tensor. As in :meth:`transform`, values are not normalized or
+            constrained automatically; use an operation such as ``softmax`` if
+            a differentiable simplex parameterization is required.
+        device:
+            Optional device for the cached kernel. Defaults to ``weight.device``.
+            It normally should not differ from the input device because torch
+            matrix multiplication requires both operands on the same device.
+        dtype:
+            Optional dtype for the cached kernel. Defaults to ``weight.dtype``.
+            It normally should match the input dtype.
+
+        Returns
+        -------
+        torch.Tensor
+            Descriptor tensor on the selected device and dtype, with the same
+            output shape as :meth:`transform`.
+
+        Examples
+        --------
+        Parameterize valid mixture weights and backpropagate through KMD:
+
+        >>> import torch
+        >>> features = np.array([[0.0, 1.0], [1.0, 0.5], [2.0, 2.0]])
+        >>> kmd = KMD(features, method="1d", n_grids=4)
+        >>> logits = torch.zeros(2, 3, requires_grad=True)
+        >>> descriptors = kmd.transform_torch(torch.softmax(logits, dim=1))
+        >>> descriptors.square().mean().backward()
+        >>> logits.grad.shape
+        torch.Size([2, 3])
         """
         kernel = self._internal_kernel_torch(device=device or weight.device, dtype=dtype or weight.dtype)
         return weight @ kernel
 
     def inverse(self, kmd: npt.ArrayLike) -> npt.NDArray[np.float64]:
-        """Recover mixing weights from descriptors (descriptors → materials).
+        """Recover non-negative, sum-to-one weights from KMD descriptors.
 
-        Solves, per sample, a non-negative simplex-constrained quadratic program
-        whose minimiser is the weight vector reproducing the given descriptor.
+        For each descriptor row ``z``, solve the quadratic program whose forward
+        model is ``z = weight @ K``, subject to ``weight >= 0`` and
+        ``weight.sum() == 1``. The Gram matrix ``K @ K.T`` is built and checked
+        once, then cached for subsequent calls.
 
         Parameters
         ----------
         kmd:
-            Descriptors as returned by :meth:`transform`, shape
-            ``(n_samples, n_descriptor_dims)``.
+            Two-dimensional numeric array-like of shape
+            ``(n_samples, n_descriptor_dims)``, normally produced by this exact
+            instance's :meth:`transform` method. ``n_descriptor_dims`` is
+            ``n_components`` for ``"md"`` and ``n_features * n_grids`` for
+            ``"1d"``.
 
         Returns
         -------
-        numpy.ndarray of shape ``(n_samples, n_components)``
-            Reconstructed mixing weights, each row summing to 1.
+        numpy.ndarray
+            ``float64`` array of shape ``(n_samples, n_components)``. Values are
+            non-negative up to solver precision and each row is normalized to
+            sum to one.
+
+        Raises
+        ------
+        ValueError
+            If ``K @ K.T`` is not positive definite, the descriptor shape is
+            incompatible, or the ``quadprog`` solver fails to return a solution.
+
+        Notes
+        -----
+        Inversion uses :func:`qpsolvers.solve_qp` with the ``quadprog`` backend.
+        It requires the optional runtime packages ``qpsolvers`` and ``quadprog``
+        and is not differentiable. A forward descriptor may be computable even
+        when the kernel is not uniquely invertible.
+
+        Examples
+        --------
+        >>> features = np.array([[0.0, 1.0], [1.0, 0.5], [2.0, 2.0]])
+        >>> weights = np.array([[0.2, 0.3, 0.5]])
+        >>> descriptor = KMD(features, method="1d", n_grids=6)
+        >>> recovered = descriptor.inverse(descriptor.transform(weights))
+        >>> np.allclose(recovered, weights, atol=1e-4)
+        True
         """
         kmd = np.asarray(kmd, dtype=float)
         kernel = self._kernel
@@ -255,11 +455,13 @@ class KMD:
     # -- kernel construction -------------------------------------------------
 
     def _build_kernel(self, cf: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+        """Build the configured kernel from a validated component feature matrix."""
         if self.method == "md":
             return self._md_kernel(cf)
         return self._1d_kernel(cf)
 
     def _md_kernel(self, cf: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+        """Build the square multidimensional RBF kernel between components."""
         if self.scale:
             cf = (cf - cf.mean(axis=0)) / cf.std(axis=0, ddof=1)
         d2 = distance_matrix(cf, cf) ** 2
@@ -276,6 +478,7 @@ class KMD:
         return np.exp(-d2 * gamma)
 
     def _1d_kernel(self, cf: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+        """Build and concatenate one grid-based RBF response block per feature."""
         assert self.n_grids is not None  # guaranteed by __init__
         if self.scale:
             cf = (cf - cf.min(axis=0)) / (cf.max(axis=0) - cf.min(axis=0))
@@ -290,7 +493,14 @@ class KMD:
         return np.concatenate(blocks, axis=1)
 
     def _gram_matrix(self) -> npt.NDArray[np.float64]:
-        """Return (and cache) the Gram matrix ``K Kᵀ``, validating invertibility."""
+        """Return and cache ``K @ K.T`` after checking positive definiteness.
+
+        Raises
+        ------
+        ValueError
+            If the smallest eigenvalue is non-positive, so the descriptor does
+            not uniquely determine component weights under the current kernel.
+        """
         if self._gram is None:
             gram = self._kernel @ self._kernel.T
             if np.linalg.eigvalsh(gram)[0] <= 0:
@@ -305,22 +515,51 @@ def stats_descriptor(
     component_features: npt.ArrayLike,
     stats: Sequence[str] = ("mean", "var", "max", "min"),
 ) -> npt.NDArray[np.float64]:
-    """Generate summary-statistics descriptors for mixture systems.
+    """Compute weighted summary-statistics descriptors for mixture samples.
+
+    Unlike :class:`KMD`, this function does not construct or cache a kernel.
+    Each requested statistic contributes one block of ``n_features`` columns,
+    and blocks appear in the same order as ``stats``.
 
     Parameters
     ----------
     weight:
-        Mixing ratios, shape ``(n_samples, n_components)``.
+        Two-dimensional numeric array-like of shape
+        ``(n_samples, n_components)``. Column ``j`` corresponds to row ``j`` of
+        ``component_features``. Weighted mean and variance conventionally assume
+        each row sums to one, but the function does not normalize or validate it.
     component_features:
-        Features for each constituent, shape ``(n_components, n_features)``.
+        Two-dimensional numeric array-like of shape
+        ``(n_components, n_features)``. Each row describes one constituent.
     stats:
-        Summary statistics to compute. Supported: ``"mean"``, ``"var"``,
-        ``"max"``, ``"min"``.
+        Ordered statistic names. Supported values are ``"mean"`` for the
+        weighted mean, ``"var"`` for weighted variance around that mean, and
+        ``"max"``/``"min"`` for feature-wise extrema over components whose
+        weight is exactly non-zero in each sample. Repeated names produce
+        repeated output blocks.
 
     Returns
     -------
-    numpy.ndarray of shape ``(n_samples, n_features * len(stats))``
-        Concatenated descriptors in the order given by ``stats``.
+    numpy.ndarray
+        ``float64`` array of shape
+        ``(n_samples, n_features * len(stats))``.
+
+    Raises
+    ------
+    ValueError
+        If ``stats`` contains an unsupported name, a sample has no non-zero
+        component when ``"max"`` or ``"min"`` is requested, or input shapes are
+        incompatible.
+
+    Examples
+    --------
+    >>> features = np.array([[1.0, 4.0], [3.0, 2.0], [5.0, 0.0]])
+    >>> weights = np.array([[0.25, 0.75, 0.0]])
+    >>> result = stats_descriptor(weights, features, stats=("mean", "max"))
+    >>> result.shape
+    (1, 4)
+    >>> np.allclose(result, [[2.5, 2.5, 3.0, 4.0]])
+    True
     """
     w = np.asarray(weight, dtype=float)
     cf = np.asarray(component_features, dtype=float)


### PR DESCRIPTION
## Summary

- expand `kmd_plus.py` docstrings with concrete shapes, parameter semantics, constraints, and examples
- add a Chinese migration guide for moving KMD descriptor calculation into another codebase
- document the production `element_features.csv` data source and the formula-to-descriptor path used by `TaskCatalog`

## Validation

- `pytest src/foundation_model/utils/kmd_plus_test.py` (`33 passed`)
- `uvx ruff check src/foundation_model/utils/kmd_plus.py`
- `uvx ruff format --check src/foundation_model/utils/kmd_plus.py`
- executed the documented production example: `(94, 58) -> (1, 94) -> (1, 464)`
- `git diff --check`