### PR TITLE
fix(pretrain): disable non-participating heads during fit (replay interval > 1)

### DIFF
--- a/src/foundation_model/workflows/pretrain.py
+++ b/src/foundation_model/workflows/pretrain.py
@@ -432,7 +432,16 @@ def _run_single(
             enable_progress_bar=False,
             callbacks=callbacks,
         )
+        # Learned-but-not-participating heads (replay off this step) must sit out the fit: forward
+        # runs every registered head, and a kernel-regression head raises without its t-sequence,
+        # which the datamodule only carries for active tasks. Restore before eval/checkpointing so
+        # the saved state keeps every head under its task_heads.* key.
+        inactive = [name for name in learned if name not in participating]
+        if inactive:
+            model.disable_task(*inactive)
         trainer.fit(model, datamodule=datamodule)
+        if inactive:
+            model.enable_task(*inactive)
 
         test_keys: set[str] | None = None
         if datamodule.split_series is not None:

--- a/src/foundation_model/workflows/pretrain_test.py
+++ b/src/foundation_model/workflows/pretrain_test.py
@@ -375,6 +375,73 @@ def test_warm_start_continues_sequence(smoke_dir, tmp_path) -> None:
     assert (out2 / "training" / "step02_b" / "a_metrics.json").exists()
 
 
+def test_no_replay_interval_disables_learned_kr_head(smoke_dir, tmp_path) -> None:
+    """interval > n_steps ⇒ replay never fires: a later single-task step must not crash on the
+    learned kernel-regression head, whose forward needs a t-sequence only active tasks provide."""
+    kr = pd.DataFrame(
+        {
+            "composition": _FORMULAS,
+            "dos": ["[0.1, 0.2, 0.3]"] * len(_FORMULAS),
+            "energy": ["[1.0, 2.0, 3.0]"] * len(_FORMULAS),
+        }
+    )
+    kr.to_parquet(smoke_dir / "kr.parquet")
+    toml = f"""
+[data]
+batch_size = 8
+
+[descriptor]
+kind = "kmd"
+n_grids = 4
+
+[datasets.d1]
+path = "{smoke_dir / "x.parquet"}"
+
+[datasets.kr]
+path = "{smoke_dir / "kr.parquet"}"
+
+[[tasks]]
+name = "a"
+kind = "regression"
+dataset = "d1"
+column = "a"
+
+[[tasks]]
+name = "dos"
+kind = "kernel_regression"
+dataset = "kr"
+column = "dos"
+t_column = "energy"
+
+[model]
+latent_dim = 8
+encoder_hidden_dims = [16]
+head_hidden_dims = [8]
+n_kernel = 4
+
+[training]
+max_epochs = 1
+accelerator = "cpu"
+seed = 1
+
+[pretrain]
+task_sequence = ["dos", "a"]
+
+[pretrain.replay]
+interval = 999
+amount = 0.5
+"""
+    out = tmp_path / "noreplay"
+    _run_pretrain(build_pretrain_config(tomllib.loads(toml), output_dir=str(out)), out)
+
+    final = torch.load(out / "training" / "final_model.pt", weights_only=True)
+    heads = {k.split(".", 2)[1] for k in final["model"] if k.startswith("task_heads.")}
+    assert {"a", "dos"} <= heads  # sat-out head re-enabled before saving
+    assert not any(k.startswith("disabled_task_heads.") for k in final["model"])
+    # the sat-out head is still evaluated at the no-replay step
+    assert (out / "training" / "step02_a" / "dos_metrics.json").exists()
+
+
 def test_replay_epoch_resample_fires_each_epoch(smoke_dir, tmp_path, monkeypatch) -> None:
     """resample = "epoch" redraws replay masks inside a real Trainer fit, once per epoch."""
     from foundation_model.data.dataset import CompoundDataset


### PR DESCRIPTION
## Problem

With `replay.interval > 1`, a pretrain step that trains the new task alone crashes as soon as a kernel-regression task has been learned earlier in the sequence:

```
ValueError: KernelRegressionHead 'magnetic_susceptibility' requires t parameter but t_sequences is missing or doesn't contain 'magnetic_susceptibility'
```

`FlexibleMultiTaskModel.forward` computes every registered head, and a `KernelRegressionHead` requires its t-sequence — which the step's datamodule only carries for **active** tasks. `interval = 1` (every run to date) always makes all learned tasks active, so the path was never hit; it surfaced live in the no-replay baseline smoke (`interval = 999`) at step 14, right after `magnetic_susceptibility` (kr, step 13) was learned.

## Fix

Mirror the `fm finetune` mechanism: `disable_task` the learned-but-not-participating heads for `trainer.fit`, `enable_task` them immediately after — before evaluation and checkpointing, so saved state keeps every head under its `task_heads.*` key (a disable at save time would emit `disabled_task_heads.*` keys instead). `disable_task`/`enable_task` are the existing weight-preserving round trip finetune already relies on.

`interval = 1` builds an empty inactive list — **zero behavior change for all existing runs**.

## Test

`test_no_replay_interval_disables_learned_kr_head`: 2-task CPU smoke (kr task then regression task, `interval = 999`) — fails with the exact ValueError above without the fix; also asserts the final checkpoint keeps both heads under `task_heads.*` and that the sat-out head is still evaluated at the no-replay step.

- `pytest src/foundation_model/workflows/pretrain_test.py`: 58 passed
- `ruff check` / `ruff format --check` / `mypy`: clean

## Context

Unblocks the no-replay + joint-retrain baseline arm of the replay experiment campaign (`experiments/replay_epoch_sweep/`). The cluster working copy will run from this branch until merge; run provenance records the branch commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMVtHKRMQJYobF9jtbvVyf