### PR TITLE
fix: key descriptor results by the requested composition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "foundation-model"
-version = "0.3.1"
+version = "0.3.2"
 description = "A multi-task learning model for predicting material properties"
 readme = "README.md"
 authors = [{ name = "TsumiNa", email = "liu.chang.1865@gmail.com" }]

--- a/src/foundation_model/data/composition_sources.py
+++ b/src/foundation_model/data/composition_sources.py
@@ -29,7 +29,9 @@ from loguru import logger
 
 from .splitter import MultiTaskSplitter
 
-DescriptorFn = Callable[[list[str]], pd.DataFrame]
+# Sequence, not list: every implementation here accepts any sequence, and declaring the
+# narrower list[str] made them fail to satisfy their own alias (parameters are contravariant).
+DescriptorFn = Callable[[Sequence[str]], pd.DataFrame]
 
 # Split labels, ordered by precedence (later wins on conflict).
 _SPLIT_PRECEDENCE: dict[str, int] = {"train": 1, "val": 2, "test": 3}
@@ -125,15 +127,41 @@ def lookup_descriptor_fn(
     """
     frame = _reindex_by_canonical(features, composition_normalizer, source="lookup_descriptor_fn")
 
-    index = frame.index
-
     def descriptor_fn(compositions: Sequence[str]) -> pd.DataFrame:
-        # Keys are usually already canonical (the DataModule normalized them), so try a direct
-        # hit first and only pay for canonicalization on a miss.
-        present = [c if c in index else canonical_key(c, composition_normalizer) for c in compositions]
-        return frame.loc[[k for k in present if k in index]]
+        return _lookup_by_canonical_key(frame, compositions, composition_normalizer)
 
     return descriptor_fn
+
+
+def _lookup_by_canonical_key(
+    frame: pd.DataFrame,
+    compositions: Sequence[str],
+    normalizer: CompositionNormalizer | None,
+) -> pd.DataFrame:
+    """Rows of ``frame`` for ``compositions``, **indexed by the keys that were asked for**.
+
+    That re-keying is the contract every ``descriptor_fn`` owes :class:`DescriptorCache`, which
+    matches the caller's own keys against whatever index comes back
+    (``present = [c for c in requested if c in self._cache.index]``). Returning the *matched*
+    key instead silently drops every composition whenever the caller's spelling and the frame's
+    canonical spelling differ — which is what happened when a DataModule opted out of
+    normalization while its descriptor source had not: 0 rows resolved, every composition
+    reported as "dropped", no error.
+
+    Normalization stays on this side of the boundary. The caller passes plain strings and gets
+    rows back under those same strings; only here does the ``str | None`` that
+    ``normalize_composition`` can return get resolved, by ``canonical_key``.
+    """
+    index = frame.index
+    # Keys are usually already canonical (the DataModule normalizes task frames the same way), so
+    # try a direct hit first and only pay for canonicalization on a miss.
+    matched = {c: (c if c in index else canonical_key(c, normalizer)) for c in compositions}
+    found = {requested: key for requested, key in matched.items() if key in index}
+    if not found:
+        return frame.iloc[:0]
+    out = frame.loc[list(found.values())].copy(deep=False)
+    out.index = pd.Index(list(found))
+    return out
 
 
 def _reindex_by_canonical(
@@ -353,25 +381,26 @@ class PrecomputedDescriptorSource:
         return self._frame
 
     def __call__(self, compositions: Sequence[str]) -> pd.DataFrame:
-        frame = self._load()
-        index = frame.index
-        # Keys are usually already canonical (the DataModule normalized them); try a direct hit
-        # first and only canonicalize on a miss, so we don't re-normalize every query at scale.
-        present = [c if c in index else canonical_key(c, self._composition_normalizer) for c in compositions]
-        return frame.loc[[k for k in present if k in index]]
+        return _lookup_by_canonical_key(self._load(), compositions, self._composition_normalizer)
 
 
 class DescriptorCache:
     """Apply a user descriptor function once per unique composition.
 
-    The descriptor function maps a list of composition strings to a DataFrame indexed by
-    composition. Results are cached; subsequent calls only compute compositions not seen
-    before. Compositions the function fails to produce (or returns as all-NaN rows) are
-    reported as "dropped" by :meth:`resolve`.
+    The descriptor function maps a list of composition strings to a DataFrame **indexed by the
+    strings it was given**. That is a contract, not a convention: :meth:`compute` matches the
+    caller's own keys against the returned index, so a function that re-keys its output — for
+    instance to a canonicalized spelling — has every row silently reported as "dropped" instead.
+    :func:`lookup_descriptor_fn` and :class:`PrecomputedDescriptorSource` satisfy it via
+    :func:`_lookup_by_canonical_key`.
+
+    Results are cached; subsequent calls only compute compositions not seen before. Compositions
+    the function fails to produce (or returns as all-NaN rows) are reported as "dropped" by
+    :meth:`resolve`.
 
     Parameters
     ----------
-    descriptor_fn : Callable[[list[str]], pd.DataFrame]
+    descriptor_fn : DescriptorFn
         Function returning a composition-indexed descriptor frame.
     """
 

--- a/src/foundation_model/data/composition_sources.py
+++ b/src/foundation_model/data/composition_sources.py
@@ -113,7 +113,8 @@ def lookup_descriptor_fn(
     """Build a ``descriptor_fn`` that looks up rows of an in-memory descriptor frame.
 
     The frame is re-indexed by :func:`canonical_key` so lookups match the canonical composition
-    keys the DataModule passes (it normalizes task frames the same way). Rows whose keys collide
+    keys the DataModule passes (it normalizes task frames the same way); :class:`_CompositionLookup`
+    then resolves raw requests against it too, so the two sides' settings need not agree. Rows whose keys collide
     after normalization — including pre-existing duplicate index labels — are collapsed keep-first
     (with a warning), guaranteeing a 1:1 key→row map so lookups never mismatch in length.
 
@@ -123,45 +124,66 @@ def lookup_descriptor_fn(
         Descriptor matrix indexed by composition.
     composition_normalizer : Callable | None, optional
         Normalizer applied to the frame index. Defaults to :func:`normalize_composition`;
-        pass ``None`` to look up by the raw (stringified) index instead.
+        pass ``None`` to keep the raw (stringified) index. Either way both raw and canonical
+        requests resolve.
     """
     frame = _reindex_by_canonical(features, composition_normalizer, source="lookup_descriptor_fn")
-
-    def descriptor_fn(compositions: Sequence[str]) -> pd.DataFrame:
-        return _lookup_by_canonical_key(frame, compositions, composition_normalizer)
-
-    return descriptor_fn
+    return _CompositionLookup(frame, composition_normalizer)
 
 
-def _lookup_by_canonical_key(
-    frame: pd.DataFrame,
-    compositions: Sequence[str],
-    normalizer: CompositionNormalizer | None,
-) -> pd.DataFrame:
-    """Rows of ``frame`` for ``compositions``, **indexed by the keys that were asked for**.
+class _CompositionLookup:
+    """A descriptor frame plus the map needed to resolve any spelling of a composition.
 
-    That re-keying is the contract every ``descriptor_fn`` owes :class:`DescriptorCache`, which
-    matches the caller's own keys against whatever index comes back
-    (``present = [c for c in requested if c in self._cache.index]``). Returning the *matched*
-    key instead silently drops every composition whenever the caller's spelling and the frame's
-    canonical spelling differ — which is what happened when a DataModule opted out of
-    normalization while its descriptor source had not: 0 rows resolved, every composition
-    reported as "dropped", no error.
+    Two independent choices decide how a composition is spelled: whether the *frame* was
+    canonicalized (this source's ``composition_normalizer``) and whether the *caller* canonicalized
+    its request (the DataModule's own, separate setting). All four combinations occur, so matching
+    on one spelling alone drops rows whenever the two disagree:
 
-    Normalization stays on this side of the boundary. The caller passes plain strings and gets
-    rows back under those same strings; only here does the ``str | None`` that
-    ``normalize_composition`` can return get resolved, by ``canonical_key``.
+    - frame canonical, request raw   -> canonicalizing the request finds it
+    - frame raw, request canonical   -> only a canonical view of the index finds it
+
+    Both are covered here, and neither affects the labels: rows always come back **indexed by the
+    keys the caller asked for**. That re-keying is the contract every ``descriptor_fn`` owes
+    :class:`DescriptorCache`, which matches the caller's own keys against whatever index comes
+    back (``present = [c for c in requested if c in self._cache.index]``). Returning the *matched*
+    key instead silently drops every composition when the spellings differ — 0 rows resolved,
+    everything reported as "dropped", no error.
+
+    Normalization is confined to this boundary. The caller passes plain strings and gets rows back
+    under those same strings; only here is the ``str | None`` that ``normalize_composition`` can
+    return resolved, by :func:`canonical_key`.
     """
-    index = frame.index
-    # Keys are usually already canonical (the DataModule normalizes task frames the same way), so
-    # try a direct hit first and only pay for canonicalization on a miss.
-    matched = {c: (c if c in index else canonical_key(c, normalizer)) for c in compositions}
-    found = {requested: key for requested, key in matched.items() if key in index}
-    if not found:
-        return frame.iloc[:0]
-    out = frame.loc[list(found.values())].copy(deep=False)
-    out.index = pd.Index(list(found))
-    return out
+
+    def __init__(self, frame: pd.DataFrame, normalizer: CompositionNormalizer | None):
+        self._frame = frame
+        self._normalizer = normalizer
+        # canonical spelling -> the label actually in the index, built once (a per-query rebuild
+        # would be O(len(frame)) on every batch). Keep-first on collision, matching the rule
+        # _reindex_by_canonical already applies. Non-formula keys (synthetic IDs, material IDs)
+        # canonicalize to themselves, so they are unaffected by this view.
+        canonical_view: dict[str, str] = {}
+        for label in frame.index:
+            canonical_view.setdefault(canonical_key(label, normalize_composition), label)
+        self._canonical_view = canonical_view
+
+    def _resolve(self, composition: str) -> str | None:
+        """The index label holding ``composition``, or None if the frame does not have it."""
+        if composition in self._frame.index:
+            return composition
+        # The frame's own spelling, if this source canonicalized it.
+        key = canonical_key(composition, self._normalizer)
+        if key in self._frame.index:
+            return key
+        # The caller's spelling may be the canonical one while the frame stayed raw.
+        return self._canonical_view.get(canonical_key(composition, normalize_composition))
+
+    def __call__(self, compositions: Sequence[str]) -> pd.DataFrame:
+        found = {c: label for c in compositions if (label := self._resolve(c)) is not None}
+        if not found:
+            return self._frame.iloc[:0]
+        out = self._frame.loc[list(found.values())].copy(deep=False)
+        out.index = pd.Index(list(found), name=self._frame.index.name)
+        return out
 
 
 def _reindex_by_canonical(
@@ -172,7 +194,9 @@ def _reindex_by_canonical(
     Uses a shallow copy (the descriptor matrix is shared, only the index is replaced) to avoid
     duplicating large descriptor frames.
     """
-    canon = pd.Index([canonical_key(c, normalizer) for c in frame.index])
+    # Keep the index name ('composition' for most sources) — it is dropped otherwise, leaving
+    # re-indexed frames inconsistent with the ones load_task_frame produces.
+    canon = pd.Index([canonical_key(c, normalizer) for c in frame.index], name=frame.index.name)
     out = frame.copy(deep=False)
     out.index = canon
     duplicated = canon.duplicated(keep="first")
@@ -349,8 +373,10 @@ class PrecomputedDescriptorSource:
         index is treated as the composition key.
     composition_normalizer : Callable | None, optional
         Normalizer applied to the descriptor index via :func:`canonical_key` (deduped keep-first
-        afterwards), so lookups match the canonical keys the DataModule passes. Defaults to
-        :func:`normalize_composition`; pass ``None`` to look up by the raw string index.
+        afterwards). Defaults to :func:`normalize_composition`; pass ``None`` to keep the raw
+        string index. This chooses how the *index* is spelled, not what can be looked up in it:
+        :class:`_CompositionLookup` resolves raw and canonical requests either way, so this
+        setting does not have to agree with the DataModule's own normalizer.
     """
 
     def __init__(
@@ -364,6 +390,7 @@ class PrecomputedDescriptorSource:
         self.composition_column = composition_column
         self._composition_normalizer = composition_normalizer
         self._frame: pd.DataFrame | None = None
+        self._lookup: _CompositionLookup | None = None
 
     def _load(self) -> pd.DataFrame:
         if self._frame is None:
@@ -381,18 +408,20 @@ class PrecomputedDescriptorSource:
         return self._frame
 
     def __call__(self, compositions: Sequence[str]) -> pd.DataFrame:
-        return _lookup_by_canonical_key(self._load(), compositions, self._composition_normalizer)
+        if self._lookup is None:
+            self._lookup = _CompositionLookup(self._load(), self._composition_normalizer)
+        return self._lookup(compositions)
 
 
 class DescriptorCache:
     """Apply a user descriptor function once per unique composition.
 
-    The descriptor function maps a list of composition strings to a DataFrame **indexed by the
-    strings it was given**. That is a contract, not a convention: :meth:`compute` matches the
+    The descriptor function maps a sequence of composition strings to a DataFrame **indexed by
+    the strings it was given**. That is a contract, not a convention: :meth:`compute` matches the
     caller's own keys against the returned index, so a function that re-keys its output — for
     instance to a canonicalized spelling — has every row silently reported as "dropped" instead.
     :func:`lookup_descriptor_fn` and :class:`PrecomputedDescriptorSource` satisfy it via
-    :func:`_lookup_by_canonical_key`.
+    :class:`_CompositionLookup`.
 
     Results are cached; subsequent calls only compute compositions not seen before. Compositions
     the function fails to produce (or returns as all-NaN rows) are reported as "dropped" by

--- a/src/foundation_model/data/composition_sources_test.py
+++ b/src/foundation_model/data/composition_sources_test.py
@@ -6,6 +6,7 @@
 import joblib
 import numpy as np
 import pandas as pd
+from collections.abc import Callable, Sequence
 from typing import Any
 
 import pytest
@@ -287,14 +288,18 @@ def test_precomputed_descriptor_source_column_file(tmp_path):
 
 
 def test_precomputed_descriptor_source_normalizes_by_default(tmp_path):
-    """By default the index is canonicalized, so heterogeneous spellings of a query still hit."""
+    """Heterogeneous spellings of a query still hit — and come back under the spelling asked for.
+
+    Canonicalization is how the match is *found*; it is not how the result is labelled. Returning
+    the canonical key instead would break the caller, which looks the rows up again by its own key.
+    """
     df = pd.DataFrame({"d0": [1.0, 2.0]}, index=pd.Index(["Fe2O3", "H2O"], name="composition"))
     path = tmp_path / "desc.parquet"
     df.to_parquet(path)
     source = PrecomputedDescriptorSource(str(path), composition_column="composition")
     # Queried with a different spelling of Fe2O3 (decimal amounts, reversed order).
     out = source(["O3.0Fe2.0", "missing"])
-    assert list(out.index) == [normalize_composition("Fe2O3")]
+    assert list(out.index) == ["O3.0Fe2.0"], "the match is canonical; the label is the caller's"
     assert out.iloc[0]["d0"] == 1.0
 
 
@@ -380,3 +385,46 @@ def test_resolve_splits_ignores_tasks_without_split_column():
     out = resolve_splits(frames, ["a", "b"], {"t1": "split"}, val_split=0.5, test_split=0.0, random_seed=1)
     assert set(out.unique()) <= {"train", "val", "test"}
     assert len(out) == 2
+
+
+# --- descriptor_fn key contract ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("build", ["lookup", "precomputed"])
+def test_descriptor_fn_returns_rows_under_the_requested_keys(build, tmp_path):
+    """The rows must come back keyed by what the caller asked for, whatever the frame is indexed by.
+
+    ``DescriptorCache.compute`` matches the caller's own keys against the returned index, so a
+    source that re-keys its output to a canonicalized spelling has every row silently reported as
+    "dropped" instead. That is a total, warning-only data loss, and it is what happened when a
+    DataModule opted out of normalization while its descriptor source had not.
+    """
+    features = pd.DataFrame({"d0": [1.0, 2.0]}, index=pd.Index(["Fe2O3", "NaCl"]))
+    fn: Callable[[Sequence[str]], pd.DataFrame]
+    if build == "lookup":
+        fn = lookup_descriptor_fn(features)
+    else:
+        path = tmp_path / "desc.parquet"
+        features.rename_axis("composition").to_parquet(path)
+        fn = PrecomputedDescriptorSource(str(path), composition_column="composition")
+
+    # Raw spellings: the frame index is canonicalised, the request is not.
+    raw = ["Fe2O3", "NaCl"]
+    frame, dropped = DescriptorCache(fn).resolve(raw)
+    assert dropped == [], f"{build}: raw keys were dropped instead of matched"
+    assert list(frame.index) == raw, f"{build}: rows must be keyed by the request, not the match"
+
+    # Canonical spellings must still resolve, keyed as asked. canonical_key is what the source
+    # itself uses to canonicalize, so this asks for exactly the frame's own index labels.
+    canonical = [canonical_key(c, normalize_composition) for c in raw]
+    frame2, dropped2 = DescriptorCache(fn).resolve(canonical)
+    assert dropped2 == []
+    assert list(frame2.index) == canonical
+
+
+def test_descriptor_fn_still_drops_genuinely_absent_compositions():
+    """Re-keying must not turn a real miss into a spurious row."""
+    features = pd.DataFrame({"d0": [1.0]}, index=pd.Index(["Fe2O3"]))
+    frame, dropped = DescriptorCache(lookup_descriptor_fn(features)).resolve(["Fe2O3", "not_a_formula_xyz"])
+    assert list(frame.index) == ["Fe2O3"]
+    assert dropped == ["not_a_formula_xyz"]

--- a/src/foundation_model/data/composition_sources_test.py
+++ b/src/foundation_model/data/composition_sources_test.py
@@ -391,6 +391,45 @@ def test_resolve_splits_ignores_tasks_without_split_column():
 
 
 @pytest.mark.parametrize("build", ["lookup", "precomputed"])
+@pytest.mark.parametrize("source_normalizes", [True, False], ids=["src-normalizes", "src-raw"])
+@pytest.mark.parametrize("request_style", ["raw", "canonical"])
+def test_descriptor_fn_resolves_any_spelling_combination(build, source_normalizes, request_style, tmp_path):
+    """All four (frame spelling x request spelling) combinations must resolve.
+
+    The frame's spelling is chosen by this source's ``composition_normalizer``; the request's is
+    chosen by the DataModule's own, separate setting. Nothing makes the two agree, so every
+    combination occurs in practice, and matching on one spelling alone silently drops every row.
+
+    Regression: a raw-indexed source queried with canonical keys resolved 0 rows and failed
+    DataModule setup outright. It previously "worked" only because the DataModule reached in and
+    overwrote this source's normalizer with its own — which also meant an explicitly passed
+    ``composition_normalizer=None`` was quietly ignored.
+    """
+    features = pd.DataFrame({"d0": [1.0, 2.0]}, index=pd.Index(["Fe2O3", "NaCl"], name="composition"))
+    normalizer = normalize_composition if source_normalizes else None
+    if build == "lookup":
+        fn: Callable[[Sequence[str]], pd.DataFrame] = lookup_descriptor_fn(features, composition_normalizer=normalizer)
+    else:
+        path = tmp_path / "desc.parquet"
+        features.to_parquet(path)
+        fn = PrecomputedDescriptorSource(str(path), composition_column="composition", composition_normalizer=normalizer)
+
+    raw = ["Fe2O3", "NaCl"]
+    requested = raw if request_style == "raw" else [canonical_key(c, normalize_composition) for c in raw]
+    frame, dropped = DescriptorCache(fn).resolve(requested)
+
+    assert dropped == [], f"{build}/{request_style}: dropped {dropped} instead of matching"
+    assert list(frame.index) == requested, "rows must be keyed by the request, not by the match"
+    assert frame["d0"].tolist() == [1.0, 2.0], "re-keying must not scramble row order"
+
+
+def test_descriptor_frames_keep_the_composition_index_name():
+    """Re-indexing must not strip the index name, or the frames diverge from load_task_frame's."""
+    features = pd.DataFrame({"d0": [1.0]}, index=pd.Index(["Fe2O3"], name="composition"))
+    assert lookup_descriptor_fn(features)(["Fe2O3"]).index.name == "composition"
+
+
+@pytest.mark.parametrize("build", ["lookup", "precomputed"])
 def test_descriptor_fn_returns_rows_under_the_requested_keys(build, tmp_path):
     """The rows must come back keyed by what the caller asked for, whatever the frame is indexed by.
 

--- a/src/foundation_model/data/datamodule.py
+++ b/src/foundation_model/data/datamodule.py
@@ -22,7 +22,6 @@ from .composition_sources import (
     CompositionNormalizer,
     DescriptorCache,
     DescriptorFn,
-    PrecomputedDescriptorSource,
     build_composition_universe,
     canonical_key,
     load_task_frame,
@@ -168,7 +167,7 @@ class CompoundDataModule(L.LightningDataModule):
     task_configs : Sequence[TaskConfig]
         Task configurations. Per-task ``data_files`` / ``composition_column`` / ``split_column``
         / ``task_masking_ratio`` / ``predict_idx`` drive data loading.
-    descriptor_fn : Callable[[list[str]], pd.DataFrame]
+    descriptor_fn : DescriptorFn
         Maps composition keys to a composition-indexed descriptor frame.
     task_frames : Mapping[str, pd.DataFrame] | None, optional
         In-memory per-task frames (indexed by composition or carrying the composition column),
@@ -275,10 +274,12 @@ class CompoundDataModule(L.LightningDataModule):
             self.default_data_files = tuple(str(p) for p in default_data_files)
         self.composition_column = composition_column
         self.composition_normalizer = composition_normalizer
-        # The DataModule owns the normalization policy; keep a recognized descriptor source in
-        # sync so the opt-out (composition_normalizer=None) only has to be set in one place.
-        if isinstance(descriptor_fn, PrecomputedDescriptorSource):
-            descriptor_fn._composition_normalizer = composition_normalizer
+        # No syncing into the descriptor source. It used to assign
+        # descriptor_fn._composition_normalizer so the opt-out "only had to be set in one place",
+        # but that reached into a private attribute of ONE of the three descriptor kinds; a
+        # closure built by lookup_descriptor_fn had nothing to assign to, and opting out there
+        # silently dropped every composition. Descriptor sources now return rows under the keys
+        # they were handed, so their own normalization never has to agree with this one.
         self.random_seed = random_seed
         self.val_split = val_split
         self.test_split = test_split

--- a/src/foundation_model/data/datamodule_test.py
+++ b/src/foundation_model/data/datamodule_test.py
@@ -218,6 +218,31 @@ def test_datamodule_disable_normalizer_keeps_raw_keys(descriptors_df, reg_cls_co
     assert set(dm.master_index) == set(COMPOSITIONS)
 
 
+def test_datamodule_default_normalizer_works_against_a_raw_source(descriptors_df, reg_cls_configs, tmp_path):
+    """The mirror case: the source keeps raw keys while the DataModule normalizes its own.
+
+    The DataModule canonicalizes task keys, so it asks for 'Fe2 O3' while the source's index still
+    says 'Fe2O3'. This must resolve. It regressed once: removing the constructor's private-attribute
+    sync left nothing able to bridge the two spellings, and setup failed with "descriptor_fn
+    produced no valid descriptors for any composition" on a config that had worked.
+    """
+    path = tmp_path / "desc.parquet"
+    descriptors_df.rename_axis("composition").to_parquet(path)
+    source = PrecomputedDescriptorSource(
+        str(path),
+        composition_column="composition",
+        composition_normalizer=None,  # raw index
+    )
+    dm = CompoundDataModule(
+        task_configs=reg_cls_configs,
+        descriptor_fn=source,
+        task_frames=_reg_cls_frames(),
+        # ... and the DataModule keeps its default normalizer
+    )
+    dm.setup(stage="fit")
+    assert set(dm.master_index) == set(COMPOSITIONS)
+
+
 def test_datamodule_opt_out_works_against_a_normalizing_source(descriptors_df, reg_cls_configs, tmp_path):
     """``composition_normalizer=None`` must resolve rows even from a source that normalizes.
 

--- a/src/foundation_model/data/datamodule_test.py
+++ b/src/foundation_model/data/datamodule_test.py
@@ -12,6 +12,7 @@ import torch
 from loguru import logger
 from torch.utils.data.distributed import DistributedSampler
 
+from foundation_model.data.composition_sources import PrecomputedDescriptorSource
 from foundation_model.data.datamodule import CompoundDataModule
 from foundation_model.models.model_config import (
     TaskConfigType,
@@ -217,13 +218,30 @@ def test_datamodule_disable_normalizer_keeps_raw_keys(descriptors_df, reg_cls_co
     assert set(dm.master_index) == set(COMPOSITIONS)
 
 
-def test_datamodule_syncs_normalizer_into_precomputed_source(reg_cls_configs):
-    """The DataModule's opt-out propagates into a PrecomputedDescriptorSource (single source of truth)."""
-    from foundation_model.data.composition_sources import PrecomputedDescriptorSource
+def test_datamodule_opt_out_works_against_a_normalizing_source(descriptors_df, reg_cls_configs, tmp_path):
+    """``composition_normalizer=None`` must resolve rows even from a source that normalizes.
 
-    source = PrecomputedDescriptorSource("unused.parquet")  # defaults to normalization ON
-    CompoundDataModule(task_configs=reg_cls_configs, descriptor_fn=source, composition_normalizer=None)
-    assert source._composition_normalizer is None
+    This used to be arranged by assigning ``descriptor_fn._composition_normalizer`` from the
+    DataModule's constructor — reaching into the private attribute of one of the three descriptor
+    kinds. A ``lookup_descriptor_fn`` closure had no such attribute, so opting out there dropped
+    every composition with nothing but a warning. Descriptor sources now key their result by the
+    compositions they were handed, so the two normalization policies never have to agree.
+
+    Asserting on resolved rows rather than on that attribute is the point: the attribute was the
+    mechanism, the rows are the property.
+    """
+    path = tmp_path / "desc.parquet"
+    descriptors_df.rename_axis("composition").to_parquet(path)
+    source = PrecomputedDescriptorSource(str(path), composition_column="composition")  # normalizes
+
+    dm = CompoundDataModule(
+        task_configs=reg_cls_configs,
+        descriptor_fn=source,
+        task_frames=_reg_cls_frames(),
+        composition_normalizer=None,  # ... and the DataModule does not
+    )
+    dm.setup(stage="fit")
+    assert set(dm.master_index) == set(COMPOSITIONS)
 
 
 def test_split_column_resolution(descriptors_df, reg_cls_configs):

--- a/src/foundation_model/workflows/task_catalog.py
+++ b/src/foundation_model/workflows/task_catalog.py
@@ -24,7 +24,7 @@ not the default.
 from __future__ import annotations
 
 import re
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -36,6 +36,7 @@ import pandas as pd
 from loguru import logger
 
 from foundation_model.data.composition_sources import (
+    DescriptorFn,
     PrecomputedDescriptorSource,
     canonical_key,
     normalize_composition,
@@ -497,14 +498,19 @@ class TaskCatalog:
             out[name] = self._task_frames[name]
         return out
 
-    def descriptor_fn(self) -> Callable[[list[str]], pd.DataFrame]:
-        """Return a ``Callable[[list[str]], pd.DataFrame]`` producing composition descriptors."""
+    def descriptor_fn(self) -> DescriptorFn:
+        """Return the composition-descriptor source for this catalog.
+
+        Per the :data:`DescriptorFn` contract the returned rows are indexed by the composition
+        strings it was handed, not by any canonicalized spelling of them.
+        """
 
         if self._descriptor_source is not None:
-            source = self._descriptor_source
-            return lambda compositions: source(list(compositions))
+            # Already a DescriptorFn; it used to be wrapped in a lambda only to re-package the
+            # argument as a list for the narrower alias.
+            return self._descriptor_source
 
-        def _kmd_descriptor(compositions: list[str]) -> pd.DataFrame:
+        def _kmd_descriptor(compositions: Sequence[str]) -> pd.DataFrame:
             uncached = [c for c in dict.fromkeys(compositions) if c not in self._desc_cache]
             if uncached:
                 weights = np.zeros((len(uncached), len(DEFAULT_ELEMENTS)), dtype=float)

--- a/uv.lock
+++ b/uv.lock
@@ -732,7 +732,7 @@ wheels = [
 
 [[package]]
 name = "foundation-model"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Scope

Fixes a silent, total data-loss path in composition→descriptor resolution, and the type
inconsistency that made it possible. Follow-up to the mypy series (#46–#50); found by
tracing the call path rather than by a failing test.

## The bug

`DescriptorCache.compute` matches the caller's own keys against whatever index the
`descriptor_fn` returns:

```python
present = [c for c in requested if c in self._cache.index]
```

Two of the three descriptor sources (`lookup_descriptor_fn`, `PrecomputedDescriptorSource`)
returned rows keyed by the **canonicalized** spelling instead of the requested one. When the
caller's spelling and the canonical spelling differ, *every* composition falls out of that
`present` list and is reported as "dropped" — a warning, not an error.

Reproduced before the fix:

```
requested (raw): ['Fe2O3', 'NaCl']
resolved rows: 0 | dropped: ['Fe2O3', 'NaCl']
```

After:

```
requested (raw): ['Fe2O3', 'NaCl']
resolved rows: 2 | index: ['Fe2O3', 'NaCl'] | dropped: []
canonical keys : 2 rows | index: ['Fe2 O3', 'Na1 Cl1'] | dropped: []
```

The constructor already tried to prevent this:

```python
if isinstance(descriptor_fn, PrecomputedDescriptorSource):
    descriptor_fn._composition_normalizer = composition_normalizer
```

That reached into a private attribute of **one** of the three descriptor kinds. A closure from
`lookup_descriptor_fn` has nothing to assign to, so `composition_normalizer=None` silently
dropped everything there.

## The fix

Per the stated type-design principle — *keep core types simple and uniform; confine variant
types to the pre/post-processing boundary* — canonicalization is confined to a single helper
that **finds the match canonically and labels the result with the key it was handed**. The
`str | None` from `normalize_composition` is resolved once, there, by the existing
`canonical_key`.

Because the two normalization policies no longer have to agree, the cross-object private-attribute
sync is **deleted** rather than extended to the other two sources. The `descriptor_fn` contract is
now documented where it is consumed.

Also unifies the `DescriptorFn` alias. It declared `Callable[[list[str]], DataFrame]` while every
implementation accepts `Sequence[str]` — so none of them actually satisfied their own alias
(parameters are contravariant). Widening it lets `PrecomputedDescriptorSource` be returned
directly, dropping a lambda that existed only to re-package the argument as a list.

## Validation

- New regression tests: both source kinds return rows under the requested keys, for raw *and*
  canonical spellings; a genuinely absent composition is still dropped (re-keying must not
  invent rows).
- `test_datamodule_syncs_normalizer_into_precomputed_source` asserted the deleted *mechanism*.
  Replaced with `test_datamodule_opt_out_works_against_a_normalizing_source`, which asserts the
  *property* that mechanism existed to protect — that rows resolve — using a normalizing source
  against a non-normalizing DataModule.
- `test_precomputed_descriptor_source_normalizes_by_default` kept its purpose (heterogeneous
  spellings still hit); only its index-label expectation changed, which is the behavior change.
- `uv run pytest src/` → 528 passed · `uv run mypy src/` → clean · `uv run ruff check src` → clean

## Backward-incompatible behavior

Descriptor sources now return rows indexed by the requested composition strings rather than by
their canonical form. Callers that relied on receiving canonicalized labels back would need to
canonicalize themselves — in-repo there are none; `DescriptorCache` is the only consumer and it
required the new behavior all along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jzv6U6vwQ6uboZLMxC7Bk
