### PR TITLE
fix(config)!: remove [[tasks]].replay, a field no code has ever read

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,7 +94,6 @@ One entry per prediction head. At least one is required; names must be unique.
 | `t_column` | str | `None` | required iff `kind = kernel_regression`; forbidden otherwise | The sequence x-axis column (e.g. energies for DOS, temperatures for ZT). |
 | `num_classes` | int | `None` | required iff `kind = classification`, `>= 2`; forbidden otherwise | Number of classes. |
 | `lr` | float | `None` | | Per-task learning-rate override (else the section LR for its kind). |
-| `replay` | float \| int | `None` | float in `(0,1)` or int `>= 1` | **Accepted and validated, but currently has no effect** — no workflow reads it. Per-task replay amounts come from `[pretrain.replay].per_task`. |
 | `hidden_dims` | list[int] | `None` | positive ints; reg/clf only | Override `[model].head_hidden_dims` for this head. |
 | `x_hidden_dims` | list[int] | `None` | positive ints; KR only | Override `[model].kr_x_hidden_dims` (value branch). |
 | `t_hidden_dims` | list[int] | `None` | positive ints; KR only | Override `[model].kr_t_hidden_dims` (coordinate branch). |

--- a/src/foundation_model/workflows/task_catalog.py
+++ b/src/foundation_model/workflows/task_catalog.py
@@ -93,21 +93,6 @@ def _coerce_task_kind(value: Any) -> TaskKind:
         ) from exc
 
 
-def _validate_replay(value: float | int | None, *, where: str) -> None:
-    if value is None:
-        return
-    if isinstance(value, bool):  # bool is an int subclass — reject it explicitly
-        raise ValueError(f"{where}: replay must be a number, got bool {value!r}.")
-    if isinstance(value, float):
-        if not 0.0 < value < 1.0:
-            raise ValueError(f"{where}: replay float must be in (0, 1) (fraction of labels), got {value}.")
-    elif isinstance(value, int):
-        if value < 1:
-            raise ValueError(f"{where}: replay int must be >= 1 (label count), got {value}.")
-    else:
-        raise ValueError(f"{where}: replay must be a float in (0, 1) or an int >= 1, got {value!r}.")
-
-
 @dataclass(kw_only=True)
 class ScalerSpec:
     """Points at a fitted scaler used to inverse-transform a task's predictions for reporting."""
@@ -155,7 +140,6 @@ class TaskSpec:
     t_column: str | None = None  # required iff kind == KERNEL_REGRESSION
     num_classes: int | None = None  # required iff kind == CLASSIFICATION
     lr: float | None = None  # per-task LR override
-    replay: float | int | None = None  # per-task replay override (fraction or count)
     scaler: ScalerSpec | None = None
     # Per-head architecture overrides (fall back to [model] defaults when None).
     hidden_dims: list[int] | None = None  # reg/clf hidden widths
@@ -176,7 +160,6 @@ class TaskSpec:
                 raise ValueError(f"Task '{self.name}': num_classes must be >= 2, got {self.num_classes}.")
         elif self.num_classes is not None:
             raise ValueError(f"Task '{self.name}': 'num_classes' is only valid for classification.")
-        _validate_replay(self.replay, where=f"Task '{self.name}'")
         self._validate_arch_overrides()
 
     def _validate_arch_overrides(self) -> None:

--- a/src/foundation_model/workflows/task_catalog_test.py
+++ b/src/foundation_model/workflows/task_catalog_test.py
@@ -251,12 +251,14 @@ column = "density"
         _build(toml)
 
 
-@pytest.mark.parametrize(
-    ("replay", "ok"),
-    [(0.1, True), (500, True), (0.0, False), (-1, False), (1.0, False)],
-)
-def test_replay_validation(replay: float, ok: bool) -> None:
-    toml = f"""
+def test_per_task_replay_key_is_rejected() -> None:
+    """``[[tasks]].replay`` was never read by any workflow — it must not silently do nothing.
+
+    Introduced by the fm-CLI refactor's PR1 for PR2 to consume; PR2 shipped
+    ``[pretrain.replay].per_task`` instead and the field was left orphaned. Removing it turns a
+    silent no-op into a config error that names the real key.
+    """
+    toml = """
 [datasets.qc]
 path = "data/qc.parquet"
 
@@ -265,13 +267,10 @@ name = "density"
 kind = "regression"
 dataset = "qc"
 column = "density"
-replay = {replay!r}
+replay = 0.1
 """
-    if ok:
-        assert _build(toml).tasks[0].replay == replay
-    else:
-        with pytest.raises(ValueError, match="replay"):
-            _build(toml)
+    with pytest.raises(ValueError, match=r"tasks\.density.*unknown key\(s\) \['replay'\]"):
+        _build(toml)
 
 
 def test_unsupported_extension_raises() -> None:


### PR DESCRIPTION
## Scope

Removes `TaskSpec.replay` (`[[tasks]].replay`) — a config field that no code has ever read — along
with its now-unused validator and its documentation row.

## Why it is dead, and why it was never alive

- `_replay_ratio_for` (`pretrain.py:476`) consults only `cfg.replay.per_task` and
  `cfg.replay.amount`, i.e. `[pretrain.replay]`.
- `git log --all -S "spec.replay" -- src/` returns **nothing**: no commit in the repository's
  history has ever read the field.

It is not a working feature that a refactor broke. The fm-CLI refactor introduced it in **PR1**
(`e919f4c`, the commit that created `task_catalog.py`), explicitly for PR2 to consume — PR1's plan
says *"count → ratio conversion happens where the number of valid labels is known (pretrain engine,
**PR2**) — `TaskSpec.replay` is stored raw here."* **PR2 shipped `[pretrain.replay].per_task`
instead**, and the PR1 field was orphaned at birth.

It was not kept for backward compatibility either: the legacy scripts it replaced used
`replay_ratio` / `replay_ratio_high` / `fixed_tail`, none of which is per-task.

## Why it matters

The failure is silent. A config that sets it is accepted, validates, trains to completion, and
returns the *global* `amount` result — with nothing in the logs saying the per-task override was
ignored. Anyone following `docs/configuration.md`, which claimed it *"overrides
`[pretrain.replay]`"*, would have gotten a wrong answer that looks right.

Because `_reject_unknown` derives its allowed-key set from `TaskSpec.__dataclass_fields__`,
deleting the field converts that silent no-op into a config error naming the real keys.

## Backward-incompatible behaviour

`[[tasks]] replay = ...` now raises instead of being silently ignored. **No config in the
repository has ever set it** (all 30 `experiments/` + `samples/` configs were checked), and the
working per-task control, `[pretrain.replay].per_task`, is untouched.

## Validation

- `uv run pytest src/` — 478 passed.
- The 16 `pretrain_test.py` replay tests pass unchanged: the consumed path is not touched.
- The field's old validation test is replaced by one asserting the key is now rejected with a
  message naming it.
- All 30 configs under `experiments/` and `samples/` still build via `build_task_catalog_config`.
- Checkpoint metadata is unaffected — `_task_spec_dump` persists only `kind` / `column` /
  `source`, verified against a real `final_model_taskconfigs.json` from the running campaign.
- `ruff` + `mypy` clean.

## Note for reviewers

Found while auditing docs against the TOML schema (#43). A Codex review comment on that PR listed
`[[tasks]].replay` as one of the ways TOML varies replay — that part was incorrect, which is what
prompted this check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jzv6U6vwQ6uboZLMxC7Bk
