### PR TITLE
chore(mypy): enable check_untyped_defs with a shrinking override list

### DIFF
--- a/docs/refactor_check_untyped_defs/00_OVERVIEW.md
+++ b/docs/refactor_check_untyped_defs/00_OVERVIEW.md
@@ -1,0 +1,95 @@
+# Enabling `check_untyped_defs` — overview
+
+**Status:** ratchet in place; backlog open.
+**Owner PR:** the one adding this document.
+
+## Why
+
+`mypy` does not look inside a function that has no annotations. Every `def f(self, batch, batch_idx):`
+in this repository is therefore **completely unchecked**, and those are the functions that carry
+the training loop.
+
+This is not hypothetical. In PR #45, `training_step` had:
+
+```python
+train_logs: dict[str, torch.Tensor] = {}
+...
+train_logs[f"train_{name}_all_missing"] = 1.0   # a float, not a Tensor
+```
+
+`uv run mypy` reported the file clean. Adding `--check-untyped-defs` reported it immediately. The
+same audit found an `opt.step()` the branch's own log message said it would not take, in the same
+unchecked function. Annotating those two step methods is what let the type checker see them at all.
+
+The goal is that no function in `src/` is invisible to the type checker.
+
+## What is actually in the way
+
+Measured on `5455da0` with `uv run mypy --check-untyped-defs src/foundation_model/`:
+
+**32 errors in 7 files.** Only **6 are in production code**, and none of the six is a runtime bug —
+they are places where a declared type does not describe the real data:
+
+| File | n | What |
+|---|---:|---|
+| `data/composition_sources_test.py` | 9 | pandas `.loc` indexing with `str \| None` keys; an unannotated `calls` list |
+| `models/flexible_multi_task_model_test.py` | 13 | mock/fixture looseness — assigning to methods, `MagicMock` passed where tensors are declared |
+| `data/datamodule.py` | 4 | `batched_y_dict` is annotated `list[Any]` but genuinely holds `Tensor \| list[Tensor]`; `on_train_epoch_start` guards with `getattr(..., None) is not None`, which mypy cannot narrow through |
+| `models/flexible_multi_task_model.py` | 2 | `encoder_config` declared `BaseEncoderConfig` where only the two concrete subclasses are valid; `head.compute_loss` unresolvable because `ModuleDict.__getitem__` returns `Module` |
+| `workflows/task_catalog_test.py` | 2 | fixture typing |
+| `data/datamodule_test.py`, `data/dataset_test.py` | 2 | fixture typing |
+
+The production errors are worth fixing on their own merits: `batched_y_dict: list[Any]` actively
+tells a reader that every value is a list when half of them are stacked tensors, and that is the
+dictionary the collate function hands to every training step.
+
+## Decision
+
+**Turn the flag on globally now and quarantine the seven known-failing modules**, rather than fix
+32 errors in one unreviewable PR or leave the flag off until someone finds time.
+
+```toml
+[tool.mypy]
+check_untyped_defs = true
+
+[[tool.mypy.overrides]]
+module = [ ... the seven ... ]
+check_untyped_defs = false
+```
+
+The ratchet is the point: from the moment this lands, **a new untyped-body error cannot enter any
+module that is already clean** — which is 48 of the 55 files. The backlog is the override list, it
+only shrinks, and `pyproject.toml` shows exactly how much is left.
+
+### Alternatives rejected
+
+- **One big PR fixing all 32.** Mixes production type corrections with test-fixture churn across
+  seven files; unreviewable, and the two categories deserve different scrutiny.
+- **Leave it off, fix opportunistically.** This is the status quo that let PR #45's defects sit in
+  an unchecked function. Without the flag on, nothing stops the next one.
+- **`--check-untyped-defs` only in CI, not in `pyproject.toml`.** Then `uv run mypy` locally and CI
+  disagree, and contributors get failures they cannot reproduce with the documented command.
+
+## Non-goals
+
+- Annotating every function signature. The flag checks *bodies*; full signature coverage
+  (`disallow_untyped_defs`) is a separate, much larger decision.
+- `strict = true`, `disallow_any_*`, or any other tightening.
+- Changing runtime behaviour. Every PR in this sequence must be behaviour-preserving; where a type
+  fix would change behaviour, that is a bug fix and belongs in its own PR with its own tests.
+
+## Ordered PRs
+
+Production first: those errors describe real data, and the modules are the ones the training loop
+runs through. Test files after, one per PR, so fixture churn never lands in the same diff as a
+production type correction.
+
+| # | Plan | Removes from the override list |
+|---|---|---|
+| 1 | [`01_pr1_datamodule.md`](01_pr1_datamodule.md) | `data.datamodule` |
+| 2 | [`02_pr2_flexible_multi_task_model.md`](02_pr2_flexible_multi_task_model.md) | `models.flexible_multi_task_model` |
+| 3 | [`03_pr3_test_fixtures.md`](03_pr3_test_fixtures.md) | the five `*_test` modules |
+| 4 | [`04_pr4_remove_the_override.md`](04_pr4_remove_the_override.md) | the override block itself |
+
+Each PR's acceptance is the same shape: remove its entries from the override list, and
+`uv run mypy src/` passes with no new `# type: ignore`.

--- a/docs/refactor_check_untyped_defs/01_pr1_datamodule.md
+++ b/docs/refactor_check_untyped_defs/01_pr1_datamodule.md
@@ -1,0 +1,37 @@
+# PR1 — `data/datamodule.py` under `check_untyped_defs`
+
+## Goal
+
+Make `foundation_model.data.datamodule` type-check with untyped bodies enabled, and remove it from
+the override list in `pyproject.toml`.
+
+## Scope
+
+Four errors, none of them a runtime bug:
+
+| Line | Error | Reality |
+|---|---|---|
+| 87, 88 | `Incompatible types in assignment (expression has type "Tensor", target has type "list[Any]")` | `batched_y_dict` / `batched_mask_dict` hold **`Tensor` for stacked tasks and `list[Tensor]` for kernel-regression tasks**. The annotation says every value is a list. |
+| 538 | `Item "None" of "DistributedSampler \| None" has no attribute "set_epoch"` | Guarded by `getattr(self, "_train_sampler", None) is not None`; mypy cannot narrow through `getattr`. |
+| 538 | `Item "None" of "Trainer \| None" has no attribute "current_epoch"` | Same, for `getattr(self, "trainer", None)`. |
+
+Fix by describing the data, not by silencing:
+
+- Widen the batched-dict annotations to `dict[str, torch.Tensor | list[torch.Tensor]]`. This is the
+  dictionary the collate function hands to every `*_step`; the current annotation misleads anyone
+  reading how kernel-regression batches differ from the rest.
+- Replace the `getattr(...) is not None` guards with direct attribute tests so narrowing works.
+
+## Non-goals
+
+- Changing what the collate function produces.
+- Touching `datamodule_test.py` (PR3).
+
+## Acceptance
+
+```bash
+uv run mypy src/foundation_model/data/datamodule.py   # clean, with the override removed
+uv run pytest src/foundation_model/data/ -q           # unchanged
+```
+
+No new `# type: ignore` in the diff.

--- a/docs/refactor_check_untyped_defs/02_pr2_flexible_multi_task_model.md
+++ b/docs/refactor_check_untyped_defs/02_pr2_flexible_multi_task_model.md
@@ -1,0 +1,42 @@
+# PR2 — `models/flexible_multi_task_model.py` under `check_untyped_defs`
+
+## Goal
+
+Make the model module type-check with untyped bodies enabled and remove it from the override list.
+
+This is the module the flag exists for: PR #45's defects — a float assigned into a
+`dict[str, Tensor]`, and an `opt.step()` the branch's own log said it would skip — both lived in
+functions mypy was not reading.
+
+## Scope
+
+Two errors:
+
+| Line | Error | Cause |
+|---|---|---|
+| 301 | `Argument "encoder_config" to "FoundationEncoder" has incompatible type "BaseEncoderConfig"` | `self.encoder_config` is declared as the abstract base, but only `MLPEncoderConfig` and `TransformerEncoderConfig` are ever valid — `EncoderConfig` is already that union. |
+| 962 | `"Tensor" not callable` on `head.compute_loss(...)` | `ModuleDict.__getitem__` returns `Module`, and `Module.__getattr__` is typed `Tensor \| Module`, so any method reached through `self.task_heads[name]` is unresolvable. |
+
+Approach:
+
+- Narrow the `encoder_config` attribute to `EncoderConfig` (the existing union). `build_encoder_config`
+  already returns exactly that.
+- For the head lookup, introduce one typed accessor — e.g. `_head(name) -> BaseTaskHead` — used by
+  the shared pipeline instead of indexing `self.task_heads` directly. One cast in one place, rather
+  than a `# type: ignore` at every call site, and it gives the heads a named protocol boundary.
+
+## Non-goals
+
+- Annotating every signature in the file (that is `disallow_untyped_defs`, out of scope).
+- Any change to loss composition, masking or optimizer behaviour — this module was just rewritten
+  in #45 and its three characterization tests must keep passing **unmodified**.
+
+## Acceptance
+
+```bash
+uv run mypy src/foundation_model/models/flexible_multi_task_model.py   # clean, override removed
+uv run pytest src/foundation_model/models/ -q                          # unchanged
+```
+
+The characterization tests (`test_step_output_is_stable`) must pass without edits — if they need
+editing, the PR has changed behaviour and is out of scope.

--- a/docs/refactor_check_untyped_defs/03_pr3_test_fixtures.md
+++ b/docs/refactor_check_untyped_defs/03_pr3_test_fixtures.md
@@ -1,0 +1,35 @@
+# PR3 — test fixtures under `check_untyped_defs`
+
+## Goal
+
+Make the five remaining `*_test` modules type-check and remove them from the override list.
+
+## Scope
+
+26 errors, all fixture/mock looseness rather than defects:
+
+| File | n | Shape of the problem |
+|---|---:|---|
+| `models/flexible_multi_task_model_test.py` | 13 | `MagicMock` passed where a `Tensor` is declared; assignment to bound methods (`model.training_step = ...`) |
+| `data/composition_sources_test.py` | 9 | pandas `.loc` indexed with `str \| None`; an unannotated `calls` list |
+| `workflows/task_catalog_test.py` | 2 | fixture return types |
+| `data/datamodule_test.py`, `data/dataset_test.py` | 2 | fixture return types |
+
+Approach: annotate fixtures and local collections, and narrow the `str | None` values that reach
+pandas indexers with an assertion that documents why they cannot be `None` at that point. Where a
+test deliberately monkey-patches a method, use `mocker.patch.object` (already used elsewhere in
+these files) instead of direct assignment.
+
+Split further if the diff grows past comfortable review — one PR per file is acceptable, and the
+override list makes partial progress visible.
+
+## Non-goals
+
+- Changing what any test asserts. A test whose assertions change is not a typing fix.
+
+## Acceptance
+
+```bash
+uv run mypy src/                # clean with only the override block left
+uv run pytest src/ -q           # same count, same passes
+```

--- a/docs/refactor_check_untyped_defs/04_pr4_remove_the_override.md
+++ b/docs/refactor_check_untyped_defs/04_pr4_remove_the_override.md
@@ -1,21 +1,46 @@
-# PR4 — remove the override block
+# PR4 — remove the override block, and enforce mypy per commit
 
 ## Goal
 
-Delete the `check_untyped_defs = false` override from `pyproject.toml` and this plan directory.
+Delete the `check_untyped_defs = false` override from `pyproject.toml`, and make the type check
+run as a pre-commit hook so the ratchet is enforced before code reaches CI rather than after.
 
 ## Scope
 
-By this point the override list is empty. The PR removes:
+By this point the override list is empty. This PR:
 
-- the `[[tool.mypy.overrides]]` block that carried the backlog,
-- `docs/refactor_check_untyped_defs/`, following the precedent of `docs/refactor_fm_cli/`, which was
-  deleted once its sequence merged.
+- removes the `[[tool.mypy.overrides]]` block that carried the backlog;
+- adds a `mypy` hook to `.pre-commit-config.yaml`, scoped to `src/` and using the project
+  environment so it sees the same settings as `uv run mypy`;
+- updates `AGENTS.md`, which currently states that the commit hook *"intentionally does not run
+  Mypy"* — that sentence is the thing being changed, and leaving it would make the repository
+  contradict itself;
+- deletes `docs/refactor_check_untyped_defs/`, following the precedent of `docs/refactor_fm_cli/`,
+  which was removed once its sequence merged.
+
+Hook design matters here. `mypy` is not a per-file linter: checking only the staged files gives
+different answers than checking the package, because inference crosses module boundaries. The hook
+therefore runs once over `src/` with `pass_filenames: false`, triggered by any staged `.py` change.
+It is slower than `ruff format`, which is the reason the original decision went the other way — the
+ratchet is what changes the trade, since a violation now blocks the whole repository rather than
+one file.
+
+## Non-goals
+
+- **Tightening beyond `check_untyped_defs`.** No `strict`, no `disallow_untyped_defs`, no
+  `disallow_any_*`. Signature coverage is a separate decision with a much larger diff.
+- **Changing runtime behaviour.** This PR touches configuration and documentation only.
+- **Adding hooks for other tools** (pytest, ruff check). One hook, one purpose; a slow test hook is
+  a different trade-off and deserves its own discussion.
+- **Removing the `joblib` `ignore_missing_imports` override**, which is unrelated to this sequence.
 
 ## Acceptance
 
 ```bash
-uv run mypy src/    # clean, with no check_untyped_defs override anywhere
+uv run mypy src/                       # clean, with no check_untyped_defs override anywhere
+uv run pre-commit run mypy --all-files # passes
+uv run pytest src/ -q                  # unchanged
 ```
 
-`grep -r "check_untyped_defs" pyproject.toml` returns only the single global `true`.
+`grep -rn "check_untyped_defs" pyproject.toml` returns only the single global `true`, and
+`grep -n "Mypy" AGENTS.md` no longer claims the hook skips it.

--- a/docs/refactor_check_untyped_defs/04_pr4_remove_the_override.md
+++ b/docs/refactor_check_untyped_defs/04_pr4_remove_the_override.md
@@ -1,0 +1,21 @@
+# PR4 — remove the override block
+
+## Goal
+
+Delete the `check_untyped_defs = false` override from `pyproject.toml` and this plan directory.
+
+## Scope
+
+By this point the override list is empty. The PR removes:
+
+- the `[[tool.mypy.overrides]]` block that carried the backlog,
+- `docs/refactor_check_untyped_defs/`, following the precedent of `docs/refactor_fm_cli/`, which was
+  deleted once its sequence merged.
+
+## Acceptance
+
+```bash
+uv run mypy src/    # clean, with no check_untyped_defs override anywhere
+```
+
+`grep -r "check_untyped_defs" pyproject.toml` returns only the single global `true`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,29 @@ dev = [
 # C901
 max-complexity = 10
 
+[tool.mypy]
+# Without this, mypy does not look inside any function that lacks annotations — which is most of
+# the training loop. PR #45 shipped a float into a dict[str, Tensor] and an opt.step() the branch
+# logged that it would skip, both in functions `uv run mypy` reported as clean.
+check_untyped_defs = true
+
 [[tool.mypy.overrides]]
 # joblib ships neither stubs nor a py.typed marker; a test writes fixtures with it.
 module = ["joblib", "joblib.*"]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# Backlog for enabling check_untyped_defs everywhere — plan in
+# docs/refactor_check_untyped_defs/. 32 errors in these 7 modules on 5455da0; the other 48 files
+# are already clean, and the flag above is what keeps them that way. This list only ever shrinks:
+# each planned PR removes its own entries. Do NOT add to it.
+module = [
+    "foundation_model.data.datamodule",                      # PR1 — 4 errors
+    "foundation_model.models.flexible_multi_task_model",     # PR2 — 2 errors
+    "foundation_model.data.composition_sources_test",        # PR3 — 9 errors
+    "foundation_model.data.datamodule_test",                 # PR3 — 1 error
+    "foundation_model.data.dataset_test",                    # PR3 — 1 error
+    "foundation_model.models.flexible_multi_task_model_test",  # PR3 — 13 errors
+    "foundation_model.workflows.task_catalog_test",          # PR3 — 2 errors
+]
+check_untyped_defs = false


### PR DESCRIPTION
## Scope

Placeholder / ratchet PR for enabling `check_untyped_defs`. Turns the flag on globally, quarantines
the seven modules that currently fail, and records the plan for clearing them. **No production
code changes.**

## Why now

`mypy` does not look inside a function that has no annotations. Every `def f(self, batch, batch_idx):`
in this repository was therefore **completely unchecked** — and those are the functions that carry
the training loop.

PR #45 is the evidence. `training_step` contained:

```python
train_logs: dict[str, torch.Tensor] = {}
...
train_logs[f"train_{name}_all_missing"] = 1.0   # a float, not a Tensor
```

`uv run mypy` reported the file clean. `--check-untyped-defs` reported it immediately. The same
audit found an `opt.step()` that the branch's own log message said it would *not* take, in the same
unchecked function. Annotating those two step methods is what let the checker see them at all —
this PR generalises that.

## What is actually in the way

Measured on `5455da0`: **32 errors in 7 files**. Only **6 are in production code**, and none of the
six is a runtime bug — they are places where a declared type does not describe the real data.

| File | n | Production? |
|---|---:|---|
| `models/flexible_multi_task_model_test.py` | 13 | no — mock/fixture looseness |
| `data/composition_sources_test.py` | 9 | no — pandas `.loc` with `str \| None`, an unannotated list |
| `data/datamodule.py` | 4 | **yes** |
| `models/flexible_multi_task_model.py` | 2 | **yes** |
| `workflows/task_catalog_test.py` | 2 | no |
| `data/datamodule_test.py`, `data/dataset_test.py` | 2 | no |

The production ones are worth fixing on their own merits. `batched_y_dict` is annotated
`list[Any]` while genuinely holding `Tensor | list[Tensor]` — that is the dictionary the collate
function hands to every training step, and the annotation tells a reader something false about how
kernel-regression batches differ from the rest.

## The decision

Turn the flag on **now** and quarantine the seven, rather than fix 32 errors in one unreviewable
PR or leave the flag off until someone finds time:

```toml
[tool.mypy]
check_untyped_defs = true

[[tool.mypy.overrides]]
module = [ ...the seven, each annotated with its error count and owning PR... ]
check_untyped_defs = false
```

The ratchet is the point: **a new untyped-body error can no longer enter any of the 48 clean
modules.** The backlog is the override list, it only shrinks, and `pyproject.toml` shows exactly
how much is left. Alternatives considered and rejected are recorded in the overview.

## Plan

`docs/refactor_check_untyped_defs/`, following the convention of the completed
`docs/refactor_fm_cli/` (`00_OVERVIEW.md` + one file per planned PR, each with Goal / Scope /
Non-goals / Acceptance). Production modules first, so fixture churn never lands in the same diff as
a production type correction:

1. `data/datamodule.py` — describe the batched dicts honestly; replace `getattr` guards mypy cannot narrow.
2. `models/flexible_multi_task_model.py` — narrow `encoder_config` to the existing `EncoderConfig` union; add one typed head accessor instead of a `# type: ignore` per call site. **PR #45's three characterization tests must pass unmodified** — if they need editing, that PR changed behaviour and is out of scope.
3. the five `*_test` modules.
4. delete the override block and this plan directory.

## Validation

- `uv run mypy src/` — **clean, 55 files**.
- `uv run pytest src/` — **521 passed**.
- **The ratchet was verified, not assumed**: temporarily adding PR #45's exact defect shape (a float
  into a `dict[str, Tensor]`, inside an untyped function) to a clean module makes `uv run mypy`
  fail with `Incompatible types in assignment`; reverting returns it to clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jzv6U6vwQ6uboZLMxC7Bk
