### PR TITLE
fix(model): score each task's R² with its own tensors, not the last task's

### DIFF
--- a/src/foundation_model/models/flexible_multi_task_model.py
+++ b/src/foundation_model/models/flexible_multi_task_model.py
@@ -1003,6 +1003,7 @@ class FlexibleMultiTaskModel(L.LightningModule):
             batch_valid_mask, batch_valid_list = valid_mask_info
 
         raw_val_supervised_losses = {}
+        val_metric_inputs: dict[str, tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]] = {}
         for name, pred_tensor in preds.items():
             head = self.task_heads[name]
 
@@ -1050,6 +1051,10 @@ class FlexibleMultiTaskModel(L.LightningModule):
                 )
 
             raw_val_supervised_losses[name] = raw_loss_t
+            # Keep this task's own tensors: the R2 update below runs in a second loop, and
+            # reading the loop variables there would score every task against whichever task
+            # happened to be processed last.
+            val_metric_inputs[name] = (pred_tensor, target, sample_mask)
             val_sum_supervised_raw_loss += raw_loss_t.detach()
             val_logs[f"val_{name}_raw_loss"] = raw_loss_t.detach()
             val_logs[f"val_{name}_all_missing"] = torch.tensor(0.0, device=x.device)
@@ -1074,12 +1079,13 @@ class FlexibleMultiTaskModel(L.LightningModule):
                 val_logs[f"val_{name}_final_loss_contrib"] = final_task_loss_component.detach()
             val_logs[f"val_{name}_static_weight"] = torch.tensor(static_weight, device=x.device)
 
+            metric_preds, metric_targets, metric_mask = val_metric_inputs[name]
             self._update_r2_metric(
                 stage="val",
                 task_name=name,
-                preds=pred_tensor,
-                targets=target,
-                sample_mask=sample_mask,
+                preds=metric_preds,
+                targets=metric_targets,
+                sample_mask=metric_mask,
             )
 
         val_logs["val_final_supervised_loss"] = val_supervised_loss_contribution.detach()
@@ -1123,6 +1129,7 @@ class FlexibleMultiTaskModel(L.LightningModule):
             batch_valid_mask, batch_valid_list = valid_mask_info
 
         raw_test_supervised_losses = {}
+        test_metric_inputs: dict[str, tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]] = {}
         for name, pred_tensor in preds.items():
             head = self.task_heads[name]
 
@@ -1170,6 +1177,10 @@ class FlexibleMultiTaskModel(L.LightningModule):
                 )
 
             raw_test_supervised_losses[name] = raw_loss_t
+            # Keep this task's own tensors: the R2 update below runs in a second loop, and
+            # reading the loop variables there would score every task against whichever task
+            # happened to be processed last.
+            test_metric_inputs[name] = (pred_tensor, target, sample_mask)
             test_sum_supervised_raw_loss += raw_loss_t.detach()
             test_logs[f"test_{name}_raw_loss"] = raw_loss_t.detach()
             test_logs[f"test_{name}_all_missing"] = torch.tensor(0.0, device=x.device)
@@ -1194,12 +1205,13 @@ class FlexibleMultiTaskModel(L.LightningModule):
                 test_logs[f"test_{name}_final_loss_contrib"] = final_task_loss_component.detach()
             test_logs[f"test_{name}_static_weight"] = torch.tensor(static_weight, device=x.device)
 
+            metric_preds, metric_targets, metric_mask = test_metric_inputs[name]
             self._update_r2_metric(
                 stage="test",
                 task_name=name,
-                preds=pred_tensor,
-                targets=target,
-                sample_mask=sample_mask,
+                preds=metric_preds,
+                targets=metric_targets,
+                sample_mask=metric_mask,
             )
 
         test_logs["test_final_supervised_loss"] = test_supervised_loss_contribution.detach()

--- a/src/foundation_model/models/flexible_multi_task_model_test.py
+++ b/src/foundation_model/models/flexible_multi_task_model_test.py
@@ -799,6 +799,61 @@ def test_r2_metric_updates_respect_masks(model_config_mixed_tasks):
     assert torch.isclose(computed, torch.tensor(1.0))
 
 
+@pytest.mark.parametrize("stage", ["val", "test"])
+def test_r2_metric_uses_each_tasks_own_tensors(model_config_mixed_tasks, sample_batch_mixed_tasks, mocker, stage):
+    """Every task's R² must be fed that task's own predictions, not the last task's.
+
+    The two loops in ``validation_step`` / ``test_step`` are separate: losses are computed in the
+    first, R² updated in the second. Reading the first loop's tensors from the second scored every
+    task against whichever task iterated last — silently wrong when the shapes happened to agree
+    (``regr_task_1`` is (B, 1), ``regr_task_2`` is (B, 2)) and a hard ``RuntimeError`` from
+    torchmetrics when they did not (a classification head last).
+    """
+    config = model_config_mixed_tasks
+    model = FlexibleMultiTaskModel(
+        task_configs=config.task_configs,
+        encoder_config=config.encoder_config,
+        shared_block_optimizer=config.shared_block_optimizer,
+    )
+    model.eval()
+    mocker.patch.object(model, "log_dict")
+    mocker.patch.object(model, "log")
+    spy = mocker.spy(model, "_update_r2_metric")
+
+    step = model.validation_step if stage == "val" else model.test_step
+    step(sample_batch_mixed_tasks, batch_idx=0)
+
+    seen = {call.kwargs["task_name"]: call.kwargs for call in spy.call_args_list}
+    batch_size = sample_batch_mixed_tasks[0].shape[0]
+    # Head output widths differ per task (dims[-1]), which is what pins the tensors to the task.
+    assert seen["regr_task_1"]["preds"].shape == (batch_size, 1)
+    assert seen["regr_task_2"]["preds"].shape == (batch_size, 2)
+    assert seen["clf_task_1"]["preds"].shape == (batch_size, 3)
+    for name, kwargs in seen.items():
+        expected = sample_batch_mixed_tasks[1][name]
+        assert torch.equal(kwargs["targets"], expected), f"{name} scored against another task's targets"
+
+
+def test_classification_task_last_does_not_break_r2(model_config_mixed_tasks, sample_batch_mixed_tasks, mocker):
+    """A classification head as the final task used to crash the R² update with a shape mismatch."""
+    config = model_config_mixed_tasks
+    reordered = [tc for tc in config.task_configs if tc.name != "clf_task_1"]
+    reordered.append(next(tc for tc in config.task_configs if tc.name == "clf_task_1"))
+    model = FlexibleMultiTaskModel(
+        task_configs=reordered,
+        encoder_config=config.encoder_config,
+        shared_block_optimizer=config.shared_block_optimizer,
+    )
+    model.eval()
+    mocker.patch.object(model, "log_dict")
+    mocker.patch.object(model, "log")
+
+    model.validation_step(sample_batch_mixed_tasks, batch_idx=0)  # used to raise RuntimeError
+
+    # Only the regression tasks own an R² metric; both must have been updated.
+    assert model._metrics_updated["val"] == {"regr_task_1", "regr_task_2"}
+
+
 # Helper for creating dummy dataframes
 def create_dummy_dataframe(num_samples, num_features, index_prefix="sample_"):
     data = np.random.rand(num_samples, num_features)


### PR DESCRIPTION
## The bug

`validation_step` and `test_step` are structured as two loops: the first computes each task's raw
loss, the second applies loss weighting and updates the R² metric. The second loop called
`_update_r2_metric(preds=pred_tensor, targets=target, sample_mask=sample_mask)` — but those are the
**first loop's** variables, left over from its final iteration. Every task's R² was therefore scored
against whichever task happened to iterate last.

Two failure modes:

- **Silent** when the shapes agreed. Two regression heads of different widths produced numbers that
  looked fine and meant nothing.
- **Hard crash** when they did not. A classification head as the final task raises during the
  sanity-check pass, before a single training epoch runs:

  ```
  RuntimeError: Predictions and targets are expected to have the same shape,
  but got torch.Size([256, 3]) and torch.Size([256, 1]).
  ```

That crash is what surfaced this — building a multi-task model where the classification head is
declared last is an ordinary thing to do.

## The fix

Record `(pred_tensor, target, sample_mask)` per task alongside its raw loss in the first loop, then
read them back by name in the second. Same change in both `validation_step` and `test_step`.

## Tests

- `test_r2_metric_uses_each_tasks_own_tensors` (parametrised val/test) — spies on `_update_r2_metric`
  and pins each call to its task's own head width and target tensor. Fails on master with
  `assert torch.Size([4, 2]) == (4, 1)`.
- `test_classification_task_last_does_not_break_r2` — reorders the fixture so the classification head
  is last; reproduces the RuntimeError on master.
- `pytest src/foundation_model/models/` — 124 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)